### PR TITLE
Actually use the new extract_duration_da

### DIFF
--- a/ovos_date_parser/__init__.py
+++ b/ovos_date_parser/__init__.py
@@ -22,7 +22,7 @@ from ovos_date_parser.dates_cs import (
     extract_duration_cs, extract_datetime_cs, nice_time_cs
 )
 from ovos_date_parser.dates_da import (
-    extract_datetime_da, nice_time_da,
+    extract_datetime_da, extract_duration_da, nice_time_da,
 )
 from ovos_date_parser.dates_de import (
     extract_datetime_de, extract_duration_de, nice_time_de,
@@ -201,6 +201,8 @@ def extract_duration(
         return extract_duration_ca(text)
     if lang.startswith("cs"):
         return extract_duration_cs(text)
+    if lang.startswith("da"):
+        return extract_duration_da(text)
     if lang.startswith("de"):
         return extract_duration_de(text)
     if lang.startswith("en"):


### PR DESCRIPTION
Forgot this in the last PR...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Extended the date parsing functionality to support duration extraction from Danish language inputs, enhancing the tool's multilingual capabilities.
  - Users working with Danish content will now benefit from more accurate date and time interpretation for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->