### PR TITLE
feat: galician datetime extraction

### DIFF
--- a/ovos_date_parser/__init__.py
+++ b/ovos_date_parser/__init__.py
@@ -45,7 +45,7 @@ from ovos_date_parser.dates_fr import (
     extract_datetime_fr, nice_time_fr
 )
 from ovos_date_parser.dates_gl import (
-    extract_duration_gl, nice_year_gl, nice_weekday_gl, nice_month_gl,
+    extract_duration_gl, extract_datetime_gl, nice_year_gl, nice_weekday_gl, nice_month_gl,
     nice_day_gl, nice_date_time_gl, nice_date_gl, nice_time_gl
 )
 from ovos_date_parser.dates_hu import nice_time_hu, extract_duration_hu, extract_datetime_hu
@@ -279,6 +279,8 @@ def extract_datetime(
         return extract_datetime_fa(text, anchorDate=anchorDate, default_time=default_time)
     if lang.startswith("fr"):
         return extract_datetime_fr(text, anchorDate=anchorDate, default_time=default_time)
+    if lang.startswith("gl"):
+        return extract_datetime_gl(text, anchorDate=anchorDate, default_time=default_time)
     if lang.startswith("hu"):
         return extract_datetime_hu(text, anchorDate=anchorDate, default_time=default_time)
     if lang.startswith("it"):

--- a/ovos_date_parser/dates_gl.py
+++ b/ovos_date_parser/dates_gl.py
@@ -2,6 +2,7 @@ import re
 from datetime import datetime
 from datetime import timedelta
 
+from dateutil.relativedelta import relativedelta
 from ovos_number_parser.numbers_gl import pronounce_number_gl
 from ovos_utils.time import now_local
 
@@ -224,6 +225,759 @@ def nice_time_gl(dt, speech=True, use_24hour=False, use_ampm=False):
             else:
                 speak += " da noite"
     return speak
+
+
+def extract_datetime_gl(text, anchorDate=None, default_time=None):
+    """
+    Extrae información de data e hora dunha frase en galego.
+
+    Args:
+        text (str): texto a interpretar
+        anchorDate (datetime): data de referencia para datas relativas
+        default_time (time): hora a usar se non se atopa ningunha no texto
+
+    Returns:
+        [datetime, str] | None: a data extraída e o texto restante,
+        ou None se non se atopa ningunha data ou hora.
+    """
+
+    def clean_string(s):
+        # limpa o texto de puntuación e maiúsculas e normaliza vocabulario
+        symbols = [".", ",", ";", "?", "!", "º", "ª"]
+
+        for word in symbols:
+            s = s.replace(word, "")
+
+        s = s.lower().replace("á", "a").replace("é", "e").replace(
+            "í", "i").replace("ó", "o").replace("ú", "u").replace(
+            "-", " ").replace("_", "")
+
+        # "que vén" == seguinte
+        s = s.replace(" que ven", " seguinte")
+
+        # horas faladas precedidas de artigo: "á unha", "ás dúas"
+        spoken_hours = {"unha": "1", "duas": "2", "tres": "3", "catro": "4",
+                        "cinco": "5", "seis": "6", "sete": "7", "oito": "8",
+                        "nove": "9", "dez": "10", "once": "11", "doce": "12"}
+        for k, v in spoken_hours.items():
+            s = re.sub(r"\b(a|as) " + k + r"\b", r"\1 " + v, s)
+
+        noise_words = ["entre", "a", "o", "do", "ao", "da", "na", "no",
+                       "de", "para", "un", "unha", "calquera",
+                       "este", "esta"]
+        for word in noise_words:
+            s = s.replace(" " + word + " ", " ")
+
+        # sinónimos e equivalentes
+        synonyms = {"maña": ["amencer", "cedo", "moi cedo"],
+                    "tarde": ["seran", "atardecer"],
+                    "noite": ["anoitecer"]}
+        for syn in synonyms:
+            for word in synonyms[syn]:
+                s = s.replace(" " + word + " ", " " + syn + " ")
+
+        # plurais relevantes
+        wordlist = ["mañas", "tardes", "noites", "dias", "semanas",
+                    "anos", "minutos", "segundos", "seguintes",
+                    "proximas", "proximos", "horas"]
+        for word in wordlist:
+            s = s.replace(word, word.rstrip('s'))
+        s = s.replace("meses", "mes").replace("anteriores", "anterior")
+        return s
+
+    def date_found():
+        return found or \
+            (
+                    datestr != "" or
+                    yearOffset != 0 or monthOffset != 0 or
+                    dayOffset is True or hrOffset != 0 or
+                    hrAbs or minOffset != 0 or
+                    minAbs or secOffset != 0
+            )
+
+    if text == "":
+        return None
+    if anchorDate is None:
+        anchorDate = now_local()
+
+    found = False
+    daySpecified = False
+    dayOffset = False
+    monthOffset = 0
+    yearOffset = 0
+    dateNow = anchorDate
+    today = dateNow.strftime("%w")
+    currentYear = dateNow.strftime("%Y")
+    fromFlag = False
+    datestr = ""
+    hasYear = False
+    timeQualifier = ""
+
+    words = clean_string(text).split(" ")
+    timeQualifiersList = ['maña', 'tarde', 'noite']
+    time_indicators = ["en", "a", "as", "o", "os", "ao", "por", "pasados",
+                       "pasadas", "dia", "hora"]
+    days = ['luns', 'martes', 'mercores',
+            'xoves', 'venres', 'sabado', 'domingo']
+    months = ['xaneiro', 'febreiro', 'marzo', 'abril', 'maio', 'xuño',
+              'xullo', 'agosto', 'setembro', 'outubro', 'novembro',
+              'decembro']
+    monthsShort = ['xan', 'feb', 'mar', 'abr', 'mai', 'xuñ', 'xul', 'ago',
+                   'set', 'out', 'nov', 'dec']
+    nexts = ["seguinte", "proximo", "proxima"]
+    suffix_nexts = ["seguinte", "seguintes", "subsecuentes"]
+    lasts = ["ultimo", "ultima"]
+    suffix_lasts = ["pasada", "pasado", "anterior", "antes"]
+    nxts = ["despois", "seguinte", "proximo", "proxima"]
+    prevs = ["antes", "previa", "previo", "anterior"]
+    froms = ["desde", "en", "para", "despois", "por", "proximo",
+             "proxima", "de"]
+    thises = ["este", "esta"]
+    froms += thises
+    lists = nxts + prevs + froms + time_indicators
+    for idx, word in enumerate(words):
+        if word == "":
+            continue
+        wordPrevPrev = words[idx - 2] if idx > 1 else ""
+        wordPrev = words[idx - 1] if idx > 0 else ""
+        wordNext = words[idx + 1] if idx + 1 < len(words) else ""
+        wordNextNext = words[idx + 2] if idx + 2 < len(words) else ""
+        wordNextNextNext = words[idx + 3] if idx + 3 < len(words) else ""
+
+        start = idx
+        used = 0
+        # gardar o cualificador de tempo para máis tarde
+        if word in timeQualifiersList:
+            timeQualifier = word
+
+        # hoxe, mañá, onte
+        elif word == "hoxe" and not fromFlag:
+            dayOffset = 0
+            used += 1
+        elif word == "maña" and not fromFlag:
+            dayOffset = 1
+            used += 1
+        elif word == "onte" and not fromFlag:
+            dayOffset -= 1
+            used += 1
+        # antonte
+        elif word == "antonte" and not fromFlag:
+            dayOffset -= 2
+            used += 1
+        elif word == "ante" and wordNext == "onte" and not fromFlag:
+            dayOffset -= 2
+            used = 2
+        # pasadomañá
+        elif word == "pasadomaña" and not fromFlag:
+            dayOffset += 2
+            used += 1
+        elif word == "pasado" and wordNext == "maña" and not fromFlag:
+            dayOffset += 2
+            used = 2
+        # en 5 días, etc
+        elif word == "dia":
+            if wordNext == "pasado" or wordNext == "ante":
+                used += 1
+                if wordPrev and wordPrev[0].isdigit():
+                    dayOffset += int(wordPrev)
+                    start -= 1
+                    used += 1
+            elif (wordPrev and wordPrev[0].isdigit() and
+                  wordNext not in months and
+                  wordNext not in monthsShort):
+                dayOffset += int(wordPrev)
+                start -= 1
+                used += 2
+            elif wordNext and wordNext[0].isdigit() and wordNextNext not in \
+                    months and wordNextNext not in monthsShort:
+                dayOffset += int(wordNext)
+                start -= 1
+                used += 2
+
+        elif word == "semana" and not fromFlag:
+            if wordPrev and wordPrev[0].isdigit():
+                dayOffset += int(wordPrev) * 7
+                start -= 1
+                used = 2
+            for w in nexts:
+                if wordPrev == w:
+                    dayOffset = 7
+                    start -= 1
+                    used = 2
+            for w in lasts:
+                if wordPrev == w:
+                    dayOffset = -7
+                    start -= 1
+                    used = 2
+            for w in suffix_nexts:
+                if wordNext == w:
+                    dayOffset = 7
+                    start -= 1
+                    used = 2
+            for w in suffix_lasts:
+                if wordNext == w:
+                    dayOffset = -7
+                    start -= 1
+                    used = 2
+        # 10 meses, mes seguinte, mes pasado
+        elif word == "mes" and not fromFlag:
+            if wordPrev and wordPrev[0].isdigit():
+                monthOffset = int(wordPrev)
+                start -= 1
+                used = 2
+            for w in nexts:
+                if wordPrev == w:
+                    monthOffset = 1
+                    start -= 1
+                    used = 2
+            for w in lasts:
+                if wordPrev == w:
+                    monthOffset = -1
+                    start -= 1
+                    used = 2
+            for w in suffix_nexts:
+                if wordNext == w:
+                    monthOffset = 1
+                    start -= 1
+                    used = 2
+            for w in suffix_lasts:
+                if wordNext == w:
+                    monthOffset = -1
+                    start -= 1
+                    used = 2
+        # 5 anos, ano seguinte, ano pasado
+        elif word == "ano" and not fromFlag:
+            if wordPrev and wordPrev[0].isdigit():
+                yearOffset = int(wordPrev)
+                start -= 1
+                used = 2
+            for w in nexts:
+                if wordPrev == w:
+                    yearOffset = 1
+                    start -= 1
+                    used = 2
+            for w in lasts:
+                if wordPrev == w:
+                    yearOffset = -1
+                    start -= 1
+                    used = 2
+            for w in suffix_nexts:
+                if wordNext == w:
+                    yearOffset = 1
+                    start -= 1
+                    used = 2
+            for w in suffix_lasts:
+                if wordNext == w:
+                    yearOffset = -1
+                    start -= 1
+                    used = 2
+        # días da semana: luns, martes...
+        elif word in days and not fromFlag:
+            d = days.index(word)
+            dayOffset = (d + 1) - int(today)
+            used = 1
+            if dayOffset < 0:
+                dayOffset += 7
+            if wordPrev in nexts:
+                dayOffset += 7
+                used += 1
+                start -= 1
+            elif wordPrev == "pasado":
+                dayOffset -= 7
+                used += 1
+                start -= 1
+            if wordNext == "seguinte":
+                used += 1
+            elif wordNext == "pasado":
+                used += 1
+        # 3 de xuño, xuño 20, etc
+        elif word in months or word in monthsShort:
+            try:
+                m = months.index(word)
+            except ValueError:
+                m = monthsShort.index(word)
+            used += 1
+            datestr = months[m]
+            if wordPrev and wordPrev[0].isdigit():
+                # 13 maio
+                datestr += " " + wordPrev
+                start -= 1
+                used += 1
+                if wordNext and wordNext[0].isdigit():
+                    datestr += " " + wordNext
+                    used += 1
+                    hasYear = True
+                else:
+                    hasYear = False
+
+            elif wordNext and wordNext[0].isdigit():
+                # maio 13
+                datestr += " " + wordNext
+                used += 1
+                if wordNextNext and wordNextNext[0].isdigit():
+                    datestr += " " + wordNextNext
+                    used += 1
+                    hasYear = True
+                else:
+                    hasYear = False
+
+            elif wordPrevPrev and wordPrevPrev[0].isdigit():
+                # 13 dia maio
+                datestr += " " + wordPrevPrev
+                start -= 2
+                used += 2
+                if wordNext and wordNext[0].isdigit():
+                    datestr += " " + wordNext
+                    used += 1
+                    hasYear = True
+                else:
+                    hasYear = False
+
+            elif wordNextNext and wordNextNext[0].isdigit():
+                # maio dia 13
+                datestr += " " + wordNextNext
+                used += 2
+                if wordNextNextNext and wordNextNextNext[0].isdigit():
+                    datestr += " " + wordNextNextNext
+                    used += 1
+                    hasYear = True
+                else:
+                    hasYear = False
+
+            if datestr in months:
+                datestr = ""
+
+        # 5 días desde mañá, 2 semanas desde o xoves, etc
+        validFollowups = days + months + monthsShort
+        validFollowups.append("hoxe")
+        validFollowups.append("maña")
+        validFollowups.append("onte")
+        validFollowups.append("antonte")
+        validFollowups.append("agora")
+        validFollowups.append("xa")
+
+        if word in froms and wordNext in validFollowups:
+
+            if not (word == "pasado" or word == "antes"):
+                used = 2
+                fromFlag = True
+            if wordNext == "maña" and word != "pasado":
+                dayOffset += 1
+            elif wordNext == "onte":
+                dayOffset -= 1
+            elif wordNext == "antonte":
+                dayOffset -= 2
+            elif wordNext in days:
+                d = days.index(wordNext)
+                tmpOffset = (d + 1) - int(today)
+                used = 2
+                if tmpOffset < 0:
+                    tmpOffset += 7
+                if wordNextNext:
+                    if wordNextNext in nxts:
+                        tmpOffset += 7
+                        used += 1
+                    elif wordNextNext in prevs:
+                        tmpOffset -= 7
+                        used += 1
+                dayOffset += tmpOffset
+            elif wordNextNext and wordNextNext in days:
+                d = days.index(wordNextNext)
+                tmpOffset = (d + 1) - int(today)
+                used = 3
+                if wordNextNextNext:
+                    if wordNextNextNext in nxts:
+                        tmpOffset += 7
+                        used += 1
+                    elif wordNextNextNext in prevs:
+                        tmpOffset -= 7
+                        used += 1
+                dayOffset += tmpOffset
+        if wordNext in months:
+            used -= 1
+        if used > 0:
+            if start - 1 > 0 and words[start - 1] in lists:
+                start -= 1
+                used += 1
+
+            for i in range(0, used):
+                words[i + start] = ""
+
+            if start - 1 >= 0 and words[start - 1] in lists:
+                words[start - 1] = ""
+            found = True
+            daySpecified = True
+
+    # analizar a hora
+    hrOffset = 0
+    minOffset = 0
+    secOffset = 0
+    hrAbs = None
+    minAbs = None
+
+    for idx, word in enumerate(words):
+        if word == "":
+            continue
+
+        wordPrevPrev = words[idx - 2] if idx > 1 else ""
+        wordPrev = words[idx - 1] if idx > 0 else ""
+        wordNext = words[idx + 1] if idx + 1 < len(words) else ""
+        wordNextNext = words[idx + 2] if idx + 2 < len(words) else ""
+        wordNextNextNext = words[idx + 3] if idx + 3 < len(words) else ""
+        # mediodía, medianoite, mañá, tarde, noite
+        used = 0
+        if word == "mediodia" or (word == "medio" and wordNext == "dia"):
+            hrAbs = 12
+            used += 2 if word == "medio" else 1
+        elif word == "medianoite" or (word == "media" and
+                                      wordNext == "noite"):
+            hrAbs = 0
+            used += 2 if word == "media" else 1
+        elif word == "media" and wordNext == "tarde":
+            if not hrAbs:
+                hrAbs = 17
+            used += 2
+        elif word == "media" and wordNext == "maña":
+            if not hrAbs:
+                hrAbs = 10
+            used += 2
+        elif word == "maña":
+            if not hrAbs:
+                hrAbs = 8
+            used += 1
+        elif word == "tarde" and wordNext == "noite":
+            if not hrAbs:
+                hrAbs = 20
+            used += 2
+        elif word == "tarde":
+            if not hrAbs:
+                hrAbs = 15
+            used += 1
+        elif word == "madrugada":
+            if not hrAbs:
+                hrAbs = 1
+            used += 1
+        elif word == "noite":
+            if not hrAbs:
+                hrAbs = 21
+            used += 1
+        # media hora, cuarto de hora
+        elif (word == "hora" and
+              (wordPrev in time_indicators or wordPrevPrev in
+               time_indicators)):
+            if wordPrev == "media":
+                minOffset = 30
+            elif wordPrev == "cuarto":
+                minOffset = 15
+            elif wordPrevPrev == "cuarto":
+                minOffset = 15
+                if idx > 2 and words[idx - 3] in time_indicators:
+                    words[idx - 3] = ""
+                words[idx - 2] = ""
+            else:
+                hrOffset = 1
+            if wordPrevPrev in time_indicators:
+                words[idx - 2] = ""
+            words[idx - 1] = ""
+            used += 1
+            hrAbs = -1
+            minAbs = -1
+        # 5:00 am, 12:00 pm, ás 8, etc
+        elif word[0].isdigit():
+            isTime = True
+            strHH = ""
+            strMM = ""
+            remainder = ""
+            if ':' in word:
+                # 17:30, 3:00 da maña
+                stage = 0
+                length = len(word)
+                for i in range(length):
+                    if stage == 0:
+                        if word[i].isdigit():
+                            strHH += word[i]
+                        elif word[i] == ":":
+                            stage = 1
+                        else:
+                            stage = 2
+                            i -= 1
+                    elif stage == 1:
+                        if word[i].isdigit():
+                            strMM += word[i]
+                        else:
+                            stage = 2
+                            i -= 1
+                    elif stage == 2:
+                        remainder = word[i:].replace(".", "")
+                        break
+                if remainder == "":
+                    nextWord = wordNext.replace(".", "")
+                    if nextWord == "am" or nextWord == "pm":
+                        remainder = nextWord
+                        used += 1
+                    elif wordNext == "maña" or wordNext == "madrugada":
+                        remainder = "am"
+                        used += 1
+                    elif wordNext == "tarde":
+                        remainder = "pm"
+                        used += 1
+                    elif wordNext == "noite":
+                        if 0 < int(strHH) < 6:
+                            remainder = "am"
+                        else:
+                            remainder = "pm"
+                        used += 1
+                    elif timeQualifier != "":
+                        if int(strHH) <= 12 and \
+                                timeQualifier in ["tarde", "noite"]:
+                            remainder = "pm"
+
+            else:
+                # números sen dous puntos
+                # ás 8 e media, en 5 minutos, etc
+                length = len(word)
+                strNum = ""
+                remainder = ""
+                for i in range(length):
+                    if word[i].isdigit():
+                        strNum += word[i]
+                    else:
+                        remainder += word[i]
+
+                if remainder == "":
+                    remainder = wordNext.replace(".", "").lstrip().rstrip()
+
+                if (
+                        remainder == "pm" or
+                        wordNext == "pm" or
+                        remainder == "p.m." or
+                        wordNext == "p.m."):
+                    strHH = strNum
+                    remainder = "pm"
+                    used = 1
+                elif (
+                        remainder == "am" or
+                        wordNext == "am" or
+                        remainder == "a.m." or
+                        wordNext == "a.m."):
+                    strHH = strNum
+                    remainder = "am"
+                    used = 1
+                # ás 8 e media, ás 8 e cuarto
+                elif wordNext == "e" and wordNextNext in ["media", "cuarto"]:
+                    strHH = strNum
+                    strMM = 30 if wordNextNext == "media" else 15
+                    used = 2
+                    if wordNextNextNext == "tarde":
+                        remainder = "pm"
+                        used += 1
+                    elif wordNextNextNext == "maña":
+                        remainder = "am"
+                        used += 1
+                    elif wordNextNextNext == "noite":
+                        if 0 < int(strNum) < 6:
+                            remainder = "am"
+                        else:
+                            remainder = "pm"
+                        used += 1
+                # ás 8 menos cuarto
+                elif wordNext == "menos" and wordNextNext == "cuarto":
+                    strHH = str(int(strNum) - 1 if int(strNum) > 0 else 23)
+                    strMM = 45
+                    used = 2
+                    if wordNextNextNext == "tarde":
+                        remainder = "pm"
+                        used += 1
+                    elif wordNextNextNext == "maña":
+                        remainder = "am"
+                        used += 1
+                    elif wordNextNextNext == "noite":
+                        if 0 < int(strHH) < 6:
+                            remainder = "am"
+                        else:
+                            remainder = "pm"
+                        used += 1
+                else:
+                    if wordNext == "tarde":
+                        strHH = strNum
+                        remainder = "pm"
+                        used = 1
+                    elif wordNext == "maña" or wordNext == "madrugada":
+                        strHH = strNum
+                        remainder = "am"
+                        used = 1
+                    elif wordNext == "noite":
+                        strHH = strNum
+                        if 0 < int(strNum) < 6:
+                            remainder = "am"
+                        else:
+                            remainder = "pm"
+                        used = 1
+                    elif (wordNext == "hora" and
+                          word[0] != '0' and
+                          int(word) < 100):
+                        # en 3 horas
+                        hrOffset = int(word)
+                        used = 2
+                        isTime = False
+                        hrAbs = -1
+                        minAbs = -1
+                    elif wordNext == "minuto":
+                        # en 10 minutos
+                        minOffset = int(word)
+                        used = 2
+                        isTime = False
+                        hrAbs = -1
+                        minAbs = -1
+                    elif wordNext == "segundo":
+                        # en 5 segundos
+                        secOffset = int(word)
+                        used = 2
+                        isTime = False
+                        hrAbs = -1
+                        minAbs = -1
+                    elif int(word) > 100:
+                        strHH = str(int(word) // 100)
+                        strMM = str(int(word) % 100)
+                        if wordNext == "hora":
+                            used += 1
+                    elif wordNext == "" or (
+                            wordNext == "en" and wordNextNext == "punto"):
+                        strHH = word
+                        strMM = 00
+                        if wordNext == "en" and wordNextNext == "punto":
+                            used += 2
+                            if wordNextNextNext == "tarde":
+                                remainder = "pm"
+                                used += 1
+                            elif wordNextNextNext == "maña":
+                                remainder = "am"
+                                used += 1
+                            elif wordNextNextNext == "noite":
+                                if 0 < int(strHH) < 6:
+                                    remainder = "am"
+                                else:
+                                    remainder = "pm"
+                                used += 1
+                    elif wordNext[0].isdigit():
+                        strHH = word
+                        strMM = wordNext
+                        used += 1
+                        if wordNextNext == "hora":
+                            used += 1
+                    else:
+                        isTime = False
+
+            strHH = int(strHH) if strHH else 0
+            strMM = int(strMM) if strMM else 0
+            strHH = strHH + 12 if (remainder == "pm" and
+                                   0 < strHH < 12) else strHH
+            strHH = strHH - 12 if (remainder == "am" and
+                                   strHH >= 12) else strHH
+            if strHH > 24 or strMM > 59:
+                isTime = False
+                used = 0
+            if isTime:
+                hrAbs = strHH * 1
+                minAbs = strMM * 1
+                used += 1
+
+        if used > 0:
+            # eliminar as palabras analizadas da frase
+            for i in range(used):
+                words[idx + i] = ""
+
+            if wordPrev == "en" or wordPrev == "punto":
+                words[words.index(wordPrev)] = ""
+
+            if idx > 0 and wordPrev in time_indicators:
+                words[idx - 1] = ""
+            if idx > 1 and wordPrevPrev in time_indicators:
+                words[idx - 2] = ""
+
+            idx += used - 1
+            found = True
+
+    # comprobar que se atopou unha data
+    if not date_found():
+        return None
+
+    if dayOffset is False:
+        dayOffset = 0
+
+    # manipulación da data
+
+    extractedDate = dateNow
+    extractedDate = extractedDate.replace(microsecond=0,
+                                          second=0,
+                                          minute=0,
+                                          hour=0)
+    if datestr != "":
+        en_months = ['january', 'february', 'march', 'april', 'may', 'june',
+                     'july', 'august', 'september', 'october', 'november',
+                     'december']
+        en_monthsShort = ['jan', 'feb', 'mar', 'apr', 'may', 'june', 'july',
+                          'aug', 'sept', 'oct', 'nov', 'dec']
+        for idx, en_month in enumerate(en_months):
+            datestr = re.sub(r"\b" + re.escape(months[idx]) + r"\b",
+                             en_month, datestr)
+        for idx, en_month in enumerate(en_monthsShort):
+            datestr = re.sub(r"\b" + re.escape(monthsShort[idx]) + r"\b",
+                             en_month, datestr)
+
+        if hasYear:
+            temp = datetime.strptime(datestr, "%B %d %Y")
+        else:
+            temp = datetime.strptime(datestr, "%B %d")
+        if extractedDate.tzinfo:
+            temp = temp.replace(tzinfo=extractedDate.tzinfo)
+
+        if not hasYear:
+            temp = temp.replace(year=extractedDate.year)
+
+            if extractedDate < temp:
+                extractedDate = extractedDate.replace(
+                    year=int(currentYear),
+                    month=int(temp.strftime("%m")),
+                    day=int(temp.strftime("%d")))
+            else:
+                extractedDate = extractedDate.replace(
+                    year=int(currentYear) + 1,
+                    month=int(temp.strftime("%m")),
+                    day=int(temp.strftime("%d")))
+        else:
+            extractedDate = extractedDate.replace(
+                year=int(temp.strftime("%Y")),
+                month=int(temp.strftime("%m")),
+                day=int(temp.strftime("%d")))
+
+    if yearOffset != 0:
+        extractedDate = extractedDate + relativedelta(years=yearOffset)
+    if monthOffset != 0:
+        extractedDate = extractedDate + relativedelta(months=monthOffset)
+    if dayOffset != 0:
+        extractedDate = extractedDate + relativedelta(days=dayOffset)
+
+    if hrAbs is None and minAbs is None and default_time:
+        hrAbs = default_time.hour
+        minAbs = default_time.minute
+
+    if hrAbs != -1 and minAbs != -1:
+        extractedDate = extractedDate + relativedelta(hours=hrAbs or 0,
+                                                      minutes=minAbs or 0)
+        if (hrAbs or minAbs) and datestr == "":
+            if not daySpecified and dateNow > extractedDate:
+                extractedDate = extractedDate + relativedelta(days=1)
+    if hrOffset != 0:
+        extractedDate = extractedDate + relativedelta(hours=hrOffset)
+    if minOffset != 0:
+        extractedDate = extractedDate + relativedelta(minutes=minOffset)
+    if secOffset != 0:
+        extractedDate = extractedDate + relativedelta(seconds=secOffset)
+
+    resultStr = " ".join(words)
+    resultStr = ' '.join(resultStr.split())
+    return [extractedDate, resultStr]
 
 
 def extract_duration_gl(text):

--- a/test/parse_tests/test_parse_gl.py
+++ b/test/parse_tests/test_parse_gl.py
@@ -1,0 +1,177 @@
+#
+# Copyright 2017 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import unittest
+from datetime import datetime, time, timedelta
+
+from ovos_config.locale import get_default_tz as default_timezone
+
+import ovos_date_parser as _odp
+
+LANG = "gl"
+
+
+def extract_datetime(text, anchorDate=None, lang=LANG, default_time=None):
+    res = _odp.extract_datetime(text, lang=lang, anchorDate=anchorDate,
+                                default_time=default_time)
+    if res is not None and res[0] is not None and res[0].tzinfo is None:
+        res = [res[0].replace(tzinfo=default_timezone()), res[1]]
+    return res
+
+
+def extract_duration(text, lang=LANG):
+    return _odp.extract_duration(text, lang=lang)
+
+
+class TestDatetimeGl(unittest.TestCase):
+    # anchor: 1998-01-01 was a thursday
+    ANCHOR = datetime(1998, 1, 1)
+    ANCHOR_NOON = datetime(1998, 1, 1, 12, 0)
+
+    def test_weekday(self):
+        # next friday after thursday jan 1st is jan 2nd
+        self.assertEqual(
+            extract_datetime("venres", anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 2, tzinfo=default_timezone()))
+        # next monday after thursday jan 1st is jan 5th
+        self.assertEqual(
+            extract_datetime("luns", anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 5, tzinfo=default_timezone()))
+        # "que vén" == next occurrence
+        self.assertEqual(
+            extract_datetime("luns que vén", anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 5, tzinfo=default_timezone()))
+
+    def test_tomorrow(self):
+        # "mañá" defaults to morning (8:00) of the next day when the
+        # anchor is past 8:00
+        self.assertEqual(
+            extract_datetime("mañá", anchorDate=self.ANCHOR_NOON)[0],
+            datetime(1998, 1, 2, 8, 0, tzinfo=default_timezone()))
+
+    def test_yesterday(self):
+        self.assertEqual(
+            extract_datetime("onte", anchorDate=self.ANCHOR)[0],
+            datetime(1997, 12, 31, tzinfo=default_timezone()))
+
+    def test_day_after_tomorrow(self):
+        self.assertEqual(
+            extract_datetime("pasadomañá", anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 3, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime("pasado mañá", anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 3, tzinfo=default_timezone()))
+
+    def test_in_n_days(self):
+        self.assertEqual(
+            extract_datetime("en 5 días", anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 6, tzinfo=default_timezone()))
+
+    def test_explicit_date(self):
+        # june 3rd comes after january 1st, so same year
+        self.assertEqual(
+            extract_datetime("3 de xuño", anchorDate=self.ANCHOR)[0],
+            datetime(1998, 6, 3, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime("11 de xaneiro",
+                             anchorDate=datetime(1998, 1, 1))[0],
+            datetime(1998, 1, 11, tzinfo=default_timezone()))
+
+    def test_time_half_past(self):
+        # 8 da tarde == 20:00, e media -> 20:30
+        self.assertEqual(
+            extract_datetime("ás 8 e media da tarde",
+                             anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 1, 20, 30, tzinfo=default_timezone()))
+
+    def test_time_quarter_past(self):
+        self.assertEqual(
+            extract_datetime("ás 8 e cuarto da mañá",
+                             anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 1, 8, 15, tzinfo=default_timezone()))
+
+    def test_time_quarter_to(self):
+        # 8 menos cuarto da mañá == 7:45
+        self.assertEqual(
+            extract_datetime("ás 8 menos cuarto da mañá",
+                             anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 1, 7, 45, tzinfo=default_timezone()))
+
+    def test_spoken_hour(self):
+        # "ás dúas da tarde" == 14:00
+        self.assertEqual(
+            extract_datetime("ás dúas da tarde",
+                             anchorDate=self.ANCHOR_NOON)[0],
+            datetime(1998, 1, 1, 14, 0, tzinfo=default_timezone()))
+
+    def test_noon(self):
+        self.assertEqual(
+            extract_datetime("mediodía", anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 1, 12, 0, tzinfo=default_timezone()))
+
+    def test_midnight(self):
+        self.assertEqual(
+            extract_datetime("medianoite", anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 1, 0, 0, tzinfo=default_timezone()))
+
+    def test_digit_time(self):
+        self.assertEqual(
+            extract_datetime("ás 17:30", anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 1, 17, 30, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime("15:30", anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 1, 15, 30, tzinfo=default_timezone()))
+
+    def test_next_week(self):
+        self.assertEqual(
+            extract_datetime("a semana que vén", anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 8, tzinfo=default_timezone()))
+
+    def test_last_week(self):
+        self.assertEqual(
+            extract_datetime("a semana pasada", anchorDate=self.ANCHOR)[0],
+            datetime(1997, 12, 25, tzinfo=default_timezone()))
+
+    def test_no_date(self):
+        self.assertIsNone(extract_datetime("ola mundo",
+                                           anchorDate=self.ANCHOR))
+        self.assertIsNone(extract_datetime("non hai tempo",
+                                           anchorDate=self.ANCHOR))
+        self.assertIsNone(extract_datetime("", anchorDate=self.ANCHOR))
+
+    def test_default_time(self):
+        # no time in the sentence -> default_time is applied
+        self.assertEqual(
+            extract_datetime("en 5 días", anchorDate=self.ANCHOR,
+                             default_time=time(9, 30))[0],
+            datetime(1998, 1, 6, 9, 30, tzinfo=default_timezone()))
+
+
+class TestExtractDurationGl(unittest.TestCase):
+    def test_extract_duration(self):
+        self.assertEqual(extract_duration("10 segundos"),
+                         (timedelta(seconds=10.0), ""))
+        self.assertEqual(extract_duration("5 minutos"),
+                         (timedelta(minutes=5), ""))
+        self.assertEqual(extract_duration("2 horas"),
+                         (timedelta(hours=2), ""))
+        self.assertEqual(extract_duration("3 días"),
+                         (timedelta(days=3), ""))
+        self.assertEqual(extract_duration("25 semanas"),
+                         (timedelta(weeks=25), ""))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds `extract_datetime_gl` and wires it into `extract_datetime`.

## What
- `extract_datetime_gl(text, anchorDate=None, default_time=None)` in `dates_gl.py`, adapted from the Spanish extractor with Galician vocabulary (weekdays, months, hoxe/mañá/onte/antonte/pasadomañá, semana/mes/ano offsets, que vén/próximo/pasado, mediodía/medianoite, e media / e cuarto / menos cuarto, da mañá/tarde/noite, spoken hours "á unha"/"ás dúas", digit times).
- `gl` branch in `extract_datetime` dispatch.
- `test/parse_tests/test_parse_gl.py` with anchor-date based coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)