### PR TITLE
feat: asturian date and time support

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -28,6 +28,17 @@ style. Explicit years parse in the languages with full date support
 - Basque, Catalan and Persian have their own idiomatic readings
   (Catalan supports `TimeVariantCA` for bell-tower style).
 
+## Asturian (ast)
+
+Full support: `nice_time`, `nice_date`, `nice_date_time`, `nice_day`,
+`nice_weekday`, `nice_month`, `nice_year`, `extract_datetime` and
+`extract_duration`. Spoken time follows the feminine-article convention
+("la una", "les cinco y media", "les ocho menos cuartu", "en puntu") with
+`use_ampm=True` adding "de la madrugada / mañana / tarde / nueche".
+Duration parsing handles the Asturian plurals in `-es` (hores, selmanes,
+díes) as well as the singular forms. "mañana" is ambiguous between
+"tomorrow" and "morning" and is disambiguated the same way as in Spanish.
+
 ## Fallbacks
 
 If a language has no `extract_datetime` implementation, the

--- a/ovos_date_parser/__init__.py
+++ b/ovos_date_parser/__init__.py
@@ -18,6 +18,10 @@ from ovos_date_parser.dates_ar import (
 from ovos_date_parser.duration import (
     DurationResolution, DurationLexicon, DURATION_LEXICONS, extract_duration_generic
 )
+from ovos_date_parser.dates_ast import (
+    extract_duration_ast, extract_datetime_ast, nice_year_ast, nice_weekday_ast, nice_month_ast,
+    nice_day_ast, nice_date_time_ast, nice_date_ast, nice_time_ast
+)
 from ovos_date_parser.dates_az import (
     extract_datetime_az, extract_duration_az, nice_duration_az, nice_time_az,
 )
@@ -106,6 +110,8 @@ def nice_time(
     """
     if lang.startswith("ar"):
         return nice_time_ar(dt, speech, use_24hour, use_ampm)
+    if lang.startswith("ast"):
+        return nice_time_ast(dt, speech, use_24hour, use_ampm)
     if lang.startswith("az"):
         return nice_time_az(dt, speech, use_24hour, use_ampm)
     if lang.startswith("gl"):
@@ -226,6 +232,8 @@ def extract_duration(
             f"resolution/replace_token not supported for language: {lang}")
     if lang.startswith("ar"):
         return extract_duration_ar(text)
+    if lang.startswith("ast"):
+        return extract_duration_ast(text)
     if lang.startswith("az"):
         return extract_duration_az(text)
     if lang.startswith("ca"):
@@ -280,6 +288,8 @@ def extract_datetime(
     """
     if lang.startswith("ar"):
         return extract_datetime_ar(text, anchorDate=anchorDate, default_time=default_time)
+    if lang.startswith("ast"):
+        return extract_datetime_ast(text, anchorDate=anchorDate, default_time=default_time)
     if lang.startswith("az"):
         return extract_datetime_az(text, anchorDate=anchorDate, default_time=default_time)
     if lang.startswith("ca"):
@@ -583,6 +593,8 @@ def nice_date(dt, lang, now=None, include_weekday=True):
         return nice_date_es(dt, now, include_weekday)
     if lang.startswith("gl"):
         return nice_date_gl(dt, now, include_weekday)
+    if lang.startswith("ast"):
+        return nice_date_ast(dt, now, include_weekday)
     date_time_format.cache(lang)
     return date_time_format.date_format(dt, lang, now, include_weekday)
 
@@ -615,6 +627,8 @@ def nice_date_time(dt, lang, now=None, use_24hour=False,
         return nice_date_time_es(dt, now, use_24hour, use_ampm)
     if lang.startswith("gl"):
         return nice_date_time_gl(dt, now, use_24hour, use_ampm)
+    if lang.startswith("ast"):
+        return nice_date_time_ast(dt, now, use_24hour, use_ampm)
     date_time_format.cache(lang)
     return date_time_format.date_time_format(dt, lang, now, use_24hour, use_ampm)
 
@@ -626,6 +640,8 @@ def nice_day(dt, lang, date_format='DMY', include_month=True):
         return nice_day_es(dt, date_format, include_month)
     if lang.startswith("gl"):
         return nice_day_gl(dt, date_format, include_month)
+    if lang.startswith("ast"):
+        return nice_day_ast(dt, date_format, include_month)
     if include_month:
         month = nice_month(dt, lang, date_format)
         if date_format == 'MDY':
@@ -643,6 +659,8 @@ def nice_weekday(dt, lang):
         return nice_weekday_es(dt)
     if lang.startswith("gl"):
         return nice_weekday_gl(dt)
+    if lang.startswith("ast"):
+        return nice_weekday_ast(dt)
     date_time_format.cache(lang)
 
     if lang in date_time_format.lang_config.keys():
@@ -662,6 +680,8 @@ def nice_month(dt, lang, date_format='MDY'):
         return nice_month_es(dt)
     if lang.startswith("gl"):
         return nice_month_gl(dt)
+    if lang.startswith("ast"):
+        return nice_month_ast(dt)
     date_time_format.cache(lang)
     if lang in date_time_format.lang_config.keys():
         localized_month_names = date_time_format.lang_config[lang]['month']
@@ -693,6 +713,8 @@ def nice_year(dt, lang, bc=False):
         return nice_year_es(dt, bc)
     if lang.startswith("gl"):
         return nice_year_gl(dt, bc)
+    if lang.startswith("ast"):
+        return nice_year_ast(dt, bc)
     date_time_format.cache(lang)
     return date_time_format.year_format(dt, lang, bc)
 

--- a/ovos_date_parser/dates_ast.py
+++ b/ovos_date_parser/dates_ast.py
@@ -1,0 +1,1064 @@
+import re
+from datetime import datetime
+from datetime import timedelta
+
+from dateutil.relativedelta import relativedelta
+from ovos_number_parser.numbers_ast import AST
+from ovos_utils.time import now_local
+
+WEEKDAYS_AST = {
+    0: "llunes",
+    1: "martes",
+    2: "miércoles",
+    3: "xueves",
+    4: "vienres",
+    5: "sábadu",
+    6: "domingu"
+}
+MONTHS_AST = {
+    1: "xineru",
+    2: "febreru",
+    3: "marzu",
+    4: "abril",
+    5: "mayu",
+    6: "xunu",
+    7: "xunetu",
+    8: "agostu",
+    9: "setiembre",
+    10: "ochobre",
+    11: "payares",
+    12: "avientu"
+}
+
+
+def pronounce_number_ast(number, **kwargs):
+    return AST.pronounce_number(number, **kwargs)
+
+
+def nice_year_ast(dt, bc=False):
+    """
+        Formatea un añu nuna forma pronunciable.
+
+        Args:
+            dt (datetime): data a formatear (asúmese que yá ta na zona horaria llocal)
+            bc (bool): amiesta a.C. dempués del añu
+        Returns:
+            (str): L'añu formateáu como cadena
+    """
+    year = pronounce_number_ast(dt.year)
+    if bc:
+        return f"{year} a.C."
+    return year
+
+
+def nice_weekday_ast(dt):
+    weekday = WEEKDAYS_AST[dt.weekday()]
+    return weekday.capitalize()
+
+
+def nice_month_ast(dt):
+    month = MONTHS_AST[dt.month]
+    return month.capitalize()
+
+
+def nice_day_ast(dt, date_format='DMY', include_month=True):
+    if include_month:
+        month = nice_month_ast(dt)
+        if date_format == 'MDY':
+            return "{} {}".format(month, dt.strftime("%d").lstrip("0"))
+        else:
+            return "{} {}".format(dt.strftime("%d").lstrip("0"), month)
+    return dt.strftime("%d").lstrip("0")
+
+
+def nice_date_time_ast(dt, now=None, use_24hour=False, use_ampm=False):
+    """
+        Formatea una data y hora de manera pronunciable.
+
+        Por exemplu, xenera 'martes, cinco de xunu de 2018 a les cinco y media'.
+
+        Args:
+            dt (datetime): data a formatear (asúmese que yá ta na zona horaria llocal)
+            now (datetime): Data actual. Si se proporciona, la data devuelta acurtiaráse.
+            use_24hour (bool): salida en formatu de 24 hores o 12 hores
+            use_ampm (bool): incluyir el am/pm en formatu de 12 hores
+        Returns:
+            (str): La cadena de data y hora formateada
+    """
+    now = now or now_local()
+    # nice_time_ast yá inclúi l'artículu ("la una", "les cinco")
+    return f"{nice_date_ast(dt, now)} a {nice_time_ast(dt, use_24hour=use_24hour, use_ampm=use_ampm)}"
+
+
+def nice_date_ast(dt: datetime, now: datetime = None, include_weekday=True):
+    """
+    Formatea una data nuna forma pronunciable.
+
+    Por exemplu, xenera 'martes, cinco de xunu de 2018'.
+
+    Args:
+        dt (datetime): data a formatear (asúmese que yá ta na zona horaria llocal)
+        now (datetime): Data actual. Si se proporciona, la data devuelta acurtiaráse:
+            Nun se devuelve l'añu si now ta nel mesmu añu que `dt`, nun se devuelve'l mes
+            si now ta nel mesmu mes que `dt`. Si `now` y `dt` son el mesmu día,
+            devuélvese 'güei'.
+        include_weekday (bool, optional): Whether to prepend the weekday name to the formatted date. Defaults to True.
+
+    Returns:
+        (str): La cadena de data formateada
+    """
+    day = pronounce_number_ast(dt.day)
+    if now is not None:
+        nice = day
+        if dt.day == now.day:
+            return "güei"
+        if dt.day == now.day + 1:
+            return "mañana"
+        if dt.day == now.day - 1:
+            return "ayeri"
+        if dt.month != now.month:
+            nice = nice + " de " + nice_month_ast(dt)
+        if dt.year != now.year:
+            nice = nice + ", " + nice_year_ast(dt)
+    else:
+        nice = f"{day} de {nice_month_ast(dt)}, {nice_year_ast(dt)}"
+
+    if include_weekday:
+        weekday = nice_weekday_ast(dt)
+        nice = f"{weekday}, {nice}"
+    return nice
+
+
+def nice_time_ast(dt, speech=True, use_24hour=False, use_ampm=False):
+    """
+    Formatea una hora nun formatu humanu comprensible
+
+    Por exemplu, xenera 'les cinco y media' pa la fala o '5:30' pa testu.
+
+    Args:
+        dt (datetime): data a formatear (asúmese que yá ta na zona horaria llocal)
+        speech (bool): formatu pa la fala (True, por defeutu) o pa testu (False)
+        use_24hour (bool): salida en formatu de 24 hores o de 12 hores
+        use_ampm (bool): incluyir am/pm pal formatu de 12 hores
+    Returns:
+        (str): La cadena de testu cola hora formateada
+    """
+    if use_24hour:
+        # ex.: "03:01" o "14:22"
+        string = dt.strftime("%H:%M")
+    else:
+        if use_ampm:
+            # ex.: "3:01 AM" o "2:22 PM"
+            string = dt.strftime("%I:%M %p")
+        else:
+            # ex.: "3:01" o "2:22"
+            string = dt.strftime("%I:%M")
+        if string[0] == '0':
+            string = string[1:]  # desaniciar ceros a la izquierda
+
+    if not speech:
+        return string
+
+    # Xenerar una versión falada de la hora
+    speak = ""
+    if use_24hour:
+        if dt.hour == 1:
+            speak += "la una"
+        else:
+            speak += "les " + pronounce_number_ast(dt.hour)
+
+        if dt.minute < 10:
+            speak += " cero " + pronounce_number_ast(dt.minute)
+        else:
+            speak += " " + pronounce_number_ast(dt.minute)
+
+    else:
+        if dt.minute == 35:
+            minute = -25
+            hour = dt.hour + 1
+        elif dt.minute == 40:
+            minute = -20
+            hour = dt.hour + 1
+        elif dt.minute == 45:
+            minute = -15
+            hour = dt.hour + 1
+        elif dt.minute == 50:
+            minute = -10
+            hour = dt.hour + 1
+        elif dt.minute == 55:
+            minute = -5
+            hour = dt.hour + 1
+        else:
+            minute = dt.minute
+            hour = dt.hour
+
+        if hour == 0 or hour == 12:
+            speak += "les doce"
+        elif hour == 1 or hour == 13:
+            speak += "la una"
+        elif hour < 13:
+            speak = "les " + pronounce_number_ast(hour)
+        else:
+            speak = "les " + pronounce_number_ast(hour - 12)
+
+        if minute != 0:
+            if minute == 15:
+                speak += " y cuartu"
+            elif minute == 30:
+                speak += " y media"
+            elif minute == -15:
+                speak += " menos cuartu"
+            else:
+                if minute > 0:
+                    speak += " y " + pronounce_number_ast(minute)
+                else:
+                    speak += " " + pronounce_number_ast(minute)
+
+        if minute == 0 and not use_ampm:
+            speak += " en puntu"
+
+        if use_ampm:
+            if hour >= 0 and hour < 6:
+                speak += " de la madrugada"
+            elif hour >= 6 and hour < 13:
+                speak += " de la mañana"
+            elif hour >= 13 and hour < 21:
+                speak += " de la tarde"
+            else:
+                speak += " de la nueche"
+    return speak
+
+
+def extract_datetime_ast(text, anchorDate=None, default_time=None):
+    """
+    Estrái información de data y hora d'una frase n'asturianu.
+
+    Args:
+        text (str): testu a interpretar
+        anchorDate (datetime): data de referencia pa dates relatives
+        default_time (time): hora a usar si nun s'atopa nenguna nel testu
+
+    Returns:
+        [datetime, str] | None: la data estrayida y el testu restante,
+        o None si nun s'atopa nenguna data o hora.
+    """
+
+    def clean_string(s):
+        # llimpia'l testu de puntuación y mayúscules y normaliza vocabulariu
+        symbols = [".", ",", ";", "?", "!", "º", "ª"]
+
+        for word in symbols:
+            s = s.replace(word, "")
+
+        s = s.lower().replace("á", "a").replace("é", "e").replace(
+            "í", "i").replace("ó", "o").replace("ú", "u").replace(
+            "ü", "u").replace("-", " ").replace("_", "")
+
+        # "que vien" == siguiente
+        s = s.replace(" que vien", " siguiente")
+
+        # hores falaes precedíes d'artículu: "a la una", "a les dos"
+        spoken_hours = {"una": "1", "dos": "2", "tres": "3", "cuatro": "4",
+                        "cinco": "5", "seis": "6", "siete": "7", "ocho": "8",
+                        "nueve": "9", "diez": "10", "once": "11", "doce": "12"}
+        for k, v in spoken_hours.items():
+            s = re.sub(r"\b(la|les) " + k + r"\b", r"\1 " + v, s)
+
+        noise_words = ["ente", "la", "les", "lo", "el", "del", "al",
+                       "de", "pa", "por", "un", "una", "cualquier",
+                       "esti", "esta"]
+        for word in noise_words:
+            s = s.replace(" " + word + " ", " ")
+
+        # sinónimos y equivalentes
+        synonyms = {"mañana": ["amanecer", "ceo", "bien ceo"],
+                    "tarde": ["atapecer"],
+                    "nueche": ["anochecer"]}
+        for syn in synonyms:
+            for word in synonyms[syn]:
+                s = s.replace(" " + word + " ", " " + syn + " ")
+
+        # plurales relevantes (n'asturianu -a > -es, -u > -os)
+        s = s.replace("mañanes", "mañana").replace("tardes", "tarde") \
+            .replace("nueches", "nueche").replace("dies", "dia") \
+            .replace("selmanes", "selmana").replace("años", "añu") \
+            .replace("minutos", "minutu").replace("segundos", "segundu") \
+            .replace("hores", "hora").replace("siguientes", "siguiente") \
+            .replace("proximes", "proxima").replace("proximos", "proximu") \
+            .replace("meses", "mes").replace("anteriores", "anterior")
+        return s
+
+    def date_found():
+        return found or \
+            (
+                    datestr != "" or
+                    yearOffset != 0 or monthOffset != 0 or
+                    dayOffset is True or hrOffset != 0 or
+                    hrAbs or minOffset != 0 or
+                    minAbs or secOffset != 0
+            )
+
+    if text == "":
+        return None
+    if anchorDate is None:
+        anchorDate = now_local()
+
+    found = False
+    daySpecified = False
+    dayOffset = False
+    monthOffset = 0
+    yearOffset = 0
+    dateNow = anchorDate
+    today = dateNow.strftime("%w")
+    currentYear = dateNow.strftime("%Y")
+    fromFlag = False
+    datestr = ""
+    hasYear = False
+    timeQualifier = ""
+
+    words = clean_string(text).split(" ")
+    timeQualifiersList = ['mañana', 'tarde', 'nueche']
+    time_indicators = ["en", "a", "la", "les", "el", "al", "por", "pasaos",
+                       "pasaes", "dia", "hora"]
+    days = ['llunes', 'martes', 'miercoles',
+            'xueves', 'vienres', 'sabadu', 'domingu']
+    months = ['xineru', 'febreru', 'marzu', 'abril', 'mayu', 'xunu',
+              'xunetu', 'agostu', 'setiembre', 'ochobre', 'payares',
+              'avientu']
+    monthsShort = ['xin', 'feb', 'mar', 'abr', 'may', 'xun', 'xnt', 'ago',
+                   'set', 'och', 'pay', 'avi']
+    nexts = ["siguiente", "proximu", "proxima"]
+    suffix_nexts = ["siguiente", "siguientes"]
+    lasts = ["ultimu", "ultima"]
+    suffix_lasts = ["pasada", "pasau", "anterior", "antes"]
+    nxts = ["dempues", "siguiente", "proximu", "proxima"]
+    prevs = ["antes", "previa", "previu", "anterior"]
+    froms = ["dende", "en", "pa", "dempues", "por", "proximu",
+             "proxima", "de"]
+    thises = ["esti", "esta"]
+    froms += thises
+    lists = nxts + prevs + froms + time_indicators
+    for idx, word in enumerate(words):
+        if word == "":
+            continue
+        wordPrevPrev = words[idx - 2] if idx > 1 else ""
+        wordPrev = words[idx - 1] if idx > 0 else ""
+        wordNext = words[idx + 1] if idx + 1 < len(words) else ""
+        wordNextNext = words[idx + 2] if idx + 2 < len(words) else ""
+        wordNextNextNext = words[idx + 3] if idx + 3 < len(words) else ""
+
+        start = idx
+        used = 0
+        # guardar el cualificador de tiempu pa dempués
+        if word in timeQualifiersList:
+            timeQualifier = word
+
+        # güei, mañana, ayeri
+        elif word == "guei" and not fromFlag:
+            dayOffset = 0
+            used += 1
+        elif word == "mañana" and not fromFlag:
+            dayOffset = 1
+            used += 1
+        elif word == "ayeri" and not fromFlag:
+            dayOffset -= 1
+            used += 1
+        # pasáu mañana
+        elif word in ("pasau", "pasao") and wordNext == "mañana" \
+                and not fromFlag:
+            dayOffset += 2
+            used = 2
+        # en 5 díes, etc
+        elif word == "dia":
+            if wordNext == "pasau" or wordNext == "pasao":
+                used += 1
+                if wordPrev and wordPrev[0].isdigit():
+                    dayOffset += int(wordPrev)
+                    start -= 1
+                    used += 1
+            elif (wordPrev and wordPrev[0].isdigit() and
+                  wordNext not in months and
+                  wordNext not in monthsShort):
+                dayOffset += int(wordPrev)
+                start -= 1
+                used += 2
+            elif wordNext and wordNext[0].isdigit() and wordNextNext not in \
+                    months and wordNextNext not in monthsShort:
+                dayOffset += int(wordNext)
+                start -= 1
+                used += 2
+
+        elif word == "selmana" and not fromFlag:
+            if wordPrev and wordPrev[0].isdigit():
+                dayOffset += int(wordPrev) * 7
+                start -= 1
+                used = 2
+            for w in nexts:
+                if wordPrev == w:
+                    dayOffset = 7
+                    start -= 1
+                    used = 2
+            for w in lasts:
+                if wordPrev == w:
+                    dayOffset = -7
+                    start -= 1
+                    used = 2
+            for w in suffix_nexts:
+                if wordNext == w:
+                    dayOffset = 7
+                    start -= 1
+                    used = 2
+            for w in suffix_lasts:
+                if wordNext == w:
+                    dayOffset = -7
+                    start -= 1
+                    used = 2
+        # 10 meses, mes siguiente, mes pasáu
+        elif word == "mes" and not fromFlag:
+            if wordPrev and wordPrev[0].isdigit():
+                monthOffset = int(wordPrev)
+                start -= 1
+                used = 2
+            for w in nexts:
+                if wordPrev == w:
+                    monthOffset = 1
+                    start -= 1
+                    used = 2
+            for w in lasts:
+                if wordPrev == w:
+                    monthOffset = -1
+                    start -= 1
+                    used = 2
+            for w in suffix_nexts:
+                if wordNext == w:
+                    monthOffset = 1
+                    start -= 1
+                    used = 2
+            for w in suffix_lasts:
+                if wordNext == w:
+                    monthOffset = -1
+                    start -= 1
+                    used = 2
+        # 5 años, añu siguiente, añu pasáu
+        elif word == "añu" and not fromFlag:
+            if wordPrev and wordPrev[0].isdigit():
+                yearOffset = int(wordPrev)
+                start -= 1
+                used = 2
+            for w in nexts:
+                if wordPrev == w:
+                    yearOffset = 1
+                    start -= 1
+                    used = 2
+            for w in lasts:
+                if wordPrev == w:
+                    yearOffset = -1
+                    start -= 1
+                    used = 2
+            for w in suffix_nexts:
+                if wordNext == w:
+                    yearOffset = 1
+                    start -= 1
+                    used = 2
+            for w in suffix_lasts:
+                if wordNext == w:
+                    yearOffset = -1
+                    start -= 1
+                    used = 2
+        # díes de la selmana: llunes, martes...
+        elif word in days and not fromFlag:
+            d = days.index(word)
+            dayOffset = (d + 1) - int(today)
+            used = 1
+            if dayOffset < 0:
+                dayOffset += 7
+            if wordPrev in nexts:
+                dayOffset += 7
+                used += 1
+                start -= 1
+            elif wordPrev in ("pasau", "pasao"):
+                dayOffset -= 7
+                used += 1
+                start -= 1
+            if wordNext == "siguiente":
+                used += 1
+            elif wordNext in ("pasau", "pasao"):
+                used += 1
+        # 3 de xunu, xunu 20, etc
+        elif word in months or word in monthsShort:
+            try:
+                m = months.index(word)
+            except ValueError:
+                m = monthsShort.index(word)
+            used += 1
+            datestr = months[m]
+            if wordPrev and wordPrev[0].isdigit():
+                # 13 mayu
+                datestr += " " + wordPrev
+                start -= 1
+                used += 1
+                if wordNext and wordNext[0].isdigit():
+                    datestr += " " + wordNext
+                    used += 1
+                    hasYear = True
+                else:
+                    hasYear = False
+
+            elif wordNext and wordNext[0].isdigit():
+                # mayu 13
+                datestr += " " + wordNext
+                used += 1
+                if wordNextNext and wordNextNext[0].isdigit():
+                    datestr += " " + wordNextNext
+                    used += 1
+                    hasYear = True
+                else:
+                    hasYear = False
+
+            elif wordPrevPrev and wordPrevPrev[0].isdigit():
+                # 13 dia mayu
+                datestr += " " + wordPrevPrev
+                start -= 2
+                used += 2
+                if wordNext and wordNext[0].isdigit():
+                    datestr += " " + wordNext
+                    used += 1
+                    hasYear = True
+                else:
+                    hasYear = False
+
+            elif wordNextNext and wordNextNext[0].isdigit():
+                # mayu dia 13
+                datestr += " " + wordNextNext
+                used += 2
+                if wordNextNextNext and wordNextNextNext[0].isdigit():
+                    datestr += " " + wordNextNextNext
+                    used += 1
+                    hasYear = True
+                else:
+                    hasYear = False
+
+            if datestr in months:
+                datestr = ""
+
+        # 5 díes dende mañana, 2 selmanes dende'l xueves, etc
+        validFollowups = days + months + monthsShort
+        validFollowups.append("guei")
+        validFollowups.append("mañana")
+        validFollowups.append("ayeri")
+        validFollowups.append("agora")
+        validFollowups.append("ya")
+
+        if word in froms and wordNext in validFollowups:
+
+            if not (word in ("pasau", "pasao") or word == "antes"):
+                used = 2
+                fromFlag = True
+            if wordNext == "mañana" and word not in ("pasau", "pasao"):
+                dayOffset += 1
+            elif wordNext == "ayeri":
+                dayOffset -= 1
+            elif wordNext in days:
+                d = days.index(wordNext)
+                tmpOffset = (d + 1) - int(today)
+                used = 2
+                if tmpOffset < 0:
+                    tmpOffset += 7
+                if wordNextNext:
+                    if wordNextNext in nxts:
+                        tmpOffset += 7
+                        used += 1
+                    elif wordNextNext in prevs:
+                        tmpOffset -= 7
+                        used += 1
+                dayOffset += tmpOffset
+            elif wordNextNext and wordNextNext in days:
+                d = days.index(wordNextNext)
+                tmpOffset = (d + 1) - int(today)
+                used = 3
+                if wordNextNextNext:
+                    if wordNextNextNext in nxts:
+                        tmpOffset += 7
+                        used += 1
+                    elif wordNextNextNext in prevs:
+                        tmpOffset -= 7
+                        used += 1
+                dayOffset += tmpOffset
+        if wordNext in months:
+            used -= 1
+        if used > 0:
+            if start - 1 > 0 and words[start - 1] in lists:
+                start -= 1
+                used += 1
+
+            for i in range(0, used):
+                words[i + start] = ""
+
+            if start - 1 >= 0 and words[start - 1] in lists:
+                words[start - 1] = ""
+            found = True
+            daySpecified = True
+
+    # analizar la hora
+    hrOffset = 0
+    minOffset = 0
+    secOffset = 0
+    hrAbs = None
+    minAbs = None
+
+    for idx, word in enumerate(words):
+        if word == "":
+            continue
+
+        wordPrevPrev = words[idx - 2] if idx > 1 else ""
+        wordPrev = words[idx - 1] if idx > 0 else ""
+        wordNext = words[idx + 1] if idx + 1 < len(words) else ""
+        wordNextNext = words[idx + 2] if idx + 2 < len(words) else ""
+        wordNextNextNext = words[idx + 3] if idx + 3 < len(words) else ""
+        # mediudía, medianueche, mañana, tarde, nueche
+        used = 0
+        if word == "mediudia" or (word == "mediu" and wordNext == "dia"):
+            hrAbs = 12
+            used += 2 if word == "mediu" else 1
+        elif word == "medianueche" or (word == "media" and
+                                       wordNext == "nueche"):
+            hrAbs = 0
+            used += 2 if word == "media" else 1
+        elif word == "media" and wordNext == "tarde":
+            if not hrAbs:
+                hrAbs = 17
+            used += 2
+        elif word == "media" and wordNext == "mañana":
+            if not hrAbs:
+                hrAbs = 10
+            used += 2
+        elif word == "mañana":
+            if not hrAbs:
+                hrAbs = 8
+            used += 1
+        elif word == "tarde" and wordNext == "nueche":
+            if not hrAbs:
+                hrAbs = 20
+            used += 2
+        elif word == "tarde":
+            if not hrAbs:
+                hrAbs = 15
+            used += 1
+        elif word == "madrugada":
+            if not hrAbs:
+                hrAbs = 1
+            used += 1
+        elif word == "nueche":
+            if not hrAbs:
+                hrAbs = 21
+            used += 1
+        # media hora, cuartu d'hora
+        elif (word == "hora" and
+              (wordPrev in time_indicators or wordPrevPrev in
+               time_indicators)):
+            if wordPrev == "media":
+                minOffset = 30
+            elif wordPrev == "cuartu":
+                minOffset = 15
+            elif wordPrevPrev == "cuartu":
+                minOffset = 15
+                if idx > 2 and words[idx - 3] in time_indicators:
+                    words[idx - 3] = ""
+                words[idx - 2] = ""
+            else:
+                hrOffset = 1
+            if wordPrevPrev in time_indicators:
+                words[idx - 2] = ""
+            words[idx - 1] = ""
+            used += 1
+            hrAbs = -1
+            minAbs = -1
+        # 5:00 am, 12:00 pm, a les 8, etc
+        elif word[0].isdigit():
+            isTime = True
+            strHH = ""
+            strMM = ""
+            remainder = ""
+            if ':' in word:
+                # 17:30, 3:00 de la mañana
+                stage = 0
+                length = len(word)
+                for i in range(length):
+                    if stage == 0:
+                        if word[i].isdigit():
+                            strHH += word[i]
+                        elif word[i] == ":":
+                            stage = 1
+                        else:
+                            stage = 2
+                            i -= 1
+                    elif stage == 1:
+                        if word[i].isdigit():
+                            strMM += word[i]
+                        else:
+                            stage = 2
+                            i -= 1
+                    elif stage == 2:
+                        remainder = word[i:].replace(".", "")
+                        break
+                if remainder == "":
+                    nextWord = wordNext.replace(".", "")
+                    if nextWord == "am" or nextWord == "pm":
+                        remainder = nextWord
+                        used += 1
+                    elif wordNext == "mañana" or wordNext == "madrugada":
+                        remainder = "am"
+                        used += 1
+                    elif wordNext == "tarde":
+                        remainder = "pm"
+                        used += 1
+                    elif wordNext == "nueche":
+                        if 0 < int(strHH) < 6:
+                            remainder = "am"
+                        else:
+                            remainder = "pm"
+                        used += 1
+                    elif timeQualifier != "":
+                        if int(strHH) <= 12 and \
+                                timeQualifier in ["tarde", "nueche"]:
+                            remainder = "pm"
+
+            else:
+                # númberos ensin dos puntos
+                # a les 8 y media, en 5 minutos, etc
+                length = len(word)
+                strNum = ""
+                remainder = ""
+                for i in range(length):
+                    if word[i].isdigit():
+                        strNum += word[i]
+                    else:
+                        remainder += word[i]
+
+                if remainder == "":
+                    remainder = wordNext.replace(".", "").lstrip().rstrip()
+
+                if (
+                        remainder == "pm" or
+                        wordNext == "pm" or
+                        remainder == "p.m." or
+                        wordNext == "p.m."):
+                    strHH = strNum
+                    remainder = "pm"
+                    used = 1
+                elif (
+                        remainder == "am" or
+                        wordNext == "am" or
+                        remainder == "a.m." or
+                        wordNext == "a.m."):
+                    strHH = strNum
+                    remainder = "am"
+                    used = 1
+                # a les 8 y media, a les 8 y cuartu
+                elif wordNext == "y" and wordNextNext in ["media", "cuartu"]:
+                    strHH = strNum
+                    strMM = 30 if wordNextNext == "media" else 15
+                    used = 2
+                    if wordNextNextNext == "tarde":
+                        remainder = "pm"
+                        used += 1
+                    elif wordNextNextNext == "mañana":
+                        remainder = "am"
+                        used += 1
+                    elif wordNextNextNext == "nueche":
+                        if 0 < int(strNum) < 6:
+                            remainder = "am"
+                        else:
+                            remainder = "pm"
+                        used += 1
+                # a les 8 menos cuartu
+                elif wordNext == "menos" and wordNextNext == "cuartu":
+                    strHH = str(int(strNum) - 1 if int(strNum) > 0 else 23)
+                    strMM = 45
+                    used = 2
+                    if wordNextNextNext == "tarde":
+                        remainder = "pm"
+                        used += 1
+                    elif wordNextNextNext == "mañana":
+                        remainder = "am"
+                        used += 1
+                    elif wordNextNextNext == "nueche":
+                        if 0 < int(strHH) < 6:
+                            remainder = "am"
+                        else:
+                            remainder = "pm"
+                        used += 1
+                else:
+                    if wordNext == "tarde":
+                        strHH = strNum
+                        remainder = "pm"
+                        used = 1
+                    elif wordNext == "mañana" or wordNext == "madrugada":
+                        strHH = strNum
+                        remainder = "am"
+                        used = 1
+                    elif wordNext == "nueche":
+                        strHH = strNum
+                        if 0 < int(strNum) < 6:
+                            remainder = "am"
+                        else:
+                            remainder = "pm"
+                        used = 1
+                    elif (wordNext == "hora" and
+                          word[0] != '0' and
+                          int(word) < 100):
+                        # en 3 hores
+                        hrOffset = int(word)
+                        used = 2
+                        isTime = False
+                        hrAbs = -1
+                        minAbs = -1
+                    elif wordNext == "minutu":
+                        # en 10 minutos
+                        minOffset = int(word)
+                        used = 2
+                        isTime = False
+                        hrAbs = -1
+                        minAbs = -1
+                    elif wordNext == "segundu":
+                        # en 5 segundos
+                        secOffset = int(word)
+                        used = 2
+                        isTime = False
+                        hrAbs = -1
+                        minAbs = -1
+                    elif int(word) > 100:
+                        strHH = str(int(word) // 100)
+                        strMM = str(int(word) % 100)
+                        if wordNext == "hora":
+                            used += 1
+                    elif wordNext == "" or (
+                            wordNext == "en" and wordNextNext == "puntu"):
+                        strHH = word
+                        strMM = 00
+                        if wordNext == "en" and wordNextNext == "puntu":
+                            used += 2
+                            if wordNextNextNext == "tarde":
+                                remainder = "pm"
+                                used += 1
+                            elif wordNextNextNext == "mañana":
+                                remainder = "am"
+                                used += 1
+                            elif wordNextNextNext == "nueche":
+                                if 0 < int(strHH) < 6:
+                                    remainder = "am"
+                                else:
+                                    remainder = "pm"
+                                used += 1
+                    elif wordNext[0].isdigit():
+                        strHH = word
+                        strMM = wordNext
+                        used += 1
+                        if wordNextNext == "hora":
+                            used += 1
+                    else:
+                        isTime = False
+
+            strHH = int(strHH) if strHH else 0
+            strMM = int(strMM) if strMM else 0
+            strHH = strHH + 12 if (remainder == "pm" and
+                                   0 < strHH < 12) else strHH
+            strHH = strHH - 12 if (remainder == "am" and
+                                   strHH >= 12) else strHH
+            if strHH > 24 or strMM > 59:
+                isTime = False
+                used = 0
+            if isTime:
+                hrAbs = strHH * 1
+                minAbs = strMM * 1
+                used += 1
+
+        if used > 0:
+            # desaniciar les pallabres analizaes de la frase
+            for i in range(used):
+                words[idx + i] = ""
+
+            if wordPrev == "en" or wordPrev == "puntu":
+                words[words.index(wordPrev)] = ""
+
+            if idx > 0 and wordPrev in time_indicators:
+                words[idx - 1] = ""
+            if idx > 1 and wordPrevPrev in time_indicators:
+                words[idx - 2] = ""
+
+            idx += used - 1
+            found = True
+
+    # comprobar que s'atopó una data
+    if not date_found():
+        return None
+
+    if dayOffset is False:
+        dayOffset = 0
+
+    # manipulación de la data
+
+    extractedDate = dateNow
+    extractedDate = extractedDate.replace(microsecond=0,
+                                          second=0,
+                                          minute=0,
+                                          hour=0)
+    if datestr != "":
+        en_months = ['january', 'february', 'march', 'april', 'may', 'june',
+                     'july', 'august', 'september', 'october', 'november',
+                     'december']
+        en_monthsShort = ['jan', 'feb', 'mar', 'apr', 'may', 'june', 'july',
+                          'aug', 'sept', 'oct', 'nov', 'dec']
+        for idx, en_month in enumerate(en_months):
+            datestr = re.sub(r"\b" + re.escape(months[idx]) + r"\b",
+                             en_month, datestr)
+        for idx, en_month in enumerate(en_monthsShort):
+            datestr = re.sub(r"\b" + re.escape(monthsShort[idx]) + r"\b",
+                             en_month, datestr)
+
+        if hasYear:
+            temp = datetime.strptime(datestr, "%B %d %Y")
+        else:
+            temp = datetime.strptime(datestr, "%B %d")
+        if extractedDate.tzinfo:
+            temp = temp.replace(tzinfo=extractedDate.tzinfo)
+
+        if not hasYear:
+            temp = temp.replace(year=extractedDate.year)
+
+            if extractedDate < temp:
+                extractedDate = extractedDate.replace(
+                    year=int(currentYear),
+                    month=int(temp.strftime("%m")),
+                    day=int(temp.strftime("%d")))
+            else:
+                extractedDate = extractedDate.replace(
+                    year=int(currentYear) + 1,
+                    month=int(temp.strftime("%m")),
+                    day=int(temp.strftime("%d")))
+        else:
+            extractedDate = extractedDate.replace(
+                year=int(temp.strftime("%Y")),
+                month=int(temp.strftime("%m")),
+                day=int(temp.strftime("%d")))
+
+    if yearOffset != 0:
+        extractedDate = extractedDate + relativedelta(years=yearOffset)
+    if monthOffset != 0:
+        extractedDate = extractedDate + relativedelta(months=monthOffset)
+    if dayOffset != 0:
+        extractedDate = extractedDate + relativedelta(days=dayOffset)
+
+    if hrAbs is None and minAbs is None and default_time:
+        hrAbs = default_time.hour
+        minAbs = default_time.minute
+
+    if hrAbs != -1 and minAbs != -1:
+        extractedDate = extractedDate + relativedelta(hours=hrAbs or 0,
+                                                      minutes=minAbs or 0)
+        if (hrAbs or minAbs) and datestr == "":
+            if not daySpecified and dateNow > extractedDate:
+                extractedDate = extractedDate + relativedelta(days=1)
+    if hrOffset != 0:
+        extractedDate = extractedDate + relativedelta(hours=hrOffset)
+    if minOffset != 0:
+        extractedDate = extractedDate + relativedelta(minutes=minOffset)
+    if secOffset != 0:
+        extractedDate = extractedDate + relativedelta(seconds=secOffset)
+
+    resultStr = " ".join(words)
+    resultStr = ' '.join(resultStr.split())
+    return [extractedDate, resultStr]
+
+
+def extract_duration_ast(text):
+    """
+    Convierte una frase n'asturianu nun númberu de segundos.
+    Convierte coses como:
+        "10 minutos"
+        "3 díes 8 hores 10 minutos y 49 segundos"
+    nun númberu enteru que representa'l total de segundos.
+    Les pallabres emplegaes na duración serán consumíes,
+    devolviéndose'l testu restante.
+    Por exemplu, "pon un temporizador de 5 minutos" devolvería
+    (300, "pon un temporizador de").
+
+    Args:
+        text (str): cadena de testu que contién una duración
+
+    Returns:
+        (timedelta, str):
+            Una tupla col tiempu total y el testu restante
+            non consumíu nel análisis. El primer valor sedrá
+            None si nun s'atopa nenguna duración.
+    """
+    if not text:
+        return None, text
+
+    text = text.lower().replace("í", "i").replace("é", "e")
+
+    time_units = {
+        'microseconds': 0,
+        'milliseconds': 0,
+        'seconds': 0,
+        'minutes': 0,
+        'hours': 0,
+        'days': 0,
+        'weeks': 0
+    }
+
+    # n'asturianu el plural femenín ye -es (hora > hores, selmana > selmanes)
+    # y díes ye'l plural de día, polo que cada unidá lleva'l so propiu patrón
+    unit_patterns = {
+        'microseconds': r"microsegundos?",
+        'milliseconds': r"milisegundos?",
+        'seconds': r"segundos?|segundu",
+        'minutes': r"minutos?|minutu",
+        'hours': r"hores|hora",
+        'days': r"dies|dias?",
+        'weeks': r"selmanes|selmana"
+    }
+
+    non_std_patterns = {
+        "months": r"meses|mes",
+        "years": r"años?|añu",
+        "decades": r"decades|decada",
+        "centuries": r"sieglos?|sieglu",
+        "millenniums": r"milenios?|mileniu"
+    }
+
+    pattern = r"(?P<value>\d+(?:\.?\d+)?)(?:\s+|\-)(?:{unit})\b"
+
+    for unit_en, unit_ast in unit_patterns.items():
+        unit_pattern = pattern.format(unit=unit_ast)
+
+        def repl(match):
+            time_units[unit_en] += float(match.group("value"))
+            return ''
+
+        text = re.sub(unit_pattern, repl, text)
+
+    for unit_en, unit_ast in non_std_patterns.items():
+        unit_pattern = pattern.format(unit=unit_ast)
+
+        def repl_non_std(match):
+            val = float(match.group("value"))
+            if unit_en == "months":
+                val = 30 * val  # aproximación d'un mes en díes
+            elif unit_en == "years":
+                val = 365 * val  # aproximación d'un añu en díes
+            elif unit_en == "decades":
+                val = 10 * 365 * val
+            elif unit_en == "centuries":
+                val = 100 * 365 * val
+            elif unit_en == "millenniums":
+                val = 1000 * 365 * val
+            time_units["days"] += val
+            return ''
+
+        text = re.sub(unit_pattern, repl_non_std, text)
+
+    text = text.strip()
+    duration = timedelta(**time_units) if any(time_units.values()) else None
+
+    return duration, text

--- a/ovos_date_parser/res/ast/date_words.json
+++ b/ovos_date_parser/res/ast/date_words.json
@@ -1,0 +1,10 @@
+{
+  "seconds": "segundos",
+  "hour": "hora",
+  "minute": "minutu",
+  "days": "díes",
+  "day": "día",
+  "minutes": "minutos",
+  "hours": "hores",
+  "second": "segundu"
+}

--- a/test/format_tests/test_format_ast.py
+++ b/test/format_tests/test_format_ast.py
@@ -1,0 +1,48 @@
+import unittest
+from datetime import datetime
+from ovos_date_parser.dates_ast import nice_year_ast, nice_weekday_ast, nice_month_ast, nice_day_ast, nice_date_ast, nice_time_ast
+
+class TestNiceDateTimeAST(unittest.TestCase):
+    def setUp(self):
+        self.test_date = datetime(2023, 6, 5, 17, 30)  # Monday, June 5, 2023, 17:30
+        self.test_now = datetime(2023, 6, 5)  # Same day as test_date
+
+    def test_nice_year_ast(self):
+        self.assertEqual(nice_year_ast(self.test_date), "dos mil y ventitrés")
+        self.assertEqual(nice_year_ast(self.test_date, bc=True), "dos mil y ventitrés a.C.")
+
+    def test_nice_weekday_ast(self):
+        self.assertEqual(nice_weekday_ast(self.test_date), "Llunes")
+
+    def test_nice_month_ast(self):
+        self.assertEqual(nice_month_ast(self.test_date), "Xunu")
+
+    def test_nice_day_ast(self):
+        self.assertEqual(nice_day_ast(self.test_date, date_format='DMY'), "5 Xunu")
+        self.assertEqual(nice_day_ast(self.test_date, date_format='MDY'), "Xunu 5")
+        self.assertEqual(nice_day_ast(self.test_date, include_month=False), "5")
+
+    def test_nice_date_ast(self):
+        self.assertEqual(nice_date_ast(self.test_date, self.test_now), "güei")
+        future_date = datetime(2023, 6, 6)
+        self.assertEqual(nice_date_ast(future_date, self.test_now), "mañana")
+        past_date = datetime(2023, 6, 4)
+        self.assertEqual(nice_date_ast(past_date, self.test_now), "ayeri")
+
+    def test_nice_time_ast(self):
+        self.assertEqual(nice_time_ast(self.test_date, speech=True, use_24hour=True), "les diecisiete trenta")
+        self.assertEqual(nice_time_ast(self.test_date, speech=True, use_24hour=False), "les cinco y media")
+        self.assertEqual(nice_time_ast(self.test_date, speech=False, use_24hour=True), "17:30")
+        self.assertEqual(nice_time_ast(self.test_date, speech=False, use_24hour=False), "5:30")
+        # one o'clock uses the singular article
+        one = datetime(2023, 6, 5, 13, 0)
+        self.assertEqual(nice_time_ast(one, speech=True, use_24hour=False), "la una en puntu")
+        # quarter past / quarter to
+        self.assertEqual(nice_time_ast(datetime(2023, 6, 5, 8, 15), use_24hour=False), "les ocho y cuartu")
+        self.assertEqual(nice_time_ast(datetime(2023, 6, 5, 7, 45), use_24hour=False), "les ocho menos cuartu")
+        # am/pm day periods
+        self.assertEqual(nice_time_ast(datetime(2023, 6, 5, 9, 30), use_ampm=True), "les nueve y media de la mañana")
+        self.assertEqual(nice_time_ast(datetime(2023, 6, 5, 22, 30), use_ampm=True), "les diez y media de la nueche")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/parse_tests/test_parse_ast.py
+++ b/test/parse_tests/test_parse_ast.py
@@ -1,0 +1,185 @@
+#
+# Copyright 2017 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import unittest
+from datetime import datetime, time, timedelta
+
+from ovos_config.locale import get_default_tz as default_timezone
+
+import ovos_date_parser as _odp
+
+LANG = "ast"
+
+
+def extract_datetime(text, anchorDate=None, lang=LANG, default_time=None):
+    res = _odp.extract_datetime(text, lang=lang, anchorDate=anchorDate,
+                                default_time=default_time)
+    if res is not None and res[0] is not None and res[0].tzinfo is None:
+        res = [res[0].replace(tzinfo=default_timezone()), res[1]]
+    return res
+
+
+def extract_duration(text, lang=LANG):
+    return _odp.extract_duration(text, lang=lang)
+
+
+class TestDatetimeAst(unittest.TestCase):
+    # anchor: 1998-01-01 was a thursday
+    ANCHOR = datetime(1998, 1, 1)
+    ANCHOR_NOON = datetime(1998, 1, 1, 12, 0)
+
+    def test_weekday(self):
+        # next friday after thursday jan 1st is jan 2nd
+        self.assertEqual(
+            extract_datetime("vienres", anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 2, tzinfo=default_timezone()))
+        # next monday after thursday jan 1st is jan 5th
+        self.assertEqual(
+            extract_datetime("llunes", anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 5, tzinfo=default_timezone()))
+        # "que vien" == next occurrence
+        self.assertEqual(
+            extract_datetime("llunes que vien", anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 5, tzinfo=default_timezone()))
+
+    def test_tomorrow(self):
+        # "mañana" defaults to morning (8:00) of the next day when the
+        # anchor is past 8:00
+        self.assertEqual(
+            extract_datetime("mañana", anchorDate=self.ANCHOR_NOON)[0],
+            datetime(1998, 1, 2, 8, 0, tzinfo=default_timezone()))
+
+    def test_today(self):
+        self.assertEqual(
+            extract_datetime("güei", anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 1, tzinfo=default_timezone()))
+
+    def test_yesterday(self):
+        self.assertEqual(
+            extract_datetime("ayeri", anchorDate=self.ANCHOR)[0],
+            datetime(1997, 12, 31, tzinfo=default_timezone()))
+
+    def test_day_after_tomorrow(self):
+        self.assertEqual(
+            extract_datetime("pasáu mañana", anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 3, tzinfo=default_timezone()))
+
+    def test_in_n_days(self):
+        self.assertEqual(
+            extract_datetime("en 5 díes", anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 6, tzinfo=default_timezone()))
+
+    def test_explicit_date(self):
+        # june 3rd comes after january 1st, so same year
+        self.assertEqual(
+            extract_datetime("3 de xunu", anchorDate=self.ANCHOR)[0],
+            datetime(1998, 6, 3, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime("11 de xineru",
+                             anchorDate=datetime(1998, 1, 1))[0],
+            datetime(1998, 1, 11, tzinfo=default_timezone()))
+
+    def test_time_half_past(self):
+        # 8 de la tarde == 20:00, y media -> 20:30
+        self.assertEqual(
+            extract_datetime("a les 8 y media de la tarde",
+                             anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 1, 20, 30, tzinfo=default_timezone()))
+
+    def test_time_quarter_past(self):
+        self.assertEqual(
+            extract_datetime("a les 8 y cuartu de la mañana",
+                             anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 1, 8, 15, tzinfo=default_timezone()))
+
+    def test_time_quarter_to(self):
+        # 8 menos cuartu de la mañana == 7:45
+        self.assertEqual(
+            extract_datetime("a les 8 menos cuartu de la mañana",
+                             anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 1, 7, 45, tzinfo=default_timezone()))
+
+    def test_spoken_hour(self):
+        # "a les dos de la tarde" == 14:00
+        self.assertEqual(
+            extract_datetime("a les dos de la tarde",
+                             anchorDate=self.ANCHOR_NOON)[0],
+            datetime(1998, 1, 1, 14, 0, tzinfo=default_timezone()))
+
+    def test_noon(self):
+        self.assertEqual(
+            extract_datetime("mediudía", anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 1, 12, 0, tzinfo=default_timezone()))
+
+    def test_midnight(self):
+        self.assertEqual(
+            extract_datetime("medianueche", anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 1, 0, 0, tzinfo=default_timezone()))
+
+    def test_digit_time(self):
+        self.assertEqual(
+            extract_datetime("a les 17:30", anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 1, 17, 30, tzinfo=default_timezone()))
+        self.assertEqual(
+            extract_datetime("15:30", anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 1, 15, 30, tzinfo=default_timezone()))
+
+    def test_next_week(self):
+        self.assertEqual(
+            extract_datetime("la selmana que vien", anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 8, tzinfo=default_timezone()))
+
+    def test_last_week(self):
+        self.assertEqual(
+            extract_datetime("la selmana pasada", anchorDate=self.ANCHOR)[0],
+            datetime(1997, 12, 25, tzinfo=default_timezone()))
+
+    def test_no_date(self):
+        self.assertIsNone(extract_datetime("hola mundu",
+                                           anchorDate=self.ANCHOR))
+        self.assertIsNone(extract_datetime("nun hai tiempu",
+                                           anchorDate=self.ANCHOR))
+        self.assertIsNone(extract_datetime("", anchorDate=self.ANCHOR))
+
+    def test_default_time(self):
+        # no time in the sentence -> default_time is applied
+        self.assertEqual(
+            extract_datetime("en 5 díes", anchorDate=self.ANCHOR,
+                             default_time=time(9, 30))[0],
+            datetime(1998, 1, 6, 9, 30, tzinfo=default_timezone()))
+
+
+class TestExtractDurationAst(unittest.TestCase):
+    def test_extract_duration(self):
+        self.assertEqual(extract_duration("10 segundos"),
+                         (timedelta(seconds=10.0), ""))
+        self.assertEqual(extract_duration("5 minutos"),
+                         (timedelta(minutes=5), ""))
+        self.assertEqual(extract_duration("2 hores"),
+                         (timedelta(hours=2), ""))
+        self.assertEqual(extract_duration("3 díes"),
+                         (timedelta(days=3), ""))
+        self.assertEqual(extract_duration("25 selmanes"),
+                         (timedelta(weeks=25), ""))
+        self.assertEqual(extract_duration("1 hora"),
+                         (timedelta(hours=1), ""))
+        self.assertEqual(extract_duration("1 día"),
+                         (timedelta(days=1), ""))
+        self.assertEqual(extract_duration("1 selmana"),
+                         (timedelta(weeks=1), ""))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_lang_parity.py
+++ b/test/test_lang_parity.py
@@ -11,13 +11,13 @@ from ovos_date_parser import (extract_datetime, extract_duration, nice_date,
                               nice_month, nice_relative_time, nice_time,
                               nice_weekday, nice_year, get_date_strings)
 
-LANGS = ["ar", "az", "ca", "cs", "da", "de", "en", "es", "eu", "fa", "fr", "gl",
+LANGS = ["ar", "ast", "az", "ca", "cs", "da", "de", "en", "es", "eu", "fa", "fr", "gl",
          "hu", "it", "nl", "pl", "pt", "ru", "sl", "sv", "uk"]
 
 ANCHOR = datetime(2017, 6, 27, 13, 4)
 
 _TOMORROW = {
-    "ar": "غداً", "az": "sabah", "ca": "demà", "cs": "zítra", "da": "i morgen",
+    "ar": "غداً", "ast": "mañana", "az": "sabah", "ca": "demà", "cs": "zítra", "da": "i morgen",
     "de": "morgen", "en": "tomorrow", "es": "mañana", "eu": "bihar",
     "fa": "فردا", "fr": "demain", "gl": "mañá", "hu": "holnap",
     "it": "domani", "nl": "morgen", "pl": "jutro", "pt": "amanhã",
@@ -25,7 +25,7 @@ _TOMORROW = {
 }
 
 _NO_DATE = {
-    "ar": "مرحبا كيف حالك", "az": "salam necəsən", "ca": "hola com estàs", "cs": "ahoj jak se máš",
+    "ar": "مرحبا كيف حالك", "ast": "hola qué tal", "az": "salam necəsən", "ca": "hola com estàs", "cs": "ahoj jak se máš",
     "da": "hej hvordan har du det", "de": "hallo wie geht es dir",
     "en": "hello how are you", "es": "hola qué tal", "eu": "kaixo zer moduz",
     "fa": "سلام چطوری", "fr": "bonjour ça va", "gl": "ola que tal",
@@ -35,7 +35,7 @@ _NO_DATE = {
 }
 
 _DURATION_STRINGS = {
-    "ar": "١٠ دقائق", "az": "10 dəqiqə", "ca": "10 minuts", "cs": "10 minut",
+    "ar": "١٠ دقائق", "ast": "10 minutos", "az": "10 dəqiqə", "ca": "10 minuts", "cs": "10 minut",
     "da": "10 minutter", "de": "10 minuten", "en": "10 minutes",
     "es": "10 minutos", "eu": "10 minutu", "fa": "۱۰ دقیقه",
     "fr": "10 minutes", "gl": "10 minutos", "hu": "10 perc",


### PR DESCRIPTION
## What

Adds Asturian (`ast`) support to ovos-date-parser:

- `ovos_date_parser/dates_ast.py`: `nice_time_ast`, `nice_date_ast`, `nice_date_time_ast`, `nice_day_ast`, `nice_weekday_ast`, `nice_month_ast`, `nice_year_ast`, `extract_datetime_ast`, `extract_duration_ast` — modeled on the Galician/Spanish implementations.
- `ovos_date_parser/res/ast/date_words.json`: unit words for the generic `nice_duration` / `nice_relative_time` helpers.
- `ast` wired into every dispatcher in `__init__.py`.
- Tests: `test/parse_tests/test_parse_ast.py`, `test/format_tests/test_format_ast.py`, and `ast` added to the language-parity suite.
- `docs/languages.md`: Asturian section.

Numbers come from `ovos-number-parser>=0.11.0a2` (`ovos_number_parser.numbers_ast`).

## Why

Extends voice date/time coverage to Asturian, matching the feature set of the other Iberian Romance languages already supported (es, gl, ca, eu, pt).

## Sources for the language data

- Weekdays (llunes, martes, miércoles, xueves, vienres, sábadu, domingu) and "selmana" = week: https://ast.wikipedia.org/wiki/Selmana
- Months (xineru, febreru, marzu, abril, mayu, xunu, xunetu, agostu, setiembre, ochobre, payares, avientu): https://ast.wikipedia.org/wiki/Mes
- Time adverbs güei / ayeri / mañana (today / yesterday / tomorrow) plus agora, dempués, ceo, tarde: https://asturies.com/espaciuytiempu/deprendeasturianu/tema7 (per the Diccionariu de la Llingua Asturiana, ALLA)
- hora (pl. hores, feminine): https://ast.wiktionary.org/wiki/hora ; minutu / segundu: https://ast.wikipedia.org/wiki/Hora
- día (pl. díes): https://ast.wiktionary.org/wiki/d%C3%ADa ; añu (pl. años): https://ast.wiktionary.org/wiki/a%C3%B1u
- cuartu = quarter (¼): https://ast.wiktionary.org/wiki/cuartu
- mediudía / medianueche as day-time reference points, and day divisions mañana / tarde / nueche / madrugada: https://ast.wiktionary.org/wiki/once, https://ast.wiktionary.org/wiki/nueche

## Coverage boundaries

- "anteayer"-style words (day before yesterday) are omitted: no authoritative Asturian form could be verified, and omission is safer than guessing.
- Spoken time follows the Spanish/Galician convention ("la una", "les cinco y media", "les ocho menos cuartu", "en puntu"; `use_ampm` adds "de la madrugada/mañana/tarde/nueche").
- "mañana" is ambiguous (tomorrow vs morning) and is disambiguated exactly as in the Spanish parser.
- Duration parsing covers both the singular and the Asturian `-es` plurals (hores, selmanes, díes) plus meses/años/décades/sieglos/milenios approximations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
