### PR TITLE
Fix French runtime date resources

### DIFF
--- a/ovos_date_parser/res/fr/date_time.json
+++ b/ovos_date_parser/res/fr/date_time.json
@@ -92,7 +92,7 @@
     "7": "juillet",
     "8": "août",
     "9": "septembre",
-    "10": "octobe",
+    "10": "octobre",
     "11": "novembre",
     "12": "décembre"
   },

--- a/ovos_date_parser/res/fr/date_words.json
+++ b/ovos_date_parser/res/fr/date_words.json
@@ -1,4 +1,5 @@
 {
+  "now": "maintenant",
   "seconds": "secondes",
   "hour": "heure",
   "minute": "minute",

--- a/test/format_tests/test_format_fr.py
+++ b/test/format_tests/test_format_fr.py
@@ -1,0 +1,19 @@
+import datetime
+import unittest
+
+from ovos_date_parser import nice_month, nice_relative_time
+from ovos_config.locale import get_default_tz as default_timezone
+
+
+class TestFrenchFormatting(unittest.TestCase):
+    def test_nice_relative_time_now(self):
+        now = datetime.datetime(2026, 3, 8, 12, 0, tzinfo=default_timezone())
+        self.assertEqual(nice_relative_time(now, now, lang="fr"), "maintenant")
+
+    def test_nice_month_october(self):
+        dt = datetime.datetime(2026, 10, 1, 12, 0, tzinfo=default_timezone())
+        self.assertEqual(nice_month(dt, lang="fr"), "octobre")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add the missing French translation for  in 
- fix the misspelled French month name for October in 
- add a focused regression test for French relative time and month formatting

## Testing
- 
-  *(fails in this environment: missing  dependency)*