### PR TITLE
refactor: port Romance and Germanic durations to the shared engine

### DIFF
--- a/ovos_date_parser/__init__.py
+++ b/ovos_date_parser/__init__.py
@@ -228,28 +228,12 @@ def extract_duration(
         return extract_duration_ar(text)
     if lang.startswith("az"):
         return extract_duration_az(text)
-    if lang.startswith("ca"):
-        return extract_duration_ca(text)
     if lang.startswith("cs"):
         return extract_duration_cs(text)
-    if lang.startswith("da"):
-        return extract_duration_da(text)
-    if lang.startswith("de"):
-        return extract_duration_de(text)
-    if lang.startswith("en"):
-        return extract_duration_en(text)
-    if lang.startswith("es"):
-        return extract_duration_es(text)
-    if lang.startswith("gl"):
-        return extract_duration_gl(text)
     if lang.startswith("fa"):
         return extract_duration_fa(text)
-    if lang.startswith("nl"):
-        return extract_duration_nl(text)
     if lang.startswith("pl"):
         return extract_duration_pl(text)
-    if lang.startswith("pt"):
-        return extract_duration_pt(text)
     if lang.startswith("ru"):
         return extract_duration_ru(text)
     if lang.startswith("sv"):

--- a/ovos_date_parser/dates_ca.py
+++ b/ovos_date_parser/dates_ca.py
@@ -5,6 +5,9 @@ from enum import IntEnum
 from dateutil.relativedelta import relativedelta
 from ovos_number_parser.numbers_ca import pronounce_number_ca, numbers_to_digits_ca
 from ovos_utils.time import now_local, DAYS_IN_1_YEAR, DAYS_IN_1_MONTH
+from ovos_date_parser.duration import (
+    DurationResolution, DURATION_LEXICONS, extract_duration_generic
+)
 
 
 class TimeVariantCA(IntEnum):
@@ -14,90 +17,26 @@ class TimeVariantCA(IntEnum):
     SPANISH_LIKE = 3
 
 
-def extract_duration_ca(text):
+def extract_duration_ca(text, resolution=DurationResolution.TIMEDELTA,
+                        replace_token=""):
     """
-    Converteix una frase en català en un nombre de segons.
-    Converteix coses com:
-        "10 Minuts"
-        "3 dies 8 hores 10 Minuts i 49 Segons"
-    en un enter, que representa el nombre total de segons.
-    Les paraules utilitzades en la durada seran consumides, i
-    el restant es retornarà.
-    Com a exemple, "posa un temporitzador per 5 minuts" retornaria
-    (300, "posa un temporitzador per").
+    Convert a phrase into a duration and return the remainder text.
+
+    The words used in the duration are consumed, the remainder of the
+    text is returned. Returns None for empty input; the duration is
+    None if no duration was found.
 
     Args:
-        text (str): cadena que conté una durada.
+        text (str): string containing a duration.
+        resolution (DurationResolution): format to return the duration in.
+        replace_token (str): string each consumed duration is replaced with.
     Returns:
-        (timedelta, str):
-                    Una tupla que conté la durada i el text restant
-                    no consumit en l'anàlisi. El primer valor serà
-                    None si no es troba cap durada. El text retornat
-                    tindrà els espais en blanc eliminats dels extrems.
+        (duration, str): the duration (timedelta, relativedelta or float
+                         depending on resolution) and the remaining
+                         unconsumed text.
     """
-    if not text:
-        return None
-
-    text = text.lower().replace("í", "i")
-    time_units = {
-        'microseconds': 'microsegons',
-        'milliseconds': 'mil·lisegons',
-        'seconds': 'segons',
-        'minutes': 'minuts',
-        'hours': 'hores',
-        'days': 'dies',
-        'weeks': 'setmanes'
-    }
-    # NOTE: alguns d'aquests unitats angleses estan escrites incorrectament a propòsit per al bucle següent que elimina la s
-    non_std_un = {
-        "months": "mesos",
-        "years": "anys",
-        'decades': "dècades",
-        'centurys': "segles",
-        'millenniums': "mil·lenis"
-    }
-
-    pattern = r"(?P<value>\d+(?:\.?\d+)?)(?:\s+|\-){unit}[s]?"
-
-    text = text.replace("í", "i").replace("é", "e").replace("ñ", "n").replace("mesos", "mes")
-    text = numbers_to_digits_ca(text)
-
-    for (unit_en, unit_ca) in time_units.items():
-        unit_pattern = pattern.format(
-            unit=unit_ca[:-1])  # remove 's' from unit
-        time_units[unit_en] = 0
-
-        def repl(match):
-            time_units[unit_en] += float(match.group(1))
-            return ''
-
-        text = re.sub(unit_pattern, repl, text)
-
-    for (unit_en, unit_ca) in non_std_un.items():
-        unit_pattern = pattern.format(
-            unit=unit_ca[:-1])  # remove 's' from unit
-
-        def repl_non_std(match):
-            val = float(match.group(1))
-            if unit_en == "months":
-                val = DAYS_IN_1_MONTH * val
-            if unit_en == "years":
-                val = DAYS_IN_1_YEAR * val
-            if unit_en == "decades":
-                val = 10 * DAYS_IN_1_YEAR * val
-            if unit_en == "centurys":
-                val = 100 * DAYS_IN_1_YEAR * val
-            if unit_en == "millenniums":
-                val = 1000 * DAYS_IN_1_YEAR * val
-            time_units["days"] += val
-            return ''
-
-        text = re.sub(unit_pattern, repl_non_std, text)
-
-    text = text.strip()
-    duration = timedelta(**time_units) if any(time_units.values()) else None
-
-    return (duration, text)
+    return extract_duration_generic(text, DURATION_LEXICONS["ca"],
+                                    resolution, replace_token)
 
 
 def nice_time_ca(dt, speech=True, use_24hour=False, use_ampm=False,

--- a/ovos_date_parser/dates_da.py
+++ b/ovos_date_parser/dates_da.py
@@ -5,6 +5,9 @@ from dateutil.relativedelta import relativedelta
 from ovos_number_parser.numbers_da import pronounce_ordinal_da, pronounce_number_da, is_ordinal_da, numbers_to_digits_da
 from ovos_number_parser.util import is_numeric
 from ovos_utils.time import now_local, DAYS_IN_1_YEAR, DAYS_IN_1_MONTH
+from ovos_date_parser.duration import (
+    DurationResolution, DURATION_LEXICONS, extract_duration_generic
+)
 
 
 _MONTHS_DA = ['januar', 'februar', 'marts', 'april', 'maj', 'juni',
@@ -798,97 +801,23 @@ def extract_datetime_da(text, anchorDate=None, default_time=None):
 
     return [extractedDate, resultStr]
 
-def extract_duration_da(text):
-    """Convert a danish phrase into a number of seconds
+def extract_duration_da(text, resolution=DurationResolution.TIMEDELTA,
+                        replace_token=""):
+    """
+    Convert a phrase into a duration and return the remainder text.
 
-    Convert things like:
-        "10 minutes"
-        "2 and a half hours"
-        "3 days 8 hours 10 minutes and 49 seconds"
-    into an int, representing the total number of seconds.
-
-    The words used in the duration will be consumed, and
-    the remainder returned.
-
-    As an example, "set a timer for 5 minutes" would return
-    (300, "set a timer for").
+    The words used in the duration are consumed, the remainder of the
+    text is returned. Returns None for empty input; the duration is
+    None if no duration was found.
 
     Args:
-        text (str): string containing a duration
-
+        text (str): string containing a duration.
+        resolution (DurationResolution): format to return the duration in.
+        replace_token (str): string each consumed duration is replaced with.
     Returns:
-        (timedelta, str):
-                    A tuple containing the duration and the remaining text
-                    not consumed in the parsing. The first value will
-                    be None if no duration is found. The text returned
-                    will have whitespace stripped from the ends.
+        (duration, str): the duration (timedelta, relativedelta or float
+                         depending on resolution) and the remaining
+                         unconsumed text.
     """
-    if not text:
-        return None, ''
-
-    time_units = {
-        'microseconds': 0,
-        'milliseconds': 0,
-        'seconds': 0,
-        'minutes': 0,
-        'hours': 0,
-        'days': 0,
-        'weeks': 0
-    }
-
-    da_translations = {
-        'microseconds': ["mikrosekund", "mikrosekunder", "mikrosekunds", "mikrosekunders"],
-        'milliseconds': ["millisekund", "millisekunder", "millisekunds"],
-        'seconds': ["sekund", "sekunder", "sekunds", "sekunders"],
-        'minutes': ["minut", "minutter", "minuts", "minutters"],
-        'hours': ["time", "timer", "times", "timers"],
-        'days': ["dag", "dage", "dags", "dages"],
-        'weeks': ["uge", "uges", "uger", "ugers"]
-    }
-
-    pattern = r"(?P<value>\d+(?:\.?\d+)?)\s+{unit}"
-    text = numbers_to_digits_da(text)
-
-    for unit in time_units:
-        unit_da_words = da_translations[unit]
-        unit_da_words.sort(key=len, reverse=True)
-        for unit_da in unit_da_words:
-            unit_pattern = pattern.format(unit=unit_da)
-            matches = re.findall(unit_pattern, text)
-            value = sum(map(float, matches))
-            time_units[unit] = time_units[unit] + value
-            text = re.sub(unit_pattern, '', text)
-
-    # Non-standard time units
-    non_std_unit = {
-        'months': ["måned", "måneder", "måneds", "måneders"],
-        'decades': ["årti", "årtier", "årtis"],
-        'centuries': ["århundrede", "århundreder", "århundredes"],
-        'millennia': ["årtusinde", "årtusinder", "årtusindes"],
-        'years': ["år", "års"]  # must be last to avoid matching on centuries and millennia
-    }
-
-    for unit in non_std_unit.keys():
-        unit_da_words = non_std_unit[unit]
-        unit_da_words.sort(key=len, reverse=True)
-        for unit_da in unit_da_words:
-            unit_pattern = pattern.format(unit=unit_da)
-            matches = re.findall(unit_pattern, text)
-            val = sum(map(float, matches))
-            if unit == "months":
-                val = DAYS_IN_1_MONTH * val
-            if unit == "years":
-                val = DAYS_IN_1_YEAR * val
-            if unit == "decades":
-                val = 10 * DAYS_IN_1_YEAR * val
-            if unit == "centuries":
-                val = 100 * DAYS_IN_1_YEAR * val
-            if unit == "millennia":
-                val = 1000 * DAYS_IN_1_YEAR * val
-            time_units["days"] += val
-            text = re.sub(unit_pattern, '', text)
-
-    text = text.strip()
-    duration = timedelta(**time_units) if any(time_units.values()) else None
-
-    return (duration, text)
+    return extract_duration_generic(text, DURATION_LEXICONS["da"],
+                                    resolution, replace_token)

--- a/ovos_date_parser/dates_de.py
+++ b/ovos_date_parser/dates_de.py
@@ -5,6 +5,9 @@ from dateutil.relativedelta import relativedelta
 from ovos_number_parser.numbers_de import pronounce_number_de, _get_ordinal_index, is_number_de, is_numeric_de, \
     numbers_to_digits_de
 from ovos_utils.time import now_local
+from ovos_date_parser.duration import (
+    DurationResolution, DURATION_LEXICONS, extract_duration_generic
+)
 
 
 def nice_time_de(dt, speech=True, use_24hour=False, use_ampm=False):
@@ -72,62 +75,26 @@ def nice_time_de(dt, speech=True, use_24hour=False, use_ampm=False):
     return string
 
 
-def extract_duration_de(text):
+def extract_duration_de(text, resolution=DurationResolution.TIMEDELTA,
+                        replace_token=""):
     """
-    Convert a german phrase into a number of seconds
-    Convert things like:
-        "10 Minuten"
-        "3 Tage 8 Stunden 10 Minuten und 49 Sekunden"
-    into an int, representing the total number of seconds.
-    The words used in the duration will be consumed, and
-    the remainder returned.
-    As an example, "set a timer for 5 minutes" would return
-    (300, "set a timer for").
+    Convert a phrase into a duration and return the remainder text.
+
+    The words used in the duration are consumed, the remainder of the
+    text is returned. Returns None for empty input; the duration is
+    None if no duration was found.
+
     Args:
-        text (str): string containing a duration
+        text (str): string containing a duration.
+        resolution (DurationResolution): format to return the duration in.
+        replace_token (str): string each consumed duration is replaced with.
     Returns:
-        (timedelta, str):
-                    A tuple containing the duration and the remaining text
-                    not consumed in the parsing. The first value will
-                    be None if no duration is found. The text returned
-                    will have whitespace stripped from the ends.
+        (duration, str): the duration (timedelta, relativedelta or float
+                         depending on resolution) and the remaining
+                         unconsumed text.
     """
-    if not text:
-        return None
-
-    text = text.lower()
-    # die time_unit values werden für timedelta() mit dem jeweiligen Wert überschrieben
-    time_units = {
-        'microseconds': 'mikrosekunden',
-        'milliseconds': 'millisekunden',
-        'seconds': 'sekunden',
-        'minutes': 'minuten',
-        'hours': 'stunden',
-        'days': 'tage',
-        'weeks': 'wochen'
-    }
-
-    # Einzahl und Mehrzahl
-    pattern = r"(?:^|\s)(?P<value>\d+(?:[.,]?\d+)?\b)(?:\s+|\-)(?P<unit>{unit}[nes]?[sn]?\b)"
-
-    text = numbers_to_digits_de(text)
-
-    for (unit_en, unit_de) in time_units.items():
-        unit_pattern = pattern.format(
-            unit=unit_de[:-1])  # remove 'n'/'e' from unit
-        time_units[unit_en] = 0
-
-        def repl(match):
-            value = match.group("value").replace(",", ".")
-            time_units[unit_en] += float(value)
-            return ''
-
-        text = re.sub(unit_pattern, repl, text)
-
-    text = text.strip()
-    duration = timedelta(**time_units) if any(time_units.values()) else None
-
-    return (duration, text)
+    return extract_duration_generic(text, DURATION_LEXICONS["de"],
+                                    resolution, replace_token)
 
 
 def extract_datetime_de(text, anchorDate=None, default_time=None):

--- a/ovos_date_parser/dates_en.py
+++ b/ovos_date_parser/dates_en.py
@@ -5,6 +5,9 @@ from dateutil.relativedelta import relativedelta
 from ovos_number_parser.numbers_en import extract_number_en, numbers_to_digits_en, pronounce_number_en
 from ovos_number_parser.util import is_numeric
 from ovos_utils.time import now_local, DAYS_IN_1_YEAR, DAYS_IN_1_MONTH
+from ovos_date_parser.duration import (
+    DurationResolution, DURATION_LEXICONS, extract_duration_generic
+)
 
 
 def nice_time_en(dt, speech=True, use_24hour=False, use_ampm=False):
@@ -91,85 +94,26 @@ def nice_time_en(dt, speech=True, use_24hour=False, use_ampm=False):
         return speak
 
 
-def extract_duration_en(text):
+def extract_duration_en(text, resolution=DurationResolution.TIMEDELTA,
+                        replace_token=""):
     """
-    Convert an english phrase into a number of seconds
+    Convert a phrase into a duration and return the remainder text.
 
-    Convert things like:
-        "10 minute"
-        "2 and a half hours"
-        "3 days 8 hours 10 minutes and 49 seconds"
-    into an int, representing the total number of seconds.
-
-    The words used in the duration will be consumed, and
-    the remainder returned.
-
-    As an example, "set a timer for 5 minutes" would return
-    (300, "set a timer for").
+    The words used in the duration are consumed, the remainder of the
+    text is returned. Returns None for empty input; the duration is
+    None if no duration was found.
 
     Args:
-        text (str): string containing a duration
-
+        text (str): string containing a duration.
+        resolution (DurationResolution): format to return the duration in.
+        replace_token (str): string each consumed duration is replaced with.
     Returns:
-        (timedelta, str):
-                    A tuple containing the duration and the remaining text
-                    not consumed in the parsing. The first value will
-                    be None if no duration is found. The text returned
-                    will have whitespace stripped from the ends.
+        (duration, str): the duration (timedelta, relativedelta or float
+                         depending on resolution) and the remaining
+                         unconsumed text.
     """
-    if not text:
-        return None
-
-    time_units = {
-        'microseconds': 0,
-        'milliseconds': 0,
-        'seconds': 0,
-        'minutes': 0,
-        'hours': 0,
-        'days': 0,
-        'weeks': 0
-    }
-    # NOTE: these are spelled wrong on purpose because of the loop below that strips the s
-    units = ['months', 'years', 'decades', 'centurys', 'millenniums'] + \
-            list(time_units.keys())
-
-    pattern = r"(?P<value>\d+(?:\.?\d+)?)(?:\s+|\-){unit}s?"
-    text = numbers_to_digits_en(text)
-    text = text.replace("centuries", "century").replace("millenia", "millennium")
-    for word in ('day', 'month', 'year', 'decade', 'century', 'millennium'):
-        text = text.replace(f'a {word}', f'1 {word}')
-
-    for unit_en in units:
-        unit_pattern = pattern.format(unit=unit_en[:-1])  # remove 's' from unit
-
-        def repl(match):
-            time_units[unit_en] += float(match.group(1))
-            return ''
-
-        def repl_non_std(match):
-            val = float(match.group(1))
-            if unit_en == "months":
-                val = DAYS_IN_1_MONTH * val
-            if unit_en == "years":
-                val = DAYS_IN_1_YEAR * val
-            if unit_en == "decades":
-                val = 10 * DAYS_IN_1_YEAR * val
-            if unit_en == "centurys":
-                val = 100 * DAYS_IN_1_YEAR * val
-            if unit_en == "millenniums":
-                val = 1000 * DAYS_IN_1_YEAR * val
-            time_units["days"] += val
-            return ''
-
-        if unit_en not in time_units:
-            text = re.sub(unit_pattern, repl_non_std, text)
-        else:
-            text = re.sub(unit_pattern, repl, text)
-
-    text = text.strip()
-    duration = timedelta(**time_units) if any(time_units.values()) else None
-
-    return (duration, text)
+    return extract_duration_generic(text, DURATION_LEXICONS["en"],
+                                    resolution, replace_token)
 
 
 def extract_datetime_en(text, anchorDate=None, default_time=None):

--- a/ovos_date_parser/dates_es.py
+++ b/ovos_date_parser/dates_es.py
@@ -4,6 +4,9 @@ from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta
 from ovos_number_parser.numbers_es import pronounce_number_es, numbers_to_digits_es
 from ovos_utils.time import now_local, DAYS_IN_1_YEAR, DAYS_IN_1_MONTH
+from ovos_date_parser.duration import (
+    DurationResolution, DURATION_LEXICONS, extract_duration_generic
+)
 
 WEEKDAYS_ES = {
     0: "lunes",
@@ -1004,86 +1007,23 @@ def extract_datetime_es(text, anchorDate=None, default_time=None):
     return [extractedDate, resultStr]
 
 
-def extract_duration_es(text):
+def extract_duration_es(text, resolution=DurationResolution.TIMEDELTA,
+                        replace_token=""):
     """
-    Convert an spanish phrase into a number of seconds
-    Convert things like:
-        "10 Minutos"
-        "3 dias 8 horas 10 Minutos e 49 Segundos"
-    into an int, representing the total number of seconds.
-    The words used in the duration will be consumed, and
-    the remainder returned.
-    As an example, "set a timer for 5 minutes" would return
-    (300, "set a timer for").
+    Convert a phrase into a duration and return the remainder text.
+
+    The words used in the duration are consumed, the remainder of the
+    text is returned. Returns None for empty input; the duration is
+    None if no duration was found.
+
     Args:
-        text (str): string containing a duration
+        text (str): string containing a duration.
+        resolution (DurationResolution): format to return the duration in.
+        replace_token (str): string each consumed duration is replaced with.
     Returns:
-        (timedelta, str):
-                    A tuple containing the duration and the remaining text
-                    not consumed in the parsing. The first value will
-                    be None if no duration is found. The text returned
-                    will have whitespace stripped from the ends.
+        (duration, str): the duration (timedelta, relativedelta or float
+                         depending on resolution) and the remaining
+                         unconsumed text.
     """
-    if not text:
-        return None
-
-    text = text.lower().replace("í", "i")
-    time_units = {
-        'microseconds': 'microsegundos',
-        'milliseconds': 'milisegundos',
-        'seconds': 'segundos',
-        'minutes': 'minutos',
-        'hours': 'horas',
-        'days': 'dias',
-        'weeks': 'semanas'
-    }
-    # NOTE: some of these english units are spelled wrong on purpose because of the loop below that strips the s
-    non_std_un = {
-        "months": "mes",
-        "years": "anos",
-        'decades': "decadas",
-        'centurys': "siglos",
-        'millenniums': "milenios"
-    }
-
-    pattern = r"(?P<value>\d+(?:\.?\d+)?)(?:\s+|\-){unit}[s]?"
-
-    text = text.replace("í", "i").replace("é", "e").replace("ñ", "n").replace("meses", "mes")
-    text = numbers_to_digits_es(text)
-
-    for (unit_en, unit_es) in time_units.items():
-        unit_pattern = pattern.format(
-            unit=unit_es[:-1])  # remove 's' from unit
-        time_units[unit_en] = 0
-
-        def repl(match):
-            time_units[unit_en] += float(match.group(1))
-            return ''
-
-        text = re.sub(unit_pattern, repl, text)
-
-    for (unit_en, unit_es) in non_std_un.items():
-        unit_pattern = pattern.format(
-            unit=unit_es[:-1])  # remove 's' from unit
-
-        def repl_non_std(match):
-            val = float(match.group(1))
-            if unit_en == "months":
-                val = DAYS_IN_1_MONTH * val
-            if unit_en == "years":
-                val = DAYS_IN_1_YEAR * val
-            if unit_en == "decades":
-                val = 10 * DAYS_IN_1_YEAR * val
-            if unit_en == "centurys":
-                val = 100 * DAYS_IN_1_YEAR * val
-            if unit_en == "millenniums":
-                val = 1000 * DAYS_IN_1_YEAR * val
-            time_units["days"] += val
-            return ''
-
-        text = re.sub(unit_pattern, repl_non_std, text)
-
-    text = text.strip()
-    duration = timedelta(**time_units) if any(time_units.values()) else None
-
-    return (duration, text)
+    return extract_duration_generic(text, DURATION_LEXICONS["es"],
+                                    resolution, replace_token)

--- a/ovos_date_parser/dates_gl.py
+++ b/ovos_date_parser/dates_gl.py
@@ -5,6 +5,9 @@ from datetime import timedelta
 from dateutil.relativedelta import relativedelta
 from ovos_number_parser.numbers_gl import pronounce_number_gl
 from ovos_utils.time import now_local
+from ovos_date_parser.duration import (
+    DurationResolution, DURATION_LEXICONS, extract_duration_generic
+)
 
 WEEKDAYS_GL = {
     0: "luns",
@@ -980,84 +983,23 @@ def extract_datetime_gl(text, anchorDate=None, default_time=None):
     return [extractedDate, resultStr]
 
 
-def extract_duration_gl(text):
+def extract_duration_gl(text, resolution=DurationResolution.TIMEDELTA,
+                        replace_token=""):
     """
-    Converte unha frase en galego nun número de segundos.
-    Converte cousas como:
-        "10 minutos"
-        "3 días 8 horas 10 minutos e 49 segundos"
-    nun número enteiro que representa o total de segundos.
-    As palabras empregadas na duración serán consumidas,
-    devolvéndose o texto restante.
-    Por exemplo, "pon un temporizador de 5 minutos" devolvería
-    (300, "pon un temporizador de").
+    Convert a phrase into a duration and return the remainder text.
+
+    The words used in the duration are consumed, the remainder of the
+    text is returned. Returns None for empty input; the duration is
+    None if no duration was found.
 
     Args:
-        text (str): cadea de texto que contén unha duración
-
+        text (str): string containing a duration.
+        resolution (DurationResolution): format to return the duration in.
+        replace_token (str): string each consumed duration is replaced with.
     Returns:
-        (timedelta, str):
-            Unha tupla co tempo total e o texto restante
-            non consumido no análise. O primeiro valor será
-            None se non se atopa ningunha duración. O texto devolto
-            terá os espazos en branco eliminados nos extremos.
+        (duration, str): the duration (timedelta, relativedelta or float
+                         depending on resolution) and the remaining
+                         unconsumed text.
     """
-    if not text:
-        return None, text
-
-    text = text.lower().replace("í", "i").replace("é", "e").replace("ñ", "n").replace("meses", "mes")
-
-    unidades_tempo = {
-        'microseconds': 'microsegundos',
-        'milliseconds': 'milisegundos',
-        'seconds': 'segundos',
-        'minutes': 'minutos',
-        'hours': 'horas',
-        'days': 'dias',
-        'weeks': 'semanas'
-    }
-
-    unidades_non_estandar = {
-        "months": "mes",
-        "years": "anos",
-        'decades': "decadas",
-        'centuries': "seculos",
-        'millenniums': "milenios"
-    }
-
-    patron = r"(?P<value>\d+(?:\.?\d+)?)(?:\s+|\-){unit}[s]?"
-
-    for (unit_en, unit_gl) in unidades_tempo.items():
-        patron_unidade = patron.format(unit=unit_gl[:-1])  # eliminar 's' da unidade
-        unidades_tempo[unit_en] = 0
-
-        def substitucion(match):
-            unidades_tempo[unit_en] += float(match.group("value"))
-            return ''
-
-        text = re.sub(patron_unidade, substitucion, text)
-
-    for (unit_en, unit_gl) in unidades_non_estandar.items():
-        patron_unidade = patron.format(unit=unit_gl[:-1])  # eliminar 's' da unidade
-
-        def substitucion_non_estandar(match):
-            val = float(match.group("value"))
-            if unit_en == "months":
-                val = 30 * val  # aproximación dun mes en días
-            elif unit_en == "years":
-                val = 365 * val  # aproximación dun ano en días
-            elif unit_en == "decades":
-                val = 10 * 365 * val
-            elif unit_en == "centuries":
-                val = 100 * 365 * val
-            elif unit_en == "millenniums":
-                val = 1000 * 365 * val
-            unidades_tempo["days"] += val
-            return ''
-
-        text = re.sub(patron_unidade, substitucion_non_estandar, text)
-
-    text = text.strip()
-    duracion = timedelta(**unidades_tempo) if any(unidades_tempo.values()) else None
-
-    return duracion, text
+    return extract_duration_generic(text, DURATION_LEXICONS["gl"],
+                                    resolution, replace_token)

--- a/ovos_date_parser/dates_nl.py
+++ b/ovos_date_parser/dates_nl.py
@@ -5,73 +5,31 @@ from dateutil.relativedelta import relativedelta
 from ovos_number_parser.numbers_nl import pronounce_number_nl, extract_number_nl, numbers_to_digits_nl
 from ovos_number_parser.util import is_numeric
 from ovos_utils.time import now_local
+from ovos_date_parser.duration import (
+    DurationResolution, DURATION_LEXICONS, extract_duration_generic
+)
 
 
-def extract_duration_nl(text):
-    """Convert an english phrase into a number of seconds
+def extract_duration_nl(text, resolution=DurationResolution.TIMEDELTA,
+                        replace_token=""):
+    """
+    Convert a phrase into a duration and return the remainder text.
 
-    Convert things like:
-        "10 minute"
-        "2 and a half hours"
-        "3 days 8 hours 10 minutes and 49 seconds"
-    into an int, representing the total number of seconds.
-
-    The words used in the duration will be consumed, and
-    the remainder returned.
-
-    As an example, "set a timer for 5 minutes" would return
-    (300, "set a timer for").
+    The words used in the duration are consumed, the remainder of the
+    text is returned. Returns None for empty input; the duration is
+    None if no duration was found.
 
     Args:
-        text (str): string containing a duration
-
+        text (str): string containing a duration.
+        resolution (DurationResolution): format to return the duration in.
+        replace_token (str): string each consumed duration is replaced with.
     Returns:
-        (timedelta, str):
-                    A tuple containing the duration and the remaining text
-                    not consumed in the parsing. The first value will
-                    be None if no duration is found. The text returned
-                    will have whitespace stripped from the ends.
+        (duration, str): the duration (timedelta, relativedelta or float
+                         depending on resolution) and the remaining
+                         unconsumed text.
     """
-    if not text:
-        return None
-
-    time_units = {
-        'microseconds': 0,
-        'milliseconds': 0,
-        'seconds': 0,
-        'minutes': 0,
-        'hours': 0,
-        'days': 0,
-        'weeks': 0
-    }
-
-    nl_translations = {
-        'microseconds': ["microsecond", "microseconde", "microseconden", "microsecondje", "microsecondjes"],
-        'milliseconds': ["millisecond", "milliseconde", "milliseconden", "millisecondje", "millisecondjes"],
-        'seconds': ["second", "seconde", "seconden", "secondje", "secondjes"],
-        'minutes': ["minuut", "minuten", "minuutje", "minuutjes"],
-        'hours': ["uur", "uren", "uurtje", "uurtjes"],
-        'days': ["dag", "dagen", "dagje", "dagjes"],
-        'weeks': ["week", "weken", "weekje", "weekjes"]
-    }
-
-    pattern = r"(?P<value>\d+(?:\.?\d+)?)\s+{unit}"
-    text = numbers_to_digits_nl(text)
-
-    for unit in time_units:
-        unit_nl_words = nl_translations[unit]
-        unit_nl_words.sort(key=len, reverse=True)
-        for unit_nl in unit_nl_words:
-            unit_pattern = pattern.format(unit=unit_nl)
-            matches = re.findall(unit_pattern, text)
-            value = sum(map(float, matches))
-            time_units[unit] = time_units[unit] + value
-            text = re.sub(unit_pattern, '', text)
-
-    text = text.strip()
-    duration = timedelta(**time_units) if any(time_units.values()) else None
-
-    return (duration, text)
+    return extract_duration_generic(text, DURATION_LEXICONS["nl"],
+                                    resolution, replace_token)
 
 
 def extract_datetime_nl(text, anchorDate=None, default_time=None):

--- a/ovos_date_parser/dates_pt.py
+++ b/ovos_date_parser/dates_pt.py
@@ -5,6 +5,9 @@ from dateutil.relativedelta import relativedelta
 from ovos_number_parser.numbers_pt import pronounce_number_pt, numbers_to_digits_pt
 from ovos_number_parser.util import GrammaticalGender
 from ovos_utils.time import now_local, DAYS_IN_1_YEAR, DAYS_IN_1_MONTH
+from ovos_date_parser.duration import (
+    DurationResolution, DURATION_LEXICONS, extract_duration_generic
+)
 
 WEEKDAYS_PT = {
     0: "segunda-feira",
@@ -1034,88 +1037,23 @@ def extract_datetime_pt(text, anchorDate=None, default_time=None):
     return [extractedDate, resultStr]
 
 
-def extract_duration_pt(text):
+def extract_duration_pt(text, resolution=DurationResolution.TIMEDELTA,
+                        replace_token=""):
     """
-    Convert a portuguese phrase into a number of seconds
-    Convert things like:
-        "10 Minutos"
-        "3 dias 8 horas 10 Minutos e 49 Segundos"
-    into an int, representing the total number of seconds.
-    The words used in the duration will be consumed, and
-    the remainder returned.
-    As an example, "set a timer for 5 minutes" would return
-    (300, "set a timer for").
+    Convert a phrase into a duration and return the remainder text.
+
+    The words used in the duration are consumed, the remainder of the
+    text is returned. Returns None for empty input; the duration is
+    None if no duration was found.
+
     Args:
-        text (str): string containing a duration
+        text (str): string containing a duration.
+        resolution (DurationResolution): format to return the duration in.
+        replace_token (str): string each consumed duration is replaced with.
     Returns:
-        (timedelta, str):
-                    A tuple containing the duration and the remaining text
-                    not consumed in the parsing. The first value will
-                    be None if no duration is found. The text returned
-                    will have whitespace stripped from the ends.
+        (duration, str): the duration (timedelta, relativedelta or float
+                         depending on resolution) and the remaining
+                         unconsumed text.
     """
-    if not text:
-        return None
-
-    text = text.lower()
-    time_units = {
-        'microseconds': 'microsegundos',
-        'milliseconds': 'milisegundos',
-        'seconds': 'segundos',
-        'minutes': 'minutos',
-        'hours': 'horas',
-        'days': 'dias',
-        'weeks': 'semanas'
-    }
-    # NOTE: some of these english units are spelled wrong on purpose because of the loop below that strips the s
-    non_std_un = {
-        "months": "meses",
-        "years": "anos",
-        'decades': "decadas",
-        'centurys': "seculos",
-        'millenniums': "milenios"
-    }
-
-    pattern = r"(?P<value>\d+(?:\.?\d+)?)(?:\s+|\-){unit}[s]?"
-
-    text = text.replace("mês", "meses").replace("é", "e")
-    text = text.replace("segundo", "_s_")  # HACK - segundo (second) will be replaced with 2
-    text = numbers_to_digits_pt(text)
-    text = text.replace("_s_", "segundo")  # undo HACK
-
-    for (unit_en, unit_pt) in time_units.items():
-        unit_pattern = pattern.format(
-            unit=unit_pt[:-1])  # remove 's' from unit
-        time_units[unit_en] = 0
-
-        def repl(match):
-            time_units[unit_en] += float(match.group(1))
-            return ''
-
-        text = re.sub(unit_pattern, repl, text)
-
-    for (unit_en, unit_pt) in non_std_un.items():
-        unit_pattern = pattern.format(
-            unit=unit_pt[:-1])  # remove 's' from unit
-
-        def repl_non_std(match):
-            val = float(match.group(1))
-            if unit_en == "months":
-                val = DAYS_IN_1_MONTH * val
-            if unit_en == "years":
-                val = DAYS_IN_1_YEAR * val
-            if unit_en == "decades":
-                val = 10 * DAYS_IN_1_YEAR * val
-            if unit_en == "centurys":
-                val = 100 * DAYS_IN_1_YEAR * val
-            if unit_en == "millenniums":
-                val = 1000 * DAYS_IN_1_YEAR * val
-            time_units["days"] += val
-            return ''
-
-        text = re.sub(unit_pattern, repl_non_std, text)
-
-    text = text.strip()
-    duration = timedelta(**time_units) if any(time_units.values()) else None
-
-    return (duration, text)
+    return extract_duration_generic(text, DURATION_LEXICONS["pt"],
+                                    resolution, replace_token)

--- a/ovos_date_parser/duration.py
+++ b/ovos_date_parser/duration.py
@@ -88,6 +88,9 @@ class DurationLexicon:
             follows a numeral. Units are matched in _UNITS order.
         value_pattern: regex for the numeric value (named group ``value``).
         joiner: regex between the value and the unit word.
+        pattern_template: optional full pattern override with a ``{unit}``
+            placeholder; must define a ``value`` group and may define a
+            ``half`` group adding 0.5 to the value when present.
         normalize: optional override for text normalization; receives the
             raw text and returns text with numerals as digits. Defaults
             to ``numbers_to_digits(text.lower(), lang)``.
@@ -96,12 +99,18 @@ class DurationLexicon:
     units: Dict[str, str]
     value_pattern: str = r"(?P<value>\d+(?:[.,]\d+)?)"
     joiner: str = r"(?:\s+|-)"
+    pattern_template: Optional[str] = None
     normalize: Optional[Callable[[str], str]] = None
 
     def _normalize(self, text: str) -> str:
         if self.normalize:
             return self.normalize(text)
         return numbers_to_digits(text.lower(), self.lang)
+
+    def _pattern(self, fragment: str) -> str:
+        if self.pattern_template:
+            return self.pattern_template.format(unit=fragment)
+        return self.value_pattern + self.joiner + "(?:" + fragment + r")\b"
 
 
 def extract_duration_generic(
@@ -125,11 +134,12 @@ def extract_duration_generic(
         frag = lexicon.units.get(unit)
         if not frag:
             continue
-        pattern = lexicon.value_pattern + lexicon.joiner + \
-            "(?:" + frag + r")\b"
+        pattern = lexicon._pattern(frag)
 
         def repl(match, _unit=unit):
             val = float(match.group("value").replace(",", "."))
+            if "half" in match.groupdict() and match.group("half"):
+                val += 0.5
             values[_unit] = values.get(_unit, 0) + val
             return replace_token
 
@@ -322,4 +332,173 @@ register_duration_lexicon(DurationLexicon(
         "decades": r"desetletj(?:e|a|i|ih)?|desetletij",
         "centuries": r"stoletj(?:e|a|i|ih)?|stoletij",
         "millenniums": r"tisočletj(?:e|a|i|ih)?|tisočletij",
+    }))
+
+
+def _normalize_en(text: str) -> str:
+    # the English-specific normalizer folds "X and a half" into X.5
+    from ovos_number_parser.numbers_en import numbers_to_digits_en
+    text = numbers_to_digits_en(text)
+    text = text.replace("centuries", "century").replace(
+        "millenia", "millennium")
+    for word in ("day", "month", "year", "decade", "century", "millennium"):
+        text = text.replace(f"a {word}", f"1 {word}")
+    return text
+
+
+register_duration_lexicon(DurationLexicon(
+    lang="en",
+    normalize=_normalize_en,
+    units={
+        "microseconds": r"microseconds?",
+        "milliseconds": r"milliseconds?",
+        "seconds": r"seconds?",
+        "minutes": r"minutes?",
+        "hours": r"hours?",
+        "days": r"days?",
+        "weeks": r"weeks?",
+        "months": r"months?",
+        "years": r"years?",
+        "decades": r"decades?",
+        "centuries": r"centurys?",
+        "millenniums": r"millenniums?",
+    }))
+
+
+def _fold_iberian(text: str) -> str:
+    return text.lower().replace("í", "i").replace("é", "e").replace("ñ", "n")
+
+
+register_duration_lexicon(DurationLexicon(
+    lang="ca",
+    normalize=lambda text: numbers_to_digits(_fold_iberian(text), "ca"),
+    units={
+        "microseconds": r"microsegons?",
+        "milliseconds": r"mil·lisegons?|milisegons?",
+        "seconds": r"segons?",
+        "minutes": r"minuts?",
+        "hours": r"hor(?:a|es)",
+        "days": r"di(?:a|es)",
+        "weeks": r"setman(?:a|es)",
+        "months": r"mes(?:os)?",
+        "years": r"anys?",
+        "decades": r"dècad(?:a|es)|decad(?:a|es)",
+        "centuries": r"segles?",
+        "millenniums": r"mil·lenis?|milenis?",
+    }))
+
+register_duration_lexicon(DurationLexicon(
+    lang="es",
+    normalize=lambda text: numbers_to_digits(_fold_iberian(text), "es"),
+    units={
+        "microseconds": r"microsegundos?",
+        "milliseconds": r"milisegundos?",
+        "seconds": r"segundos?",
+        "minutes": r"minutos?",
+        "hours": r"horas?",
+        "days": r"dias?",
+        "weeks": r"semanas?",
+        "months": r"mes(?:es)?",
+        "years": r"anos?",
+        "decades": r"decadas?",
+        "centuries": r"siglos?",
+        "millenniums": r"milenios?",
+    }))
+
+# the Galician number normalizer folds articles ("un temporizador" ->
+# "1 temporizador"), so only accent folding is applied here
+register_duration_lexicon(DurationLexicon(
+    lang="gl",
+    normalize=_fold_iberian,
+    units={
+        "microseconds": r"microsegundos?",
+        "milliseconds": r"milisegundos?",
+        "seconds": r"segundos?",
+        "minutes": r"minutos?",
+        "hours": r"horas?",
+        "days": r"dias?",
+        "weeks": r"semanas?",
+        "months": r"mes(?:es)?",
+        "years": r"anos?",
+        "decades": r"decadas?",
+        "centuries": r"seculos?",
+        "millenniums": r"milenios?",
+    }))
+
+
+def _normalize_pt(text: str) -> str:
+    text = text.lower().replace("mês", "meses").replace("é", "e")
+    # "segundo" (second) is also the ordinal "second"; shield it from the
+    # number normalizer
+    text = text.replace("segundo", "_s_")
+    text = numbers_to_digits(text, "pt")
+    return text.replace("_s_", "segundo")
+
+
+register_duration_lexicon(DurationLexicon(
+    lang="pt",
+    normalize=_normalize_pt,
+    units={
+        "microseconds": r"microsegundos?",
+        "milliseconds": r"milisegundos?",
+        "seconds": r"segundos?",
+        "minutes": r"minutos?",
+        "hours": r"horas?",
+        "days": r"dias?",
+        "weeks": r"semanas?",
+        "months": r"meses",
+        "years": r"anos?",
+        "decades": r"decadas?",
+        "centuries": r"seculos?",
+        "millenniums": r"milenios?",
+    }))
+
+register_duration_lexicon(DurationLexicon(
+    lang="de",
+    pattern_template=r"(?:^|\s)(?P<value>\d+(?:[.,]?\d+)?\b)(?:\s+|\-)"
+                     r"(?:{unit})\b",
+    units={
+        "microseconds": r"mikrosekunde[nes]?[sn]?",
+        "milliseconds": r"millisekunde[nes]?[sn]?",
+        "seconds": r"sekunde[nes]?[sn]?",
+        "minutes": r"minute[nes]?[sn]?",
+        "hours": r"stunde[nes]?[sn]?",
+        "days": r"tag[nes]?[sn]?",
+        "weeks": r"woche[nes]?[sn]?",
+    }))
+
+register_duration_lexicon(DurationLexicon(
+    lang="nl",
+    units={
+        "microseconds": r"microsecond(?:jes|je|en|e)?",
+        "milliseconds": r"millisecond(?:jes|je|en|e)?",
+        "seconds": r"second(?:jes|je|en|e)?",
+        "minutes": r"minu(?:ut(?:jes|je)?|ten)",
+        "hours": r"u(?:ur(?:tjes|tje)?|ren)",
+        "days": r"dag(?:jes|je|en)?",
+        "weeks": r"we(?:ek(?:jes|je)?|ken)",
+    }))
+
+def _normalize_da(text: str) -> str:
+    # the Danish-specific normalizer keeps the article "en" intact
+    from ovos_number_parser.numbers_da import numbers_to_digits_da
+    return numbers_to_digits_da(text.lower())
+
+
+register_duration_lexicon(DurationLexicon(
+    lang="da",
+    normalize=_normalize_da,
+    units={
+        "microseconds": r"mikrosekund(?:ers|er|s)?",
+        "milliseconds": r"millisekund(?:er|s)?",
+        "seconds": r"sekund(?:ers|er|s)?",
+        "minutes": r"minut(?:ters|ter|s)?",
+        "hours": r"time(?:rs|r|s)?",
+        "days": r"dag(?:es|e|s)?",
+        "weeks": r"uge(?:rs|r|s)?",
+        "months": r"måned(?:ers|er|s)?",
+        "years": r"års?",
+        "decades": r"årti(?:er|s)?",
+        "centuries": r"århundrede(?:r|s)?",
+        "millenniums": r"årtusinde(?:r|s)?",
     }))

--- a/test/format_tests/test_parse_da.py
+++ b/test/format_tests/test_parse_da.py
@@ -32,7 +32,7 @@ class TestExtractDurationDA(unittest.TestCase):
 
     def test_no_duration_found(self):
         self.assertEqual(extract_duration_da("der er ikke nogen tid"), (None, "der er ikke nogen tid"))
-        self.assertEqual(extract_duration_da(""), (None, ""))
+        self.assertEqual(extract_duration_da(""), None)
 
 
 if __name__ == "__main__":

--- a/test/format_tests/test_parse_gl.py
+++ b/test/format_tests/test_parse_gl.py
@@ -1,6 +1,7 @@
 import unittest
 from datetime import timedelta
 from ovos_date_parser.dates_gl import extract_duration_gl
+from ovos_utils.time import DAYS_IN_1_MONTH, DAYS_IN_1_YEAR
 
 
 class TestExtractDurationGL(unittest.TestCase):
@@ -23,15 +24,15 @@ class TestExtractDurationGL(unittest.TestCase):
                          (timedelta(hours=1), "avisame en"))
 
     def test_non_standard_units(self):
-        self.assertEqual(extract_duration_gl("2 meses"), (timedelta(days=60), ""))
-        self.assertEqual(extract_duration_gl("1 ano"), (timedelta(days=365), ""))
-        self.assertEqual(extract_duration_gl("1 década"), (timedelta(days=10 * 365), ""))
-        self.assertEqual(extract_duration_gl("1 século"), (timedelta(days=100 * 365), ""))
-        self.assertEqual(extract_duration_gl("1 milenio"), (timedelta(days=1000 * 365), ""))
+        self.assertEqual(extract_duration_gl("2 meses"), (timedelta(days=DAYS_IN_1_MONTH * 2), ""))
+        self.assertEqual(extract_duration_gl("1 ano"), (timedelta(days=DAYS_IN_1_YEAR), ""))
+        self.assertEqual(extract_duration_gl("1 década"), (timedelta(days=10 * DAYS_IN_1_YEAR), ""))
+        self.assertEqual(extract_duration_gl("1 século"), (timedelta(days=100 * DAYS_IN_1_YEAR), ""))
+        self.assertEqual(extract_duration_gl("1 milenio"), (timedelta(days=1000 * DAYS_IN_1_YEAR), ""))
 
     def test_no_duration_found(self):
         self.assertEqual(extract_duration_gl("isto non ten tempo"), (None, "isto non ten tempo"))
-        self.assertEqual(extract_duration_gl(""), (None, ""))
+        self.assertEqual(extract_duration_gl(""), None)
 
 
 if __name__ == "__main__":

--- a/test/parse_tests/test_durations.py
+++ b/test/parse_tests/test_durations.py
@@ -230,7 +230,7 @@ class TestDurationResolution(unittest.TestCase):
 
     def test_legacy_languages_reject_new_params(self):
         with self.assertRaises(NotImplementedError):
-            extract_duration("10 minutes", "en",
+            extract_duration("10 minutes", "fa",
                              resolution=DurationResolution.RELATIVEDELTA)
         with self.assertRaises(NotImplementedError):
-            extract_duration("10 minutes", "en", replace_token="_")
+            extract_duration("10 minutes", "fa", replace_token="_")


### PR DESCRIPTION
Moves Catalan, Spanish, Galician, Portuguese, English, German, Dutch and Danish `extract_duration` onto the shared `DurationLexicon` engine from #119, deleting the per-language regex loops. All eight languages gain the `DurationResolution` and `replace_token` parameters.

## Behavior fixes folded in

- **ca**: singular units *hora*, *dia*, *setmana*, *dècada* never matched (patterns were built by stripping the plural `-s` from the plural form), and months never matched at all — the text was pre-folded to `mes` while the pattern still expected `meso`. `"5 mesos"` used to return `(None, "5 mes")`; it now returns five months.
- **es**: `"un mes"` now extracts one month (the bare stem pattern `me` failed to consume `mes`).
- **gl**: calendar units now use the shared `DAYS_IN_1_MONTH`/`DAYS_IN_1_YEAR` constants instead of hardcoded 30/365, matching every other language (tests updated).
- **da/gl**: empty input returns `None` like every other language instead of `(None, "")` (tests updated).
- **en**: remainder strings now have internal whitespace collapsed ("wake me up in , and" instead of "wake me up in ,  and").

Danish keeps its language-specific number normalizer so the article *en* is not read as the numeral 1; Galician applies accent folding only, matching its previous behavior; Portuguese keeps the `segundo` (second/2nd) shielding hack; English keeps `X and a half` folding via its language-specific normalizer.

Every port was differentially tested against the legacy implementation on hand-written sample phrases per language in addition to the existing suites.

## Tests

Full suite: 309 passed, 2 skipped (same counts as dev — only expectations noted above changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)