### PR TITLE
feat: Kabyle (kab) date and time support

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -38,6 +38,20 @@ Full support: `nice_time`, `nice_date`, `nice_date_time`, `nice_day`,
 Duration parsing handles the Asturian plurals in `-es` (hores, selmanes,
 díes) as well as the singular forms. "mañana" is ambiguous between
 "tomorrow" and "morning" and is disambiguated the same way as in Spanish.
+## Kabyle
+
+Weekdays are the everyday Arabic-derived names (`letnayen` ... `lḥedd`);
+months follow the Kabyle calendar spellings (`yennayer`, `fuṛar`, ...
+`dujembeṛ`). `extract_datetime` covers the relative day words (`azekka`
+"tomorrow", `iḍelli` "yesterday", `ass-a` "today"), weekday and month
+names with day numbers, and digit clock times; it does not yet cover
+spoken clock phrases or year words. `extract_duration` accepts both the
+Amazigh neologisms (`tasint` second, `amalas` week) and the
+Arabic-derived units in daily use (`ddqiqa` minute, `ssaɛa` hour), with
+an optional genitive `n` between quantity and unit (`10 n tesdidin`).
+`nice_time` joins hour and minutes with the conjunction `d`; day parts
+use `ssbeḥ` (morning) and `tameddit` (evening). Years are given in
+digits; a verified spoken-year formulation is not available.
 
 ## Fallbacks
 

--- a/ovos_date_parser/__init__.py
+++ b/ovos_date_parser/__init__.py
@@ -59,6 +59,9 @@ from ovos_date_parser.dates_gl import (
     nice_day_gl, nice_date_time_gl, nice_date_gl, nice_time_gl
 )
 from ovos_date_parser.dates_hu import nice_time_hu, extract_duration_hu, extract_datetime_hu
+from ovos_date_parser.dates_kab import (
+    extract_datetime_kab, extract_duration_kab, nice_time_kab,
+)
 from ovos_date_parser.dates_it import (
     extract_datetime_it, nice_time_it, extract_duration_it
 )
@@ -138,6 +141,8 @@ def nice_time(
         return nice_time_hu(dt, speech, use_24hour, use_ampm)
     if lang.startswith("it"):
         return nice_time_it(dt, speech, use_24hour, use_ampm)
+    if lang.startswith("kab"):
+        return nice_time_kab(dt, speech, use_24hour, use_ampm)
     if lang.startswith("nl"):
         return nice_time_nl(dt, speech, use_24hour, use_ampm)
     if lang.startswith("pl"):
@@ -238,6 +243,8 @@ def extract_duration(
         return extract_duration_az(text)
     if lang.startswith("cs"):
         return extract_duration_cs(text)
+    if lang.startswith("kab"):
+        return extract_duration_kab(text)
     if lang.startswith("fa"):
         return extract_duration_fa(text)
     if lang.startswith("pl"):
@@ -300,6 +307,8 @@ def extract_datetime(
         return extract_datetime_hu(text, anchorDate=anchorDate, default_time=default_time)
     if lang.startswith("it"):
         return extract_datetime_it(text, anchorDate=anchorDate, default_time=default_time)
+    if lang.startswith("kab"):
+        return extract_datetime_kab(text, anchorDate=anchorDate, default_time=default_time)
     if lang.startswith("nl"):
         return extract_datetime_nl(text, anchorDate=anchorDate, default_time=default_time)
     if lang.startswith("pl"):

--- a/ovos_date_parser/dates_kab.py
+++ b/ovos_date_parser/dates_kab.py
@@ -1,0 +1,217 @@
+"""Kabyle (Taqbaylit, ``kab``) date and time tools.
+
+Weekday names are the Arabic-derived forms in everyday use (letnayen,
+ttlata, ...); month names follow the Kabyle calendar spellings (yennayer,
+fuṛar, ... dujembeṛ). Time units mix the attested Amazigh neologisms
+(tasint "second", asrag "hour", amalas "week") with the Arabic-derived
+words that carry daily usage (ddqiqa "minute", ssaɛa "hour").
+
+Sources:
+- https://kab.wikipedia.org/wiki/Yennayer (month names)
+- https://apprendrelekabyle.com/les-jours-de-la-semaine-en-kabyle/
+- https://glosbe.com/fr/kab (heure, minute, seconde, matin, soir, semaine)
+- https://en.wikipedia.org/wiki/Kabyle_language (grammar)
+"""
+import re
+from datetime import datetime, timedelta
+from typing import Optional, Tuple
+
+from ovos_number_parser.numbers_kab import (pronounce_number_kab,
+                                            extract_number_kab, _normalize)
+
+WEEKDAYS_KAB = {0: "letnayen", 1: "ttlata", 2: "laṛebɛa", 3: "lexmis",
+                4: "lǧemɛa", 5: "ssebt", 6: "lḥedd"}
+MONTHS_KAB = {1: "yennayer", 2: "fuṛar", 3: "meɣres", 4: "yebrir",
+              5: "mayyu", 6: "yunyu", 7: "yulyu", 8: "ɣuct",
+              9: "ctembeṛ", 10: "tubeṛ", 11: "wambeṛ", 12: "dujembeṛ"}
+
+# day-part words: ssbeḥ "morning", tameddit "evening", iḍ "night"
+_MORNING = "ssbeḥ"
+_EVENING = "tameddit"
+
+# duration units, singular and plural spellings (Amazigh neologisms and
+# the Arabic-derived words both extract)
+_SECONDS_UNITS = {"tasint", "tisinin"}
+_MINUTES_UNITS = {"ddqiqa", "tesdidin", "tisdidin", "dqiqa"}
+_HOURS_UNITS = {"ssaɛa", "saɛa", "tsaɛtin", "tisaɛtin", "asrag", "isragen",
+                "wesrag", "usrag"}
+_DAYS_UNITS = {"ass", "ussan", "wass", "wussan"}
+_WEEKS_UNITS = {"amalas", "imalasen", "yimalasen", "ddurt", "dduṛt",
+                "wamalas"}
+
+_RELATIVE_DAYS = {"azekka": 1, "iḍelli": -1, "idelli": -1,
+                  "ass-a": 0, "assa": 0, "ass-agi": 0}
+
+
+def nice_time_kab(dt, speech=True, use_24hour=False, use_ampm=False):
+    """Format a time to a comfortable human format in Kabyle.
+
+    Hours and minutes are joined with the conjunction "d"; exact hours
+    are spoken alone.
+    """
+    if use_24hour:
+        string = dt.strftime("%H:%M")
+    else:
+        string = dt.strftime("%I:%M")
+        if string[0] == '0':
+            string = string[1:]
+        if use_ampm:
+            string += " " + (_MORNING if dt.hour < 12 else _EVENING)
+    if not speech:
+        return string
+
+    if use_24hour:
+        speak = pronounce_number_kab(dt.hour)
+        if dt.minute:
+            speak += f" d {pronounce_number_kab(dt.minute)}"
+        return speak
+
+    hour = dt.hour % 12 or 12
+    speak = pronounce_number_kab(hour)
+    if dt.minute:
+        speak += f" d {pronounce_number_kab(dt.minute)}"
+    if use_ampm:
+        speak += " " + (_MORNING if dt.hour < 12 else _EVENING)
+    return speak
+
+
+def extract_duration_kab(text: str) -> Tuple[Optional[timedelta], str]:
+    """Extract a duration from Kabyle text.
+
+    Understands digit and spoken quantities followed by an optional "n"
+    genitive particle and a time unit ("10 n ddqayeq", "sin wussan").
+    """
+    if not text:
+        return None, text
+
+    unit_seconds = {}
+    for w in _SECONDS_UNITS:
+        unit_seconds[_normalize(w)] = 1
+    for w in _MINUTES_UNITS:
+        unit_seconds[_normalize(w)] = 60
+    for w in _HOURS_UNITS:
+        unit_seconds[_normalize(w)] = 3600
+    for w in _DAYS_UNITS:
+        unit_seconds[_normalize(w)] = 86400
+    for w in _WEEKS_UNITS:
+        unit_seconds[_normalize(w)] = 604800
+
+    tokens = text.split()
+    total = 0.0
+    found = False
+    consumed = set()
+    i = 0
+    while i < len(tokens):
+        tok = _normalize(tokens[i].strip(".,!?;:"))
+        if tok in unit_seconds:
+            # find the quantity immediately before (skipping genitive "n")
+            j = i - 1
+            if j >= 0 and _normalize(tokens[j].strip(".,!?;:")) == "n":
+                j -= 1
+            # allow multiword spoken numbers before the unit
+            start = j
+            value = None
+            while start >= 0:
+                if start in consumed:
+                    break
+                candidate = " ".join(tokens[start:j + 1])
+                val = extract_number_kab(candidate)
+                if val is False:
+                    break
+                value = val
+                start -= 1
+            if value is None:
+                value = 1
+                start = j
+            total += value * unit_seconds[tok]
+            found = True
+            consumed.update(range(start + 1, i + 1))
+        i += 1
+
+    if not found:
+        return None, text
+
+    remainder = " ".join(t for idx, t in enumerate(tokens)
+                         if idx not in consumed)
+    return timedelta(seconds=total), remainder.strip()
+
+
+def extract_datetime_kab(text: str, anchorDate: Optional[datetime] = None,
+                         default_time=None):
+    """Extract a datetime from Kabyle text.
+
+    Understands the relative day words (azekka "tomorrow", iḍelli
+    "yesterday", ass-a "today"), weekday and month names, day-of-month
+    numbers and clock times ("13:04").
+    """
+    if not text:
+        return None
+    anchor = anchorDate or datetime.now()
+    tokens = [t.strip(".,!?;:") for t in text.lower().split()]
+    norm = [_normalize(t) for t in tokens]
+
+    date_found = False
+    result = anchor
+    consumed = set()
+
+    rel_days = {_normalize(k): v for k, v in _RELATIVE_DAYS.items()}
+    weekdays = {_normalize(v): k for k, v in WEEKDAYS_KAB.items()}
+    months = {_normalize(v): k for k, v in MONTHS_KAB.items()}
+
+    for i, tok in enumerate(norm):
+        if tok in rel_days:
+            result = anchor + timedelta(days=rel_days[tok])
+            date_found = True
+            consumed.add(i)
+        elif tok in weekdays:
+            target = weekdays[tok]
+            diff = (target - anchor.weekday()) % 7 or 7
+            result = anchor + timedelta(days=diff)
+            date_found = True
+            consumed.add(i)
+        elif tok in months:
+            month = months[tok]
+            day = None
+            for j in (i - 1, i + 1):
+                if 0 <= j < len(tokens):
+                    if j == i + 1 and norm[j] == "n" and j + 1 < len(tokens):
+                        j += 1
+                    val = extract_number_kab(tokens[j])
+                    if val and float(val).is_integer() and 1 <= val <= 31:
+                        day = int(val)
+                        consumed.add(j)
+                        break
+            year = anchor.year
+            if datetime(year, month, day or 1) < anchor.replace(
+                    hour=0, minute=0, second=0, microsecond=0):
+                year += 1
+            result = result.replace(year=year, month=month, day=day or 1)
+            date_found = True
+            consumed.add(i)
+
+    time_found = False
+    for i, tok in enumerate(tokens):
+        m = re.fullmatch(r"(\d{1,2}):(\d{2})", tok)
+        if m:
+            hour, minute = int(m.group(1)), int(m.group(2))
+            if hour < 24 and minute < 60:
+                result = result.replace(hour=hour, minute=minute, second=0,
+                                        microsecond=0)
+                time_found = True
+                consumed.add(i)
+                break
+
+    if not date_found and not time_found:
+        return None
+    if not time_found:
+        if default_time:
+            result = result.replace(hour=default_time.hour,
+                                    minute=default_time.minute,
+                                    second=default_time.second,
+                                    microsecond=0)
+        else:
+            result = result.replace(hour=0, minute=0, second=0,
+                                    microsecond=0)
+    remainder = " ".join(t for idx, t in enumerate(tokens)
+                         if idx not in consumed)
+    return result, remainder.strip()

--- a/ovos_date_parser/res/kab/date_time.json
+++ b/ovos_date_parser/res/kab/date_time.json
@@ -1,0 +1,83 @@
+{
+  "decade_format": {
+    "default": "{number}"
+  },
+  "hundreds_format": {
+    "default": "{number}"
+  },
+  "thousand_format": {
+    "default": "{number}"
+  },
+  "year_format": {
+    "default": "{year} {bc}",
+    "bc": ""
+  },
+  "date_format": {
+    "date_full": "{weekday}, {day} {month} {formatted_year}",
+    "date_full_no_year": "{weekday}, {day} {month}",
+    "date_full_no_year_month": "{weekday}, {day}",
+    "today": "ass-a",
+    "tomorrow": "azekka",
+    "yesterday": "iḍelli"
+  },
+  "date_time_format": {
+    "date_time": "{formatted_date} {formatted_time}"
+  },
+  "weekday": {
+    "0": "letnayen",
+    "1": "ttlata",
+    "2": "laṛebɛa",
+    "3": "lexmis",
+    "4": "lǧemɛa",
+    "5": "ssebt",
+    "6": "lḥedd"
+  },
+  "date": {
+    "1": "yiwen",
+    "2": "sin",
+    "3": "kṛaḍ",
+    "4": "kuẓ",
+    "5": "semmus",
+    "6": "sḍis",
+    "7": "sa",
+    "8": "tam",
+    "9": "tẓa",
+    "10": "mraw",
+    "11": "ḥḍac",
+    "12": "tnac",
+    "13": "tleṭṭac",
+    "14": "ṛbeɛṭac",
+    "15": "xemseṭṭac",
+    "16": "seṭṭac",
+    "17": "sebeɛṭac",
+    "18": "temmenṭac",
+    "19": "tseɛṭac",
+    "20": "ɛecrin",
+    "21": "waḥed u ɛecrin",
+    "22": "tnayn u ɛecrin",
+    "23": "tlata u ɛecrin",
+    "24": "ṛebɛa u ɛecrin",
+    "25": "xemsa u ɛecrin",
+    "26": "setta u ɛecrin",
+    "27": "sebɛa u ɛecrin",
+    "28": "tmanya u ɛecrin",
+    "29": "tesɛa u ɛecrin",
+    "30": "tlatin",
+    "31": "waḥed u tlatin"
+  },
+  "month": {
+    "1": "yennayer",
+    "2": "fuṛar",
+    "3": "meɣres",
+    "4": "yebrir",
+    "5": "mayyu",
+    "6": "yunyu",
+    "7": "yulyu",
+    "8": "ɣuct",
+    "9": "ctembeṛ",
+    "10": "tubeṛ",
+    "11": "wambeṛ",
+    "12": "dujembeṛ"
+  },
+  "number": {}
+}

--- a/ovos_date_parser/res/kab/date_words.json
+++ b/ovos_date_parser/res/kab/date_words.json
@@ -1,0 +1,11 @@
+{
+  "now": "tura",
+  "second": "tasint",
+  "seconds": "tisinin",
+  "minute": "ddqiqa",
+  "minutes": "tesdidin",
+  "hour": "ssaɛa",
+  "hours": "tsaɛtin",
+  "day": "ass",
+  "days": "ussan"
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dateutil~=2.6
 quebra_frases>=0.3.7
-ovos-number-parser>=0.11.0a1,<1.0.0
+ovos-number-parser>=0.13.0a2,<1.0.0
 dateparser
 ovos-config

--- a/test/test_dates_kab.py
+++ b/test/test_dates_kab.py
@@ -1,0 +1,107 @@
+import unittest
+from datetime import datetime, timedelta
+
+from ovos_date_parser import (extract_datetime, extract_duration, nice_date,
+                              nice_month, nice_time, nice_weekday)
+
+ANCHOR = datetime(2017, 6, 27, 13, 4)  # a Tuesday
+
+
+class TestNiceTimeKab(unittest.TestCase):
+    def test_24hour(self):
+        self.assertEqual(nice_time(ANCHOR, "kab", use_24hour=True),
+                         "tleṭṭac d kuẓ")
+        self.assertEqual(
+            nice_time(datetime(2017, 6, 27, 8, 0), "kab", use_24hour=True),
+            "tam")
+
+    def test_12hour(self):
+        self.assertEqual(nice_time(ANCHOR, "kab"), "yiwen d kuẓ")
+        self.assertEqual(nice_time(ANCHOR, "kab", use_ampm=True),
+                         "yiwen d kuẓ tameddit")
+        self.assertEqual(
+            nice_time(datetime(2017, 6, 27, 9, 30), "kab", use_ampm=True),
+            "tẓa d tlatin ssbeḥ")
+
+    def test_display(self):
+        self.assertEqual(nice_time(ANCHOR, "kab", speech=False,
+                                   use_24hour=True), "13:04")
+
+
+class TestNiceDateKab(unittest.TestCase):
+    def test_weekday_month(self):
+        self.assertEqual(nice_weekday(ANCHOR, "kab").lower(), "ttlata")
+        self.assertEqual(nice_month(ANCHOR, "kab").lower(), "yunyu")
+
+    def test_relative_words(self):
+        self.assertEqual(nice_date(ANCHOR + timedelta(days=1), "kab",
+                                   now=ANCHOR), "azekka")
+        self.assertEqual(nice_date(ANCHOR, "kab", now=ANCHOR), "ass-a")
+        self.assertEqual(nice_date(ANCHOR - timedelta(days=1), "kab",
+                                   now=ANCHOR), "iḍelli")
+
+
+class TestExtractDurationKab(unittest.TestCase):
+    def test_digit_quantities(self):
+        self.assertEqual(extract_duration("10 n tesdidin", "kab")[0],
+                         timedelta(minutes=10))
+        self.assertEqual(extract_duration("5 n ddqiqa", "kab")[0],
+                         timedelta(minutes=5))
+
+    def test_spoken_quantities(self):
+        self.assertEqual(extract_duration("sin wussan", "kab")[0],
+                         timedelta(days=2))
+        self.assertEqual(extract_duration("snat n tsaɛtin", "kab")[0],
+                         timedelta(hours=2))
+        self.assertEqual(extract_duration("yiwen amalas", "kab")[0],
+                         timedelta(weeks=1))
+        self.assertEqual(extract_duration("tlatin tasint", "kab")[0],
+                         timedelta(seconds=30))
+
+    def test_remainder(self):
+        duration, remainder = extract_duration(
+            "sekker tanafa n 10 n tesdidin", "kab")
+        self.assertEqual(duration, timedelta(minutes=10))
+        self.assertNotIn("tesdidin", remainder)
+
+    def test_no_duration(self):
+        self.assertEqual(extract_duration("azul fell-awen", "kab"),
+                         (None, "azul fell-awen"))
+
+
+class TestExtractDatetimeKab(unittest.TestCase):
+    def test_relative_days(self):
+        result = extract_datetime("azekka", "kab", anchorDate=ANCHOR)
+        self.assertEqual(result[0].date(),
+                         (ANCHOR + timedelta(days=1)).date())
+        result = extract_datetime("iḍelli", "kab", anchorDate=ANCHOR)
+        self.assertEqual(result[0].date(),
+                         (ANCHOR - timedelta(days=1)).date())
+        result = extract_datetime("ass-a", "kab", anchorDate=ANCHOR)
+        self.assertEqual(result[0].date(), ANCHOR.date())
+
+    def test_weekday(self):
+        # anchor is a Tuesday; lexmis = Thursday
+        result = extract_datetime("ass n lexmis", "kab", anchorDate=ANCHOR)
+        self.assertEqual(result[0].weekday(), 3)
+        self.assertGreater(result[0].date(), ANCHOR.date())
+
+    def test_month_day(self):
+        result = extract_datetime("3 yennayer", "kab", anchorDate=ANCHOR)
+        self.assertEqual((result[0].month, result[0].day), (1, 3))
+        self.assertEqual(result[0].year, 2018)
+
+    def test_time(self):
+        result = extract_datetime("azekka 15:30", "kab", anchorDate=ANCHOR)
+        self.assertEqual(result[0].date(),
+                         (ANCHOR + timedelta(days=1)).date())
+        self.assertEqual((result[0].hour, result[0].minute), (15, 30))
+
+    def test_no_date(self):
+        self.assertIsNone(
+            extract_datetime("azul fell-awen amek tellam", "kab",
+                             anchorDate=ANCHOR))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_lang_parity.py
+++ b/test/test_lang_parity.py
@@ -11,8 +11,8 @@ from ovos_date_parser import (extract_datetime, extract_duration, nice_date,
                               nice_month, nice_relative_time, nice_time,
                               nice_weekday, nice_year, get_date_strings)
 
-LANGS = ["ar", "ast", "az", "ca", "cs", "da", "de", "en", "es", "eu", "fa", "fr", "gl",
-         "hu", "it", "nl", "pl", "pt", "ru", "sl", "sv", "uk"]
+LANGS = ["ar", "ast", "az", "ca", "cs", "da", "de", "en", "es", "eu", "fa", "fr",
+         "gl", "hu", "it", "kab", "nl", "pl", "pt", "ru", "sl", "sv", "uk"]
 
 ANCHOR = datetime(2017, 6, 27, 13, 4)
 
@@ -20,7 +20,7 @@ _TOMORROW = {
     "ar": "غداً", "ast": "mañana", "az": "sabah", "ca": "demà", "cs": "zítra", "da": "i morgen",
     "de": "morgen", "en": "tomorrow", "es": "mañana", "eu": "bihar",
     "fa": "فردا", "fr": "demain", "gl": "mañá", "hu": "holnap",
-    "it": "domani", "nl": "morgen", "pl": "jutro", "pt": "amanhã",
+    "it": "domani", "kab": "azekka", "nl": "morgen", "pl": "jutro", "pt": "amanhã",
     "ru": "завтра", "sl": "jutri", "sv": "imorgon", "uk": "завтра",
 }
 
@@ -29,7 +29,8 @@ _NO_DATE = {
     "da": "hej hvordan har du det", "de": "hallo wie geht es dir",
     "en": "hello how are you", "es": "hola qué tal", "eu": "kaixo zer moduz",
     "fa": "سلام چطوری", "fr": "bonjour ça va", "gl": "ola que tal",
-    "hu": "szia hogy vagy", "it": "ciao come stai", "nl": "hallo hoe gaat het",
+    "hu": "szia hogy vagy", "it": "ciao come stai",
+    "kab": "azul fell-awen amek tellam", "nl": "hallo hoe gaat het",
     "pl": "cześć jak się masz", "pt": "olá tudo bem", "ru": "привет как дела",
     "sl": "živjo kako si", "sv": "hej hur mår du", "uk": "привіт як справи",
 }
@@ -39,7 +40,7 @@ _DURATION_STRINGS = {
     "da": "10 minutter", "de": "10 minuten", "en": "10 minutes",
     "es": "10 minutos", "eu": "10 minutu", "fa": "۱۰ دقیقه",
     "fr": "10 minutes", "gl": "10 minutos", "hu": "10 perc",
-    "it": "10 minuti", "nl": "10 minuten", "pl": "10 minut",
+    "it": "10 minuti", "kab": "10 n tesdidin", "nl": "10 minuten", "pl": "10 minut",
     "pt": "10 minutos", "ru": "10 минут", "sl": "10 minut",
     "sv": "10 minuter", "uk": "10 хвилин",
 }


### PR DESCRIPTION
Adds Kabyle (Taqbaylit, `kab`) support: `nice_time_kab`, `extract_duration_kab`, `extract_datetime_kab`, and `res/kab/date_time.json` + `res/kab/date_words.json` so the resource-driven `nice_date` family and the generic duration/relative-time helpers work.

## Vocabulary decisions

- **Weekdays**: the Arabic-derived names in everyday use — `letnayen`, `ttlata`, `laṛebɛa`, `lexmis`, `lǧemɛa`, `ssebt`, `lḥedd`.
- **Months**: Kabyle calendar spellings — `yennayer`, `fuṛar`, `meɣres`, `yebrir`, `mayyu`, `yunyu`, `yulyu`, `ɣuct`, `ctembeṛ`, `tubeṛ`, `wambeṛ`, `dujembeṛ`.
- **Relative days**: `azekka` (tomorrow), `iḍelli` (yesterday), `ass-a` (today).
- **Time units**: duration extraction accepts both the Amazigh neologisms (`tasint` second, `asrag` hour, `amalas` week) and the Arabic-derived words carrying daily usage (`ddqiqa` minute, `ssaɛa` hour), with the genitive particle `n` between quantity and unit (`10 n tesdidin`).
- `nice_time` joins hour and minutes with the conjunction `d` (`tleṭṭac d kuẓ` = 13:04); `use_ampm` appends `ssbeḥ` (morning) / `tameddit` (evening).
- Day-of-month words in `date_time.json` come from `pronounce_number` for `kab` (ovos-number-parser >= 0.13.0a2, floor pin bumped).

## Coverage boundary

Years are rendered in digits — no verified spoken-year formulation. `extract_datetime` covers relative day words, weekday/month names with day numbers, and digit clock times; spoken clock phrases, year words and a BC-era word are not attested in the sources used and are omitted. Documented in `docs/languages.md`.

## Sources

- https://kab.wikipedia.org/wiki/Yennayer — month names
- https://apprendrelekabyle.com/les-jours-de-la-semaine-en-kabyle/ — weekday names
- https://glosbe.com/fr/kab — heure (`ssaɛa`, `asrag`), minute (`ddqiqa`), minutes (`tesdidin`), seconde (`tasint`), semaine (`amalas`, `ddurt`), matin (`ssbeḥ`), soir (`tameddit`)
- https://www.targumi.com/vocabulaire/kabyle — `ass-a`, `iḍelli`, `azekka`, `snat n tsaɛtin`
- https://en.wikipedia.org/wiki/Kabyle_language — grammar (conjunction `d`, genitive `n`)

## Tests

- `test/test_dates_kab.py`: hand-verified anchors for nice_time (24h/12h/ampm/display), nice_date relative words, weekday/month names, duration extraction (digit and spoken quantities, both unit systems, remainder handling) and datetime extraction (relative days, weekday, month+day with year rollover, clock time, no-date)
- `kab` added to `test/test_lang_parity.py` LANGS with tomorrow (`azekka`), no-date and duration (`10 n tesdidin`) anchor strings

This PR was authored with Claude (Fable 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
