### PR TITLE
ci: install setuptools for the release workflow

### DIFF
--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -49,7 +49,7 @@ jobs:
           python-version: '3.14'
       - name: Install Build Tools
         run: |
-          python -m pip install build wheel
+          python -m pip install build wheel setuptools
       - name: version
         run: echo "::set-output name=version::$(python setup.py --version)"
         id: version
@@ -80,6 +80,7 @@ jobs:
       - name: Get version from setup.py
         id: get_version
         run: |
+          python -m pip install setuptools
           VERSION=$(python setup.py --version)
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 


### PR DESCRIPTION
The release workflow's `publish_pypi` and `propose_release` jobs call `python setup.py --version` and `python setup.py sdist`, which fails on current runners where setuptools is no longer bundled with Python. Installs setuptools in both jobs before the setup.py calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)