### PR TITLE
Implement extract_duration_da

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,63 @@
+# This workflow will run unit tests
+
+name: Run Unit Tests
+on:
+  pull_request:
+    branches:
+      - dev
+    paths-ignore:
+      - 'ovos_date_parser/version.py'
+      - '.github/**'
+      - '.gitignore'
+      - 'LICENSE'
+      - 'CHANGELOG.md'
+      - 'MANIFEST.in'
+      - 'README.md'
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'ovos_date_parser/version.py'
+      - '.github/**'
+      - '.gitignore'
+      - 'LICENSE'
+      - 'CHANGELOG.md'
+      - 'MANIFEST.in'
+      - 'README.md'
+  workflow_dispatch:
+
+jobs:
+  unit_tests:
+    strategy:
+      max-parallel: 2
+      matrix:
+        python-version: [ 3.9, "3.10" ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install System Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt install python3-dev
+          python -m pip install build wheel python-dateutil quebra_frases ovos-number-parser dateparser ovos-config
+      - name: Install core repo
+        run: |
+          pip install -e .[extras]
+      - name: Install test dependencies
+        run: |
+          pip install pytest pytest-timeout pytest-cov
+      - name: Run unittests
+        run: |
+          pytest --cov=ovos_utils --cov-report xml tests/
+          # NOTE: additional pytest invocations should also add the --cov-append flag
+          #       or they will overwrite previous invocations' coverage reports
+          #       (for an example, see OVOS Skill Manager's workflow)
+      - name: Upload coverage
+        if: "${{ matrix.python-version == '3.9' }}"
+        env:
+          CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
+        uses: codecov/codecov-action@v2

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -52,7 +52,7 @@ jobs:
           pip install pytest pytest-timeout pytest-cov
       - name: Run unittests
         run: |
-          pytest --cov=ovos_utils --cov-report xml tests/
+          pytest --cov=ovos_utils --cov-report xml test/format_tests/
           # NOTE: additional pytest invocations should also add the --cov-append flag
           #       or they will overwrite previous invocations' coverage reports
           #       (for an example, see OVOS Skill Manager's workflow)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ time expressions.
 | az       | ✅                  | ✅                  |
 | ca       | ✅                  | ✅                  |
 | cs       | ✅                  | ✅                  |
-| da       | ❌                  | ✅                  |
+| da       | ✅                  | ✅                  |
 | de       | ✅                  | ✅                  |
 | en       | ✅                  | ✅                  |
 | es       | ✅                  | ✅                  |

--- a/ovos_date_parser/dates_da.py
+++ b/ovos_date_parser/dates_da.py
@@ -1,13 +1,13 @@
 from datetime import datetime
 
 from dateutil.relativedelta import relativedelta
-from ovos_number_parser.numbers_da import pronounce_ordinal_da, pronounce_number_da, is_ordinal_da
+from ovos_number_parser.numbers_da import pronounce_ordinal_da, pronounce_number_da, is_ordinal_da, numbers_to_digits_da
 from ovos_number_parser.util import is_numeric
 from ovos_utils.time import now_local
 
-_MONTHS_DA = ['januar', 'februar', 'märz', 'april', 'mai', 'juni',
+_MONTHS_DA = ['januar', 'februar', 'marts', 'april', 'maj', 'juni',
               'juli', 'august', 'september', 'oktober', 'november',
-              'dezember']
+              'december']
 
 
 def nice_time_da(dt, speech=True, use_24hour=False, use_ampm=False):
@@ -781,3 +781,69 @@ def extract_datetime_da(text, anchorDate=None, default_time=None):
     resultStr = ' '.join(resultStr.split())
 
     return [extractedDate, resultStr]
+
+def extract_duration_da(text):
+    """Convert a danish phrase into a number of seconds
+
+    Convert things like:
+        "10 minutes"
+        "2 and a half hours"
+        "3 days 8 hours 10 minutes and 49 seconds"
+    into an int, representing the total number of seconds.
+
+    The words used in the duration will be consumed, and
+    the remainder returned.
+
+    As an example, "set a timer for 5 minutes" would return
+    (300, "set a timer for").
+
+    Args:
+        text (str): string containing a duration
+
+    Returns:
+        (timedelta, str):
+                    A tuple containing the duration and the remaining text
+                    not consumed in the parsing. The first value will
+                    be None if no duration is found. The text returned
+                    will have whitespace stripped from the ends.
+    """
+    if not text:
+        return None
+
+    time_units = {
+        'microseconds': 0,
+        'milliseconds': 0,
+        'seconds': 0,
+        'minutes': 0,
+        'hours': 0,
+        'days': 0,
+        'weeks': 0
+    }
+
+    da_translations = {
+        'microseconds': ["mikrosekund", "mikrosekunder", "mikrosekunds", "mikrosekunders"],
+        'milliseconds': ["millisekund", "millisekunder", "millisekunds"],
+        'seconds': ["sekund", "sekunder", "sekunds", "sekunders"],
+        'minutes': ["minut", "minutter", "minuts", "minutters"],
+        'hours': ["time", "timer", "times", "timers"],
+        'days': ["dag", "dage", "dags", "dages"],
+        'weeks': ["uge", "uges", "uger", "ugers"]
+    }
+
+    pattern = r"(?P<value>\d+(?:\.?\d+)?)\s+{unit}"
+    text = numbers_to_digits_da(text)
+
+    for unit in time_units:
+        unit_nl_words = da_translations[unit]
+        unit_nl_words.sort(key=len, reverse=True)
+        for unit_nl in unit_nl_words:
+            unit_pattern = pattern.format(unit=unit_nl)
+            matches = re.findall(unit_pattern, text)
+            value = sum(map(float, matches))
+            time_units[unit] = time_units[unit] + value
+            text = re.sub(unit_pattern, '', text)
+
+    text = text.strip()
+    duration = timedelta(**time_units) if any(time_units.values()) else None
+
+    return (duration, text)

--- a/ovos_date_parser/dates_da.py
+++ b/ovos_date_parser/dates_da.py
@@ -873,7 +873,6 @@ def extract_duration_da(text):
                 val = 1000 * DAYS_IN_1_YEAR * val
             time_units["days"] += val
             text = re.sub(unit_pattern, '', text)
-    print(time_units)
 
     text = text.strip()
     duration = timedelta(**time_units) if any(time_units.values()) else None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dateutil~=2.6
 quebra_frases>=0.3.7
-ovos-number-parser>=0.0.2,<1.0.0
+ovos-number-parser>=0.3.2,<1.0.0
 dateparser
 ovos-config

--- a/test/format_tests/test_parse_da.py
+++ b/test/format_tests/test_parse_da.py
@@ -1,14 +1,15 @@
 import unittest
 from datetime import timedelta
 from ovos_date_parser.dates_da import extract_duration_da
+from ovos_utils.time import now_local, DAYS_IN_1_YEAR, DAYS_IN_1_MONTH
 
 
 class TestExtractDurationDA(unittest.TestCase):
     def test_single_unit(self):
-        self.assertEqual(extract_duration_da("10 minutter"), (timedelta(minutes=10), ""))
-        self.assertEqual(extract_duration_da("3 dage"), (timedelta(days=3), ""))
+        self.assertEqual(extract_duration_da("ti minutter"), (timedelta(minutes=10), ""))
+        self.assertEqual(extract_duration_da("tre dage"), (timedelta(days=3), ""))
         self.assertEqual(extract_duration_da("8 timer"), (timedelta(hours=8), ""))
-        self.assertEqual(extract_duration_da("49 sekunder"), (timedelta(seconds=49), ""))
+        self.assertEqual(extract_duration_da("ni og fyrre sekunder"), (timedelta(seconds=49), ""))
 
     def test_multiple_units(self):
         self.assertEqual(extract_duration_da("3 dage 8 timer 10 minutter og 49 sekunder"),
@@ -17,17 +18,17 @@ class TestExtractDurationDA(unittest.TestCase):
                          (timedelta(weeks=2, days=5), ""))
 
     def test_with_extra_text(self):
-        self.assertEqual(extract_duration_da("sæt en timer på 5 minutter"),
+        self.assertEqual(extract_duration_da("sæt en timer på fem minutter"),
                          (timedelta(minutes=5), "sæt en timer på"))
-        self.assertEqual(extract_duration_da("giv besked om en time"),
+        self.assertEqual(extract_duration_da("giv besked om 1 time"),
                          (timedelta(hours=1), "giv besked om"))
 
     def test_non_standard_units(self):
-        self.assertEqual(extract_duration_da("2 måneder"), (timedelta(days=60), ""))
-        self.assertEqual(extract_duration_da("1 år"), (timedelta(days=365), ""))
-        self.assertEqual(extract_duration_da("1 årti"), (timedelta(days=10 * 365), ""))
-        self.assertEqual(extract_duration_da("1 århundrede"), (timedelta(days=100 * 365), ""))
-        self.assertEqual(extract_duration_da("1 årtusinde"), (timedelta(days=1000 * 365), ""))
+        self.assertEqual(extract_duration_da("to måneder"), (timedelta(days=DAYS_IN_1_MONTH * 2), ""))
+        self.assertEqual(extract_duration_da("1 år"), (timedelta(days=DAYS_IN_1_YEAR), ""))
+        self.assertEqual(extract_duration_da("1 årti"), (timedelta(days=10 * DAYS_IN_1_YEAR), ""))
+        self.assertEqual(extract_duration_da("1 århundrede"), (timedelta(days=100 * DAYS_IN_1_YEAR), ""))
+        self.assertEqual(extract_duration_da("1 årtusinde"), (timedelta(days=1000 * DAYS_IN_1_YEAR), ""))
 
     def test_no_duration_found(self):
         self.assertEqual(extract_duration_da("der er ikke nogen tid"), (None, "der er ikke nogen tid"))

--- a/test/format_tests/test_parse_da.py
+++ b/test/format_tests/test_parse_da.py
@@ -1,0 +1,38 @@
+import unittest
+from datetime import timedelta
+from ovos_date_parser.dates_da import extract_duration_da
+
+
+class TestExtractDurationDA(unittest.TestCase):
+    def test_single_unit(self):
+        self.assertEqual(extract_duration_da("10 minutter"), (timedelta(minutes=10), ""))
+        self.assertEqual(extract_duration_da("3 dage"), (timedelta(days=3), ""))
+        self.assertEqual(extract_duration_da("8 timer"), (timedelta(hours=8), ""))
+        self.assertEqual(extract_duration_da("49 sekunder"), (timedelta(seconds=49), ""))
+
+    def test_multiple_units(self):
+        self.assertEqual(extract_duration_da("3 dage 8 timer 10 minutter og 49 sekunder"),
+                         (timedelta(days=3, hours=8, minutes=10, seconds=49), "og"))
+        self.assertEqual(extract_duration_da("2 uger 5 dage"),
+                         (timedelta(weeks=2, days=5), ""))
+
+    def test_with_extra_text(self):
+        self.assertEqual(extract_duration_da("sæt en timer på 5 minutter"),
+                         (timedelta(minutes=5), "sæt en timer på"))
+        self.assertEqual(extract_duration_da("giv besked om en time"),
+                         (timedelta(hours=1), "giv besked om"))
+
+    def test_non_standard_units(self):
+        self.assertEqual(extract_duration_da("2 måneder"), (timedelta(days=60), ""))
+        self.assertEqual(extract_duration_da("1 år"), (timedelta(days=365), ""))
+        self.assertEqual(extract_duration_da("1 årti"), (timedelta(days=10 * 365), ""))
+        self.assertEqual(extract_duration_da("1 århundrede"), (timedelta(days=100 * 365), ""))
+        self.assertEqual(extract_duration_da("1 årtusinde"), (timedelta(days=1000 * 365), ""))
+
+    def test_no_duration_found(self):
+        self.assertEqual(extract_duration_da("der er ikke nogen tid"), (None, "der er ikke nogen tid"))
+        self.assertEqual(extract_duration_da(""), (None, ""))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new functionality to interpret duration phrases in Danish, converting various time units (seconds, minutes, hours, days, weeks, months, decades, centuries, and millennia) into a computed time value while preserving any additional text.
  - Improved the accuracy of Danish month names.
  - Updated the support status for the Danish language in the documentation to reflect support for the `extract_duration` method.

- **Tests**
  - Added comprehensive tests covering multiple scenarios, including single and combined time units, handling of extra text, and cases with non-standard time units, ensuring the new functionality works as expected.

- **Chores**
  - Updated the version specification for the `ovos-number-parser` package in the requirements.
  - Introduced a new GitHub Actions workflow to automate unit testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->