### PR TITLE
refactor: port Slavic and Turkic durations to the shared engine

### DIFF
--- a/ovos_date_parser/__init__.py
+++ b/ovos_date_parser/__init__.py
@@ -239,22 +239,12 @@ def extract_duration(
         return extract_duration_ar(text)
     if lang.startswith("ast"):
         return extract_duration_ast(text)
-    if lang.startswith("az"):
-        return extract_duration_az(text)
-    if lang.startswith("cs"):
-        return extract_duration_cs(text)
     if lang.startswith("kab"):
         return extract_duration_kab(text)
     if lang.startswith("fa"):
         return extract_duration_fa(text)
-    if lang.startswith("pl"):
-        return extract_duration_pl(text)
-    if lang.startswith("ru"):
-        return extract_duration_ru(text)
     if lang.startswith("sv"):
         return extract_duration_sv(text)
-    if lang.startswith("uk"):
-        return extract_duration_uk(text)
     raise NotImplementedError(f"Unsupported language: {lang}")
 
 

--- a/ovos_date_parser/dates_az.py
+++ b/ovos_date_parser/dates_az.py
@@ -5,6 +5,9 @@ from dateutil.relativedelta import relativedelta
 from ovos_number_parser.numbers_az import pronounce_number_az, extract_number_az, numbers_to_digits_az
 from ovos_number_parser.util import is_numeric
 from ovos_utils.time import now_local
+from ovos_date_parser.duration import (
+    DurationResolution, DURATION_LEXICONS, extract_duration_generic
+)
 
 _HARD_VOWELS = ['a', 'ı', 'o', 'u']
 _SOFT_VOWELS = ['e', 'ə', 'i', 'ö', 'ü']
@@ -213,70 +216,26 @@ def nice_duration_az(duration, speech=True):
     return out
 
 
-def extract_duration_az(text):
+def extract_duration_az(text, resolution=DurationResolution.TIMEDELTA,
+                        replace_token=""):
     """
-    Convert an azerbaijani phrase into a number of seconds
+    Convert a phrase into a duration and return the remainder text.
 
-    Convert things like:
-        "10 dəqiqə"
-        "2 yarım saat"
-        "3 gün 8 saat 10 dəqiqə 49 saniyə"
-    into an int, representing the total number of seconds.
-
-    The words used in the duration will be consumed, and
-    the remainder returned.
-
-    As an example, "5 dəqiqəyə taymer qur" would return
-    (300, "taymer qur").
+    The words used in the duration are consumed, the remainder of the
+    text is returned. Returns None for empty input; the duration is
+    None if no duration was found.
 
     Args:
-        text (str): string containing a duration
-
+        text (str): string containing a duration.
+        resolution (DurationResolution): format to return the duration in.
+        replace_token (str): string each consumed duration is replaced with.
     Returns:
-        (timedelta, str):
-                    A tuple containing the duration and the remaining text
-                    not consumed in the parsing. The first value will
-                    be None if no duration is found. The text returned
-                    will have whitespace stripped from the ends.
+        (duration, str): the duration (timedelta, relativedelta or float
+                         depending on resolution) and the remaining
+                         unconsumed text.
     """
-    if not text:
-        return None
-
-    time_units = {
-        'microseconds': 0,
-        'milliseconds': 0,
-        'seconds': 0,
-        'minutes': 0,
-        'hours': 0,
-        'days': 0,
-        'weeks': 0
-    }
-
-    time_units_az = {
-        'mikrosaniyə': 'microseconds',
-        'milisaniyə': 'milliseconds',
-        'saniyə': 'seconds',
-        'dəqiqə': 'minutes',
-        'saat': 'hours',
-        'gün': 'days',
-        'həftə': 'weeks'
-    }
-
-    pattern = r"(?P<value>\d+(?:\.?\d+)?)(?:\s+|\-){unit}?(?:yə|a|ə)?(?:(?:\s|,)+)?(?P<half>yarım|0\.5)?(?:a)?"
-    text = numbers_to_digits_az(text)
-    for unit_az in time_units_az:
-        unit_pattern = pattern.format(unit=unit_az)
-
-        def repl(match):
-            time_units[time_units_az[unit_az]] += float(match.group(1)) + (0.5 if match.group(2) else 0)
-            return ''
-
-        text = re.sub(unit_pattern, repl, text)
-
-    text = text.strip()
-    duration = timedelta(**time_units) if any(time_units.values()) else None
-
-    return (duration, text)
+    return extract_duration_generic(text, DURATION_LEXICONS["az"],
+                                    resolution, replace_token)
 
 
 def extract_datetime_az(text, anchorDate=None, default_time=None):

--- a/ovos_date_parser/dates_cs.py
+++ b/ovos_date_parser/dates_cs.py
@@ -6,6 +6,9 @@ from ovos_number_parser.numbers_cs import pronounce_number_cs, _ORDINAL_BASE_CS,
     numbers_to_digits_cs
 from ovos_number_parser.util import is_numeric
 from ovos_utils.time import now_local
+from ovos_date_parser.duration import (
+    DurationResolution, DURATION_LEXICONS, extract_duration_generic
+)
 
 _MONTHS_CONVERSION = {
     0: "january",
@@ -132,64 +135,26 @@ def nice_time_cs(dt, speech=True, use_24hour=True, use_ampm=False):
         return speak
 
 
-def extract_duration_cs(text):
+def extract_duration_cs(text, resolution=DurationResolution.TIMEDELTA,
+                        replace_token=""):
     """
-    Convert an english phrase into a number of seconds
+    Convert a phrase into a duration and return the remainder text.
 
-    Convert things like:
-        "10 minute"
-        "2 and a half hours"
-        "3 days 8 hours 10 minutes and 49 seconds"
-    into an int, representing the total number of seconds.
-
-    The words used in the duration will be consumed, and
-    the remainder returned.
-
-    As an example, "set a timer for 5 minutes" would return
-    (300, "set a timer for").
+    The words used in the duration are consumed, the remainder of the
+    text is returned. Returns None for empty input; the duration is
+    None if no duration was found.
 
     Args:
-        text (str): string containing a duration
-
+        text (str): string containing a duration.
+        resolution (DurationResolution): format to return the duration in.
+        replace_token (str): string each consumed duration is replaced with.
     Returns:
-        (timedelta, str):
-                    A tuple containing the duration and the remaining text
-                    not consumed in the parsing. The first value will
-                    be None if no duration is found. The text returned
-                    will have whitespace stripped from the ends.
+        (duration, str): the duration (timedelta, relativedelta or float
+                         depending on resolution) and the remaining
+                         unconsumed text.
     """
-    if not text:
-        return None
-
-    # Czech inflection for time: minuta,minuty,minut - safe to use minut as pattern
-    # For day: den, dny, dnů - short patern not applicable, list all
-
-    time_units = {
-        'microseconds': 0,
-        'milliseconds': 0,
-        'seconds': 0,
-        'minutes': 0,
-        'hours': 0,
-        'days': 0,
-        'weeks': 0
-    }
-
-    pattern = r"(?P<value>\d+(?:\.?\d+)?)(?:\s+|\-){unit}[ay]?"
-    text = numbers_to_digits_cs(text)
-
-    for (unit_cs, unit_en) in _TIME_UNITS_CONVERSION.items():
-        unit_pattern = pattern.format(unit=unit_cs)
-
-        def repl(match):
-            time_units[unit_en] += float(match.group(1))
-            return ''
-
-        text = re.sub(unit_pattern, repl, text)
-
-    text = text.strip()
-    duration = timedelta(**time_units) if any(time_units.values()) else None
-
-    return (duration, text)
+    return extract_duration_generic(text, DURATION_LEXICONS["cs"],
+                                    resolution, replace_token)
 
 
 def extract_datetime_cs(text, anchorDate=None, default_time=None):

--- a/ovos_date_parser/dates_pl.py
+++ b/ovos_date_parser/dates_pl.py
@@ -5,6 +5,9 @@ from dateutil.relativedelta import relativedelta
 from ovos_number_parser.numbers_pl import pronounce_number_pl, extract_number_pl, numbers_to_digits_pl
 from ovos_number_parser.util import is_numeric
 from ovos_utils.time import now_local
+from ovos_date_parser.duration import (
+    DurationResolution, DURATION_LEXICONS, extract_duration_generic
+)
 
 _TIME_UNITS_CONVERSION = {
     'mikrosekund': 'microseconds',
@@ -372,61 +375,26 @@ def get_pronounce_number_for_duration(num):
     return 'jedna' if pronounced == 'jeden' else pronounced
 
 
-def extract_duration_pl(text):
+def extract_duration_pl(text, resolution=DurationResolution.TIMEDELTA,
+                        replace_token=""):
     """
-    Convert an english phrase into a number of seconds
+    Convert a phrase into a duration and return the remainder text.
 
-    Convert things like:
-        "10 minute"
-        "2 and a half hours"
-        "3 days 8 hours 10 minutes and 49 seconds"
-    into an int, representing the total number of seconds.
-
-    The words used in the duration will be consumed, and
-    the remainder returned.
-
-    As an example, "set a timer for 5 minutes" would return
-    (300, "set a timer for").
+    The words used in the duration are consumed, the remainder of the
+    text is returned. Returns None for empty input; the duration is
+    None if no duration was found.
 
     Args:
-        text (str): string containing a duration
-
+        text (str): string containing a duration.
+        resolution (DurationResolution): format to return the duration in.
+        replace_token (str): string each consumed duration is replaced with.
     Returns:
-        (timedelta, str):
-                    A tuple containing the duration and the remaining text
-                    not consumed in the parsing. The first value will
-                    be None if no duration is found. The text returned
-                    will have whitespace stripped from the ends.
+        (duration, str): the duration (timedelta, relativedelta or float
+                         depending on resolution) and the remaining
+                         unconsumed text.
     """
-    if not text:
-        return None
-
-    time_units = {
-        'microseconds': None,
-        'milliseconds': None,
-        'seconds': None,
-        'minutes': None,
-        'hours': None,
-        'days': None,
-        'weeks': None
-    }
-
-    pattern = r"(?P<value>\d+(?:\.?\d+)?)(?:\s+|\-){unit}[ayeę]?"
-    text = numbers_to_digits_pl(text)
-
-    for unit in _TIME_UNITS_CONVERSION:
-        unit_pattern = pattern.format(unit=unit)
-        matches = re.findall(unit_pattern, text)
-        value = sum(map(float, matches))
-        unit_en = _TIME_UNITS_CONVERSION.get(unit)
-        if time_units[unit_en] is None or time_units.get(unit_en) == 0:
-            time_units[unit_en] = value
-        text = re.sub(unit_pattern, '', text)
-
-    text = text.strip()
-    duration = timedelta(**time_units) if any(time_units.values()) else None
-
-    return (duration, text)
+    return extract_duration_generic(text, DURATION_LEXICONS["pl"],
+                                    resolution, replace_token)
 
 
 def extract_datetime_pl(string, anchorDate=None, default_time=None):

--- a/ovos_date_parser/dates_ru.py
+++ b/ovos_date_parser/dates_ru.py
@@ -6,6 +6,9 @@ from ovos_number_parser.numbers_ru import pronounce_number_ru, _ORDINAL_BASE_RU,
     numbers_to_digits_ru
 from ovos_number_parser.util import is_numeric
 from ovos_utils.time import now_local
+from ovos_date_parser.duration import (
+    DurationResolution, DURATION_LEXICONS, extract_duration_generic
+)
 
 _MONTHS_CONVERSION = {
     0: "january",
@@ -243,64 +246,26 @@ def pronounce_hour_ru(num):
     return pronounce_number_ru(num)
 
 
-def extract_duration_ru(text):
+def extract_duration_ru(text, resolution=DurationResolution.TIMEDELTA,
+                        replace_token=""):
     """
-    Convert an english phrase into a number of seconds
+    Convert a phrase into a duration and return the remainder text.
 
-    Convert things like:
-        "10 minute"
-        "2 and a half hours"
-        "3 days 8 hours 10 minutes and 49 seconds"
-    into an int, representing the total number of seconds.
-
-    The words used in the duration will be consumed, and
-    the remainder returned.
-
-    As an example, "set a timer for 5 minutes" would return
-    (300, "set a timer for").
+    The words used in the duration are consumed, the remainder of the
+    text is returned. Returns None for empty input; the duration is
+    None if no duration was found.
 
     Args:
-        text (str): string containing a duration
-
+        text (str): string containing a duration.
+        resolution (DurationResolution): format to return the duration in.
+        replace_token (str): string each consumed duration is replaced with.
     Returns:
-        (timedelta, str):
-                    A tuple containing the duration and the remaining text
-                    not consumed in the parsing. The first value will
-                    be None if no duration is found. The text returned
-                    will have whitespace stripped from the ends.
+        (duration, str): the duration (timedelta, relativedelta or float
+                         depending on resolution) and the remaining
+                         unconsumed text.
     """
-    if not text:
-        return None
-
-    # Russian inflection for time: минута, минуты, минут - safe to use минута as pattern
-    # For day: день, дня, дней - short pattern not applicable, list all
-
-    time_units = {
-        'microseconds': 0,
-        'milliseconds': 0,
-        'seconds': 0,
-        'minutes': 0,
-        'hours': 0,
-        'days': 0,
-        'weeks': 0
-    }
-
-    pattern = r"(?P<value>\d+(?:\.?\d+)?)(?:\s+|\-){unit}(?:а|ов|у|ут|уту)?"
-    text = numbers_to_digits_ru(text)
-
-    for (unit_ru, unit_en) in _TIME_UNITS_CONVERSION.items():
-        unit_pattern = pattern.format(unit=unit_ru)
-
-        def repl(match):
-            time_units[unit_en] += float(match.group(1))
-            return ''
-
-        text = re.sub(unit_pattern, repl, text)
-
-    text = text.strip()
-    duration = timedelta(**time_units) if any(time_units.values()) else None
-
-    return duration, text
+    return extract_duration_generic(text, DURATION_LEXICONS["ru"],
+                                    resolution, replace_token)
 
 
 def extract_datetime_ru(text, anchor_date=None, default_time=None):

--- a/ovos_date_parser/dates_uk.py
+++ b/ovos_date_parser/dates_uk.py
@@ -6,6 +6,9 @@ from ovos_number_parser.numbers_uk import extract_number_uk, numbers_to_digits_u
     _NUM_STRING_UK
 from ovos_number_parser.util import invert_dict, is_numeric
 from ovos_utils.time import now_local
+from ovos_date_parser.duration import (
+    DurationResolution, DURATION_LEXICONS, extract_duration_generic
+)
 
 # hours
 HOURS_UK = {
@@ -163,69 +166,26 @@ _STRING_NUM_UK.update({
 })
 
 
-def extract_duration_uk(text):
+def extract_duration_uk(text, resolution=DurationResolution.TIMEDELTA,
+                        replace_token=""):
     """
-    Convert an english phrase into a number of seconds
+    Convert a phrase into a duration and return the remainder text.
 
-    Convert things like:
-        "10 minute"
-        "2 and a half hours"
-        "3 days 8 hours 10 minutes and 49 seconds"
-    into an int, representing the total number of seconds.
-
-    The words used in the duration will be consumed, and
-    the remainder returned.
-
-    As an example, "set a timer for 5 minutes" would return
-    (300, "set a timer for").
+    The words used in the duration are consumed, the remainder of the
+    text is returned. Returns None for empty input; the duration is
+    None if no duration was found.
 
     Args:
-        text (str): string containing a duration
-
+        text (str): string containing a duration.
+        resolution (DurationResolution): format to return the duration in.
+        replace_token (str): string each consumed duration is replaced with.
     Returns:
-        (timedelta, str):
-                    A tuple containing the duration and the remaining text
-                    not consumed in the parsing. The first value will
-                    be None if no duration is found. The text returned
-                    will have whitespace stripped from the ends.
+        (duration, str): the duration (timedelta, relativedelta or float
+                         depending on resolution) and the remaining
+                         unconsumed text.
     """
-    if not text:
-        return None
-
-    # Ukrainian inflection for time: хвилина, хвилини, хвилин - safe to use хвилина as pattern
-    # For day: день, дня, днів - short pattern not applicable, list all
-
-    time_units = {
-        'microseconds': 0,
-        'milliseconds': 0,
-        'seconds': 0,
-        'minutes': 0,
-        'hours': 0,
-        'days': 0,
-        'weeks': 0
-    }
-
-    pattern = r"(?P<value>\d+(?:\.?\d+)?)(?:\s+|\-){unit}(?:ів|я|и|ин|і|унд|ни|ну|ку|дні|у|днів)?"
-    text = numbers_to_digits_uk(text)
-
-    for (unit_uk, unit_en) in _TIME_UNITS_CONVERSION.items():
-        unit_pattern = pattern.format(unit=unit_uk)
-
-        def repl(match):
-            time_units[unit_en] += float(match.group(1))
-            return ''
-
-        text = re.sub(unit_pattern, repl, text)
-
-    new_text = []
-    tokens_in_result_text = text.split(' ')
-    for token in tokens_in_result_text:
-        if not token.isdigit():
-            new_text.append(token)
-    text = " ".join(new_text).strip()
-    duration = timedelta(**time_units) if any(time_units.values()) else None
-
-    return duration, text
+    return extract_duration_generic(text, DURATION_LEXICONS["uk"],
+                                    resolution, replace_token)
 
 
 def extract_datetime_uk(text, anchor_date=None, default_time=None):

--- a/ovos_date_parser/duration.py
+++ b/ovos_date_parser/duration.py
@@ -502,3 +502,66 @@ register_duration_lexicon(DurationLexicon(
         "centuries": r"århundrede(?:r|s)?",
         "millenniums": r"årtusinde(?:r|s)?",
     }))
+
+
+register_duration_lexicon(DurationLexicon(
+    lang="cs",
+    units={
+        "microseconds": r"mikrosekund[ay]?",
+        "milliseconds": r"milisekund[ay]?",
+        "seconds": r"sekund(?:u|y|a)?",
+        "minutes": r"minut(?:u|y|a)?",
+        "hours": r"hodin[ay]?",
+        "days": r"(?:den|dny|dnů|dní|dne)",
+        "weeks": r"(?:týden|týdny|týdnů)",
+    }))
+
+register_duration_lexicon(DurationLexicon(
+    lang="pl",
+    units={
+        "microseconds": r"mikrosekund(?:y|a|ę)?",
+        "milliseconds": r"milisekund(?:y|a|ę)?",
+        "seconds": r"sekund(?:y|a|ę)?",
+        "minutes": r"minut(?:y|a|ę)?",
+        "hours": r"godzin(?:y|a|ę)?",
+        "days": r"(?:dzień|dni[aeę]?)",
+        "weeks": r"(?:tydzień|tygodni(?:e|u|a)?)",
+    }))
+
+register_duration_lexicon(DurationLexicon(
+    lang="ru",
+    units={
+        "microseconds": r"микросекунд(?:а|ы|у)?",
+        "milliseconds": r"мил(?:л)?исекунд(?:а|ы|у)?",
+        "seconds": r"секунд(?:а|ы|у)?",
+        "minutes": r"минут(?:а|ы|у)?",
+        "hours": r"(?:час(?:а|ов|у)?|годин(?:а|ы|ой|ами|е|у)?)",
+        "days": r"(?:день|дня|дней|дню)",
+        "weeks": r"недел(?:я|и|ь|ю|ей)?",
+    }))
+
+register_duration_lexicon(DurationLexicon(
+    lang="uk",
+    units={
+        "microseconds": r"мікросекунд(?:а|и|у)?",
+        "milliseconds": r"мілісекунд(?:а|и|у)?",
+        "seconds": r"секунд(?:а|и|у)?",
+        "minutes": r"хвилин(?:а|и|у)?",
+        "hours": r"годин(?:а|и|у|ами|ою)?",
+        "days": r"(?:днів|день|дні|дня|дню)",
+        "weeks": r"(?:тиждень|тижн(?:я|і|ів|ю))",
+    }))
+
+register_duration_lexicon(DurationLexicon(
+    lang="az",
+    pattern_template=r"(?P<value>\d+(?:\.?\d+)?)(?:\s+|\-)(?:{unit})"
+                     r"(?:yə|a|ə)?(?:(?:\s|,)+)?(?P<half>yarım|0\.5)?(?:a)?",
+    units={
+        "microseconds": r"mikrosaniyə",
+        "milliseconds": r"milisaniyə",
+        "seconds": r"saniyə",
+        "minutes": r"dəqiqə",
+        "hours": r"saat",
+        "days": r"gün",
+        "weeks": r"həftə",
+    }))


### PR DESCRIPTION
Moves Czech, Polish, Russian, Ukrainian and Azerbaijani `extract_duration` onto the shared `DurationLexicon` engine from #119, deleting the per-language regex loops. All five languages gain the `DurationResolution` and `replace_token` parameters. The declined surface forms from the legacy `_TIME_UNITS_CONVERSION` tables become per-unit regex fragments.

## Behavior fixes folded in

- **pl**: repeated mentions of the same unit now accumulate ("2 minuty i 3 minuty" sums to 5); the legacy loop kept only the first non-zero match per unit.
- **az**: the unit word is now required — the legacy pattern marked it optional, letting a bare number match as a duration; the "yarım" (half) suffix handling is preserved via the pattern-template override.
- **uk**: the remainder text no longer silently drops every standalone digit token that was not part of a duration.

Persian and Swedish stay on their legacy token-based parsers: both implement vocabulary the regex engine cannot express yet (Persian numeral parsing; Swedish "en kvart"/"halvtimme" idioms plus adjacent-number folding that the generic Swedish number normalizer mangles). They keep rejecting the new keyword parameters explicitly.

Every port was differentially tested against the legacy implementation on hand-written sample phrases per language in addition to the existing suites.

## Tests

Full suite: 334 passed, 2 skipped — identical to dev; no expectations changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)