### PR TITLE
feat: calendar range, season and date-ordinal utilities

### DIFF
--- a/ovos_date_parser/__init__.py
+++ b/ovos_date_parser/__init__.py
@@ -15,6 +15,13 @@ from ovos_date_parser.common import nice_duration_generic, nice_relative_time_ge
 from ovos_date_parser.dates_ar import (
     extract_datetime_ar, extract_duration_ar, nice_time_ar, nice_duration_ar,
 )
+from ovos_date_parser.ranges import (
+    Hemisphere, Season, DateTimeResolution, BEFORE_PRESENT_EPOCH,
+    get_week_range, get_weekend_range, get_month_range, get_year_range,
+    get_decade_range, get_century_range, get_millennium_range,
+    get_season_range, get_week_number, get_date_ordinal,
+    date_to_season, season_to_date, next_season_date, last_season_date,
+)
 from ovos_date_parser.duration import (
     DurationResolution, DurationLexicon, DURATION_LEXICONS, extract_duration_generic
 )

--- a/ovos_date_parser/ranges.py
+++ b/ovos_date_parser/ranges.py
@@ -1,0 +1,483 @@
+"""Language-agnostic calendar range and season utilities.
+
+Ranges are inclusive ``(start, end)`` tuples of the same type as the
+reference date passed in. Decades, centuries and millennia follow the
+calendar convention (the 1990s are 1990-1999, the 1900s are 1900-1999).
+
+Seasons are meteorological (month-aligned) and hemisphere-aware: northern
+spring starts March 1st, southern spring starts September 1st.
+"""
+from datetime import date, datetime, timedelta
+from enum import Enum
+from typing import Optional, Tuple, Union
+
+from dateutil.relativedelta import relativedelta
+from ovos_utils.time import now_local
+
+
+class Hemisphere(Enum):
+    NORTH = 0
+    SOUTH = 1
+
+
+class Season(Enum):
+    SPRING = 0
+    SUMMER = 1
+    FALL = 2
+    WINTER = 3
+    AUTUMN = 2
+
+
+class DateTimeResolution(Enum):
+    """Granularity for :func:`get_date_ordinal`.
+
+    ``UNIT`` counts from the start of the calendar (ordinal 1 = year 1);
+    ``UNIT_OF_SCOPE`` counts inside the scope containing the reference
+    date; ``BEFORE_PRESENT_UNIT`` counts backwards from the before-present
+    reference epoch (January 1st 1950).
+    """
+    DAY = 0
+    DAY_OF_MONTH = 1
+    DAY_OF_YEAR = 2
+    DAY_OF_DECADE = 3
+    DAY_OF_CENTURY = 4
+    DAY_OF_MILLENNIUM = 5
+
+    WEEK = 6
+    WEEK_OF_MONTH = 7
+    WEEK_OF_YEAR = 8
+    WEEK_OF_DECADE = 9
+    WEEK_OF_CENTURY = 10
+    WEEK_OF_MILLENNIUM = 11
+
+    MONTH = 12
+    MONTH_OF_YEAR = 13
+    MONTH_OF_DECADE = 14
+    MONTH_OF_CENTURY = 15
+    MONTH_OF_MILLENNIUM = 16
+
+    YEAR = 17
+    YEAR_OF_DECADE = 18
+    YEAR_OF_CENTURY = 19
+    YEAR_OF_MILLENNIUM = 20
+
+    DECADE = 21
+    DECADE_OF_CENTURY = 22
+    DECADE_OF_MILLENNIUM = 23
+
+    CENTURY = 24
+    CENTURY_OF_MILLENNIUM = 25
+
+    MILLENNIUM = 26
+
+    BEFORE_PRESENT_DAY = 27
+    BEFORE_PRESENT_WEEK = 28
+    BEFORE_PRESENT_MONTH = 29
+    BEFORE_PRESENT_YEAR = 30
+    BEFORE_PRESENT_DECADE = 31
+    BEFORE_PRESENT_CENTURY = 32
+    BEFORE_PRESENT_MILLENNIUM = 33
+
+
+# before-present reference epoch (as in radiocarbon dating)
+BEFORE_PRESENT_EPOCH = date(year=1950, day=1, month=1)
+
+DateRange = Tuple[date, date]
+
+
+def get_week_range(ref_date: date) -> DateRange:
+    """Monday..Sunday range of the week containing ``ref_date``."""
+    start = ref_date - timedelta(days=ref_date.weekday())
+    end = start + timedelta(days=6)
+    return start, end
+
+
+def get_weekend_range(ref_date: date) -> DateRange:
+    """Saturday..Sunday of the weekend containing or following ``ref_date``.
+
+    During the week this is the upcoming weekend; on a weekend day it is
+    the current weekend.
+    """
+    if ref_date.weekday() == 5:
+        start = ref_date
+    elif ref_date.weekday() == 6:
+        start = ref_date - timedelta(days=1)
+    else:
+        start = get_week_range(ref_date)[0] + timedelta(days=5)
+    return start, start + timedelta(days=1)
+
+
+def get_month_range(ref_date: date) -> DateRange:
+    """First..last day of the month containing ``ref_date``."""
+    start = ref_date.replace(day=1)
+    if ref_date.month == 12:
+        end = ref_date.replace(day=31)
+    else:
+        end = ref_date.replace(day=1, month=ref_date.month + 1) - \
+            timedelta(days=1)
+    return start, end
+
+
+def get_year_range(ref_date: date) -> DateRange:
+    """January 1st..December 31st of the year containing ``ref_date``."""
+    return (ref_date.replace(day=1, month=1),
+            ref_date.replace(day=31, month=12))
+
+
+def get_decade_range(ref_date: date) -> DateRange:
+    """Calendar decade containing ``ref_date`` (1990s = 1990-1999)."""
+    start = date(day=1, month=1, year=(ref_date.year // 10) * 10)
+    end = date(day=31, month=12, year=start.year + 9)
+    return start, end
+
+
+def get_century_range(ref_date: date) -> DateRange:
+    """Calendar century containing ``ref_date`` (1900s = 1900-1999)."""
+    start = date(day=1, month=1, year=(ref_date.year // 100) * 100)
+    end = date(day=31, month=12, year=start.year + 99)
+    return start, end
+
+
+def get_millennium_range(ref_date: date) -> DateRange:
+    """Calendar millennium containing ``ref_date`` (1000-1999)."""
+    start = date(day=1, month=1, year=(ref_date.year // 1000) * 1000)
+    end = date(day=31, month=12, year=start.year + 999)
+    return start, end
+
+
+def get_week_number(ref_date: Optional[date] = None) -> int:
+    """ISO-8601 week number of ``ref_date`` (default: today)."""
+    ref_date = ref_date or now_local()
+    return ref_date.isocalendar()[1]
+
+
+def _as_date(ref_date: Union[date, datetime]) -> date:
+    if isinstance(ref_date, datetime):
+        return ref_date.date()
+    return ref_date
+
+
+# meteorological season boundaries: {season: (start_month, end_month)}
+# northern hemisphere; the southern hemisphere is shifted by two seasons
+_NORTH_SEASONS = {
+    Season.SPRING: (3, 5),
+    Season.SUMMER: (6, 8),
+    Season.FALL: (9, 11),
+}
+_SOUTH_SEASONS = {
+    Season.FALL: (3, 5),
+    Season.WINTER: (6, 8),
+    Season.SPRING: (9, 11),
+}
+# season starting in December, wrapping over the new year
+_NORTH_WRAP = Season.WINTER
+_SOUTH_WRAP = Season.SUMMER
+
+
+def date_to_season(ref_date: Optional[date] = None,
+                   hemisphere: Hemisphere = Hemisphere.NORTH) -> Season:
+    """Meteorological season containing ``ref_date`` (default: today)."""
+    ref_date = _as_date(ref_date or now_local().date())
+    seasons = _NORTH_SEASONS if hemisphere == Hemisphere.NORTH \
+        else _SOUTH_SEASONS
+    for season, (first, last) in seasons.items():
+        if first <= ref_date.month <= last:
+            return season
+    return _NORTH_WRAP if hemisphere == Hemisphere.NORTH else _SOUTH_WRAP
+
+
+def season_to_date(season: Season, year: Optional[Union[int, date]] = None,
+                   hemisphere: Hemisphere = Hemisphere.NORTH) -> date:
+    """Start date of ``season`` in ``year`` (default: current year)."""
+    if year is None:
+        year = now_local().year
+    elif not isinstance(year, int):
+        year = year.year
+    seasons = _NORTH_SEASONS if hemisphere == Hemisphere.NORTH \
+        else _SOUTH_SEASONS
+    wrap = _NORTH_WRAP if hemisphere == Hemisphere.NORTH else _SOUTH_WRAP
+    season = Season(season.value) if isinstance(season, Season) \
+        else Season(season)
+    if season == wrap:
+        return date(day=1, month=12, year=year)
+    if season not in seasons:
+        raise ValueError(f"Unknown Season: {season}")
+    return date(day=1, month=seasons[season][0], year=year)
+
+
+def next_season_date(season: Season, ref_date: Optional[date] = None,
+                     hemisphere: Hemisphere = Hemisphere.NORTH) -> date:
+    """Next start date of ``season`` on or after ``ref_date``."""
+    ref_date = _as_date(ref_date or now_local().date())
+    start = season_to_date(season, ref_date, hemisphere)
+    if ref_date <= start:
+        return start
+    return season_to_date(season, ref_date.year + 1, hemisphere)
+
+
+def last_season_date(season: Season, ref_date: Optional[date] = None,
+                     hemisphere: Hemisphere = Hemisphere.NORTH) -> date:
+    """Most recent start date of ``season`` before ``ref_date``."""
+    ref_date = _as_date(ref_date or now_local().date())
+    start = season_to_date(season, ref_date, hemisphere)
+    if ref_date <= start:
+        return season_to_date(season, ref_date.year - 1, hemisphere)
+    return start
+
+
+def get_season_range(ref_date: Optional[date] = None,
+                     hemisphere: Hemisphere = Hemisphere.NORTH) -> DateRange:
+    """First..last day of the season containing ``ref_date``.
+
+    The December-starting season wraps the new year: its range runs from
+    December 1st to the last day of the following February (the 29th on
+    leap years).
+    """
+    ref_date = _as_date(ref_date or now_local().date())
+    seasons = _NORTH_SEASONS if hemisphere == Hemisphere.NORTH \
+        else _SOUTH_SEASONS
+    for first, last in seasons.values():
+        if first <= ref_date.month <= last:
+            start = date(day=1, month=first, year=ref_date.year)
+            end = date(day=1, month=last + 1, year=ref_date.year) - \
+                timedelta(days=1)
+            return start, end
+    # December..February wrap-around season
+    if ref_date.month == 12:
+        start = date(day=1, month=12, year=ref_date.year)
+    else:
+        start = date(day=1, month=12, year=ref_date.year - 1)
+    end = date(day=1, month=3, year=start.year + 1) - timedelta(days=1)
+    return start, end
+
+
+def get_date_ordinal(ordinal: int, ref_date: Optional[date] = None,
+                     resolution: DateTimeResolution =
+                     DateTimeResolution.DAY_OF_MONTH) -> date:
+    """Resolve "the Nth {unit} of {scope}" into a date.
+
+    Args:
+        ordinal: 1-based ordinal; -1 selects the last unit in the scope.
+        ref_date: reference date the containing scope is derived from
+            (default: today).
+        resolution: which unit/scope pair the ordinal refers to.
+
+    Returns:
+        The date of the requested unit (weeks resolve to their Monday,
+        months/years/decades/centuries/millennia to their first day).
+    """
+    ordinal = int(ordinal)
+    ref_date = _as_date(ref_date or now_local())
+
+    _decade = (ref_date.year // 10) * 10 or 1
+    _century = (ref_date.year // 100) * 100 or 1
+    _mil = (ref_date.year // 1000) * 1000 or 1
+
+    if resolution == DateTimeResolution.DAY:
+        if ordinal < 0:
+            raise OverflowError("The last day of existence can not be "
+                                "represented")
+        return date(year=1, day=1, month=1) + timedelta(days=ordinal - 1)
+    if resolution == DateTimeResolution.DAY_OF_MONTH:
+        if ordinal == -1:
+            return get_month_range(ref_date)[1]
+        return ref_date.replace(day=ordinal)
+    if resolution == DateTimeResolution.DAY_OF_YEAR:
+        if ordinal == -1:
+            return date(year=ref_date.year, day=31, month=12)
+        return date(year=ref_date.year, day=1, month=1) + \
+            timedelta(days=ordinal - 1)
+    if resolution == DateTimeResolution.DAY_OF_DECADE:
+        if ordinal == -1:
+            return date(year=_decade + 9, day=31, month=12)
+        return date(year=_decade, day=1, month=1) + \
+            timedelta(days=ordinal - 1)
+    if resolution == DateTimeResolution.DAY_OF_CENTURY:
+        if ordinal == -1:
+            return date(year=_century + 99, day=31, month=12)
+        return date(year=_century, day=1, month=1) + \
+            timedelta(days=ordinal - 1)
+    if resolution == DateTimeResolution.DAY_OF_MILLENNIUM:
+        if ordinal == -1:
+            return date(year=_mil + 999, day=31, month=12)
+        return date(year=_mil, day=1, month=1) + timedelta(days=ordinal - 1)
+
+    if resolution == DateTimeResolution.WEEK:
+        if ordinal < 0:
+            raise OverflowError("The last week of existence can not be "
+                                "represented")
+        _day = date(1, 1, 1) + relativedelta(weeks=ordinal) - \
+            timedelta(days=1)
+        return get_week_range(_day)[0]
+    if resolution == DateTimeResolution.WEEK_OF_MONTH:
+        if ordinal == -1:
+            _day = get_month_range(ref_date)[1]
+        else:
+            if not 0 < ordinal <= 4:
+                raise ValueError("months only have 4 weeks")
+            _day = ref_date.replace(day=1) + relativedelta(weeks=ordinal) - \
+                timedelta(days=1)
+        return get_week_range(_day)[0]
+    if resolution == DateTimeResolution.WEEK_OF_YEAR:
+        if ordinal == -1:
+            _day = ref_date.replace(day=31, month=12)
+        else:
+            _day = ref_date.replace(day=1, month=1) + \
+                relativedelta(weeks=ordinal) - timedelta(days=1)
+        return get_week_range(_day)[0]
+    if resolution == DateTimeResolution.WEEK_OF_DECADE:
+        if ordinal == -1:
+            _day = date(day=31, month=12, year=_decade + 9)
+        else:
+            _day = date(day=1, month=1, year=_decade) + \
+                relativedelta(weeks=ordinal) - timedelta(days=1)
+        return get_week_range(_day)[0]
+    if resolution == DateTimeResolution.WEEK_OF_CENTURY:
+        if ordinal == -1:
+            _day = date(day=31, month=12, year=_century + 99)
+        else:
+            _day = date(day=1, month=1, year=_century) + \
+                relativedelta(weeks=ordinal) - timedelta(days=1)
+        return get_week_range(_day)[0]
+    if resolution == DateTimeResolution.WEEK_OF_MILLENNIUM:
+        if ordinal == -1:
+            _day = date(day=31, month=12, year=_mil + 999)
+        else:
+            _day = date(day=1, month=1, year=_mil) + \
+                relativedelta(weeks=ordinal) - timedelta(days=1)
+        return get_week_range(_day)[0]
+
+    if resolution == DateTimeResolution.MONTH:
+        if ordinal < 0:
+            raise OverflowError("The last month of existence can not be "
+                                "represented")
+        return date(year=1, day=1, month=1) + \
+            relativedelta(months=ordinal - 1)
+    if resolution == DateTimeResolution.MONTH_OF_YEAR:
+        if ordinal == -1:
+            return ref_date.replace(month=12, day=1)
+        return ref_date.replace(day=1, month=1) + \
+            relativedelta(months=ordinal - 1)
+    if resolution == DateTimeResolution.MONTH_OF_DECADE:
+        if ordinal == -1:
+            return date(year=_decade + 9, day=1, month=12)
+        return date(year=_decade, month=1, day=1) + \
+            relativedelta(months=ordinal - 1)
+    if resolution == DateTimeResolution.MONTH_OF_CENTURY:
+        if ordinal == -1:
+            return date(year=_century + 99, day=1, month=12)
+        return date(year=_century, month=1, day=1) + \
+            relativedelta(months=ordinal - 1)
+    if resolution == DateTimeResolution.MONTH_OF_MILLENNIUM:
+        if ordinal == -1:
+            return date(year=_mil + 999, day=1, month=12)
+        return date(year=_mil, month=1, day=1) + \
+            relativedelta(months=ordinal - 1)
+
+    if resolution == DateTimeResolution.YEAR:
+        if ordinal == -1:
+            raise OverflowError("The last year of existence can not be "
+                                "represented")
+        if ordinal == 0:
+            # NOTE: no year 0
+            return date(year=1, day=1, month=1)
+        return date(year=ordinal, day=1, month=1)
+    if resolution == DateTimeResolution.YEAR_OF_DECADE:
+        if ordinal == -1:
+            return date(year=_decade + 9, day=1, month=1)
+        if not 0 < ordinal <= 10:
+            raise ValueError("decades only have 10 years")
+        return date(year=_decade + ordinal - 1, day=1, month=1)
+    if resolution == DateTimeResolution.YEAR_OF_CENTURY:
+        if ordinal == -1:
+            return date(year=_century + 99, day=1, month=1)
+        if not 0 < ordinal <= 100:
+            raise ValueError("centuries only have 100 years")
+        return date(year=_century + ordinal - 1, day=1, month=1)
+    if resolution == DateTimeResolution.YEAR_OF_MILLENNIUM:
+        if ordinal == -1:
+            return date(year=_mil + 999, day=1, month=1)
+        if not 0 < ordinal <= 1000:
+            raise ValueError("millennia only have 1000 years")
+        return date(year=_mil + ordinal - 1, day=1, month=1)
+
+    if resolution == DateTimeResolution.DECADE:
+        if ordinal == -1:
+            raise OverflowError("The last decade of existence can not be "
+                                "represented")
+        if ordinal == 1:
+            return date(day=1, month=1, year=1)
+        return date(year=(ordinal - 1) * 10, day=1, month=1)
+    if resolution == DateTimeResolution.DECADE_OF_CENTURY:
+        if ordinal == -1:
+            return date(year=_century + 90, day=1, month=1)
+        if not 0 < ordinal <= 10:
+            raise ValueError("centuries only have 10 decades")
+        if ordinal == 1:
+            return date(day=1, month=1, year=_century)
+        return date(year=_century + (ordinal - 1) * 10, day=1, month=1)
+    if resolution == DateTimeResolution.DECADE_OF_MILLENNIUM:
+        if ordinal == -1:
+            return date(year=_mil + 990, day=1, month=1)
+        if not 0 < ordinal <= 100:
+            raise ValueError("millennia only have 100 decades")
+        if ordinal == 1:
+            return date(day=1, month=1, year=_mil)
+        return date(year=_mil + (ordinal - 1) * 10, day=1, month=1)
+
+    if resolution == DateTimeResolution.CENTURY:
+        if ordinal == -1:
+            raise OverflowError("The last century of existence can not be "
+                                "represented")
+        if ordinal == 1:
+            # NOTE: no century 0 / year 0
+            return date(day=1, month=1, year=1)
+        return date(year=(ordinal - 1) * 100, day=1, month=1)
+    if resolution == DateTimeResolution.CENTURY_OF_MILLENNIUM:
+        if ordinal == -1:
+            return date(year=_mil + 900, day=1, month=1)
+        if not 0 < ordinal <= 10:
+            raise ValueError("millennia only have 10 centuries")
+        if ordinal == 1:
+            return date(day=1, month=1, year=_mil)
+        return date(year=_mil + (ordinal - 1) * 100, day=1, month=1)
+
+    if resolution == DateTimeResolution.MILLENNIUM:
+        if ordinal < 0:
+            raise OverflowError("The last millennium of existence can not "
+                                "be represented")
+        if ordinal == 1:
+            return date(day=1, month=1, year=1)
+        return date(year=(ordinal - 1) * 1000, day=1, month=1)
+
+    if resolution == DateTimeResolution.BEFORE_PRESENT_DAY:
+        if ordinal < 0:
+            raise OverflowError("Can not represent dates BC")
+        return BEFORE_PRESENT_EPOCH - relativedelta(days=ordinal)
+    if resolution == DateTimeResolution.BEFORE_PRESENT_WEEK:
+        if ordinal < 0:
+            raise OverflowError("Can not represent dates BC")
+        _week = BEFORE_PRESENT_EPOCH - relativedelta(weeks=ordinal)
+        return get_week_range(_week)[1]
+    if resolution == DateTimeResolution.BEFORE_PRESENT_MONTH:
+        if ordinal < 0:
+            raise OverflowError("Can not represent dates BC")
+        return BEFORE_PRESENT_EPOCH - relativedelta(months=ordinal)
+    if resolution == DateTimeResolution.BEFORE_PRESENT_YEAR:
+        if ordinal < 0:
+            raise OverflowError("Can not represent dates BC")
+        return BEFORE_PRESENT_EPOCH - relativedelta(years=ordinal)
+    if resolution == DateTimeResolution.BEFORE_PRESENT_DECADE:
+        if ordinal < 0:
+            raise OverflowError("Can not represent dates BC")
+        return BEFORE_PRESENT_EPOCH - relativedelta(years=10 * ordinal)
+    if resolution == DateTimeResolution.BEFORE_PRESENT_CENTURY:
+        if ordinal < 0:
+            raise OverflowError("Can not represent dates BC")
+        return BEFORE_PRESENT_EPOCH - relativedelta(years=100 * ordinal)
+    if resolution == DateTimeResolution.BEFORE_PRESENT_MILLENNIUM:
+        if ordinal < 0:
+            raise OverflowError("Can not represent dates BC")
+        return BEFORE_PRESENT_EPOCH - relativedelta(years=1000 * ordinal)
+
+    raise ValueError(f"Invalid DateTimeResolution: {resolution}")

--- a/test/test_ranges.py
+++ b/test/test_ranges.py
@@ -1,0 +1,308 @@
+import unittest
+from datetime import date, datetime
+
+from ovos_date_parser import (
+    Hemisphere, Season, DateTimeResolution,
+    get_week_range, get_weekend_range, get_month_range, get_year_range,
+    get_decade_range, get_century_range, get_millennium_range,
+    get_season_range, get_week_number, get_date_ordinal,
+    date_to_season, season_to_date, next_season_date, last_season_date,
+)
+
+
+class TestRanges(unittest.TestCase):
+    def test_week_range(self):
+        # 1994-02-27 was a sunday
+        self.assertEqual(get_week_range(date(1994, 2, 27)),
+                         (date(1994, 2, 21), date(1994, 2, 27)))
+        # 2026-07-16 is a thursday
+        self.assertEqual(get_week_range(date(2026, 7, 16)),
+                         (date(2026, 7, 13), date(2026, 7, 19)))
+        # monday maps onto itself
+        self.assertEqual(get_week_range(date(2026, 7, 13)),
+                         (date(2026, 7, 13), date(2026, 7, 19)))
+
+    def test_weekend_range(self):
+        # from a weekday: the upcoming weekend
+        self.assertEqual(get_weekend_range(date(2026, 7, 16)),
+                         (date(2026, 7, 18), date(2026, 7, 19)))
+        # from a saturday or sunday: the current weekend
+        self.assertEqual(get_weekend_range(date(2026, 7, 18)),
+                         (date(2026, 7, 18), date(2026, 7, 19)))
+        self.assertEqual(get_weekend_range(date(2026, 7, 19)),
+                         (date(2026, 7, 18), date(2026, 7, 19)))
+
+    def test_month_range(self):
+        self.assertEqual(get_month_range(date(1994, 2, 27)),
+                         (date(1994, 2, 1), date(1994, 2, 28)))
+        # leap year february
+        self.assertEqual(get_month_range(date(2024, 2, 10)),
+                         (date(2024, 2, 1), date(2024, 2, 29)))
+        # december does not overflow into the next year
+        self.assertEqual(get_month_range(date(2026, 12, 5)),
+                         (date(2026, 12, 1), date(2026, 12, 31)))
+
+    def test_year_range(self):
+        self.assertEqual(get_year_range(date(1994, 2, 27)),
+                         (date(1994, 1, 1), date(1994, 12, 31)))
+
+    def test_decade_century_millennium_ranges(self):
+        ref = date(1994, 2, 27)
+        self.assertEqual(get_decade_range(ref),
+                         (date(1990, 1, 1), date(1999, 12, 31)))
+        self.assertEqual(get_century_range(ref),
+                         (date(1900, 1, 1), date(1999, 12, 31)))
+        self.assertEqual(get_millennium_range(ref),
+                         (date(1000, 1, 1), date(1999, 12, 31)))
+        ref = date(2112, 2, 27)
+        self.assertEqual(get_decade_range(ref),
+                         (date(2110, 1, 1), date(2119, 12, 31)))
+        self.assertEqual(get_century_range(ref),
+                         (date(2100, 1, 1), date(2199, 12, 31)))
+        self.assertEqual(get_millennium_range(ref),
+                         (date(2000, 1, 1), date(2999, 12, 31)))
+
+    def test_week_number(self):
+        # ISO-8601: 2026-01-01 is a thursday, week 1
+        self.assertEqual(get_week_number(date(2026, 1, 1)), 1)
+        # 2021-01-01 is a friday, ISO week 53 of 2020
+        self.assertEqual(get_week_number(date(2021, 1, 1)), 53)
+        self.assertEqual(get_week_number(date(1994, 2, 27)), 8)
+
+
+class TestSeasons(unittest.TestCase):
+    def test_date_to_season_north(self):
+        self.assertEqual(date_to_season(date(2026, 4, 10)), Season.SPRING)
+        self.assertEqual(date_to_season(date(2026, 7, 16)), Season.SUMMER)
+        self.assertEqual(date_to_season(date(2026, 10, 1)), Season.FALL)
+        self.assertEqual(date_to_season(date(2026, 1, 15)), Season.WINTER)
+        # season boundaries: last days belong to the season
+        self.assertEqual(date_to_season(date(2026, 5, 31)), Season.SPRING)
+        self.assertEqual(date_to_season(date(2026, 8, 31)), Season.SUMMER)
+        self.assertEqual(date_to_season(date(2026, 11, 30)), Season.FALL)
+        self.assertEqual(date_to_season(date(2026, 12, 1)), Season.WINTER)
+        self.assertEqual(date_to_season(date(2024, 2, 29)), Season.WINTER)
+
+    def test_date_to_season_south(self):
+        south = Hemisphere.SOUTH
+        self.assertEqual(date_to_season(date(2026, 4, 10), south),
+                         Season.FALL)
+        self.assertEqual(date_to_season(date(2026, 7, 16), south),
+                         Season.WINTER)
+        self.assertEqual(date_to_season(date(2026, 10, 1), south),
+                         Season.SPRING)
+        self.assertEqual(date_to_season(date(2026, 1, 15), south),
+                         Season.SUMMER)
+
+    def test_autumn_is_fall(self):
+        self.assertEqual(Season.AUTUMN, Season.FALL)
+        self.assertEqual(date_to_season(date(2026, 10, 1)), Season.AUTUMN)
+
+    def test_season_to_date(self):
+        self.assertEqual(season_to_date(Season.SPRING, 2026),
+                         date(2026, 3, 1))
+        self.assertEqual(season_to_date(Season.SUMMER, 2026),
+                         date(2026, 6, 1))
+        self.assertEqual(season_to_date(Season.FALL, 2026),
+                         date(2026, 9, 1))
+        self.assertEqual(season_to_date(Season.WINTER, 2026),
+                         date(2026, 12, 1))
+        # southern hemisphere is shifted by two seasons
+        south = Hemisphere.SOUTH
+        self.assertEqual(season_to_date(Season.SPRING, 2026, south),
+                         date(2026, 9, 1))
+        self.assertEqual(season_to_date(Season.SUMMER, 2026, south),
+                         date(2026, 12, 1))
+        self.assertEqual(season_to_date(Season.FALL, 2026, south),
+                         date(2026, 3, 1))
+        self.assertEqual(season_to_date(Season.WINTER, 2026, south),
+                         date(2026, 6, 1))
+        # a date can stand in for the year
+        self.assertEqual(season_to_date(Season.SPRING, date(2026, 7, 16)),
+                         date(2026, 3, 1))
+
+    def test_next_and_last_season_date(self):
+        ref = date(2026, 7, 16)  # northern summer
+        self.assertEqual(next_season_date(Season.FALL, ref),
+                         date(2026, 9, 1))
+        self.assertEqual(next_season_date(Season.SPRING, ref),
+                         date(2027, 3, 1))
+        self.assertEqual(last_season_date(Season.SPRING, ref),
+                         date(2026, 3, 1))
+        self.assertEqual(last_season_date(Season.FALL, ref),
+                         date(2025, 9, 1))
+        # on the start day itself, "next" is today
+        self.assertEqual(next_season_date(Season.SUMMER, date(2026, 6, 1)),
+                         date(2026, 6, 1))
+
+    def test_season_range(self):
+        self.assertEqual(get_season_range(date(2026, 7, 16)),
+                         (date(2026, 6, 1), date(2026, 8, 31)))
+        self.assertEqual(get_season_range(date(2026, 4, 10)),
+                         (date(2026, 3, 1), date(2026, 5, 31)))
+        self.assertEqual(get_season_range(date(2026, 10, 1)),
+                         (date(2026, 9, 1), date(2026, 11, 30)))
+        # winter wraps the new year
+        self.assertEqual(get_season_range(date(2026, 12, 15)),
+                         (date(2026, 12, 1), date(2027, 2, 28)))
+        self.assertEqual(get_season_range(date(2027, 1, 15)),
+                         (date(2026, 12, 1), date(2027, 2, 28)))
+        # leap year february
+        self.assertEqual(get_season_range(date(2024, 2, 10)),
+                         (date(2023, 12, 1), date(2024, 2, 29)))
+        # southern hemisphere: july is winter, december starts summer
+        south = Hemisphere.SOUTH
+        self.assertEqual(get_season_range(date(2026, 7, 16), south),
+                         (date(2026, 6, 1), date(2026, 8, 31)))
+        self.assertEqual(get_season_range(date(2026, 12, 15), south),
+                         (date(2026, 12, 1), date(2027, 2, 28)))
+
+
+class TestDateOrdinals(unittest.TestCase):
+    def test_day_ordinals(self):
+        ref = date(2026, 7, 16)
+        self.assertEqual(
+            get_date_ordinal(1, ref, DateTimeResolution.DAY_OF_MONTH),
+            date(2026, 7, 1))
+        self.assertEqual(
+            get_date_ordinal(-1, ref, DateTimeResolution.DAY_OF_MONTH),
+            date(2026, 7, 31))
+        self.assertEqual(
+            get_date_ordinal(-1, date(2026, 2, 5),
+                             DateTimeResolution.DAY_OF_MONTH),
+            date(2026, 2, 28))
+        self.assertEqual(
+            get_date_ordinal(1, ref, DateTimeResolution.DAY_OF_YEAR),
+            date(2026, 1, 1))
+        # 2026 is not a leap year: day 100 is april 10
+        self.assertEqual(
+            get_date_ordinal(100, ref, DateTimeResolution.DAY_OF_YEAR),
+            date(2026, 4, 10))
+        self.assertEqual(
+            get_date_ordinal(-1, ref, DateTimeResolution.DAY_OF_YEAR),
+            date(2026, 12, 31))
+        self.assertEqual(
+            get_date_ordinal(1, ref, DateTimeResolution.DAY_OF_DECADE),
+            date(2020, 1, 1))
+        self.assertEqual(
+            get_date_ordinal(-1, ref, DateTimeResolution.DAY_OF_DECADE),
+            date(2029, 12, 31))
+        self.assertEqual(
+            get_date_ordinal(1, ref, DateTimeResolution.DAY_OF_CENTURY),
+            date(2000, 1, 1))
+        self.assertEqual(
+            get_date_ordinal(-1, ref, DateTimeResolution.DAY_OF_CENTURY),
+            date(2099, 12, 31))
+        self.assertEqual(
+            get_date_ordinal(-1, ref, DateTimeResolution.DAY_OF_MILLENNIUM),
+            date(2999, 12, 31))
+        # the very first day
+        self.assertEqual(get_date_ordinal(1, ref, DateTimeResolution.DAY),
+                         date(1, 1, 1))
+
+    def test_week_ordinals(self):
+        ref = date(2026, 7, 16)
+        # weeks resolve to their monday; the first week of july 2026
+        # is the week containing july 7 (monday july 6)
+        self.assertEqual(
+            get_date_ordinal(1, ref, DateTimeResolution.WEEK_OF_MONTH),
+            date(2026, 7, 6))
+        self.assertEqual(
+            get_date_ordinal(-1, ref, DateTimeResolution.WEEK_OF_MONTH),
+            date(2026, 7, 27))
+        self.assertEqual(
+            get_date_ordinal(1, ref, DateTimeResolution.WEEK_OF_YEAR),
+            date(2026, 1, 5))
+        self.assertEqual(
+            get_date_ordinal(-1, ref, DateTimeResolution.WEEK_OF_YEAR),
+            date(2026, 12, 28))
+        with self.assertRaises(ValueError):
+            get_date_ordinal(5, ref, DateTimeResolution.WEEK_OF_MONTH)
+
+    def test_month_ordinals(self):
+        ref = date(2026, 7, 16)
+        self.assertEqual(
+            get_date_ordinal(1, ref, DateTimeResolution.MONTH_OF_YEAR),
+            date(2026, 1, 1))
+        self.assertEqual(
+            get_date_ordinal(7, ref, DateTimeResolution.MONTH_OF_YEAR),
+            date(2026, 7, 1))
+        self.assertEqual(
+            get_date_ordinal(-1, ref, DateTimeResolution.MONTH_OF_YEAR),
+            date(2026, 12, 1))
+        self.assertEqual(
+            get_date_ordinal(15, ref, DateTimeResolution.MONTH_OF_DECADE),
+            date(2021, 3, 1))
+        self.assertEqual(
+            get_date_ordinal(-1, ref, DateTimeResolution.MONTH_OF_CENTURY),
+            date(2099, 12, 1))
+
+    def test_year_ordinals(self):
+        ref = date(2026, 7, 16)
+        self.assertEqual(get_date_ordinal(2026, ref, DateTimeResolution.YEAR),
+                         date(2026, 1, 1))
+        self.assertEqual(
+            get_date_ordinal(1, ref, DateTimeResolution.YEAR_OF_DECADE),
+            date(2020, 1, 1))
+        self.assertEqual(
+            get_date_ordinal(-1, ref, DateTimeResolution.YEAR_OF_DECADE),
+            date(2029, 1, 1))
+        self.assertEqual(
+            get_date_ordinal(50, ref, DateTimeResolution.YEAR_OF_CENTURY),
+            date(2049, 1, 1))
+        self.assertEqual(
+            get_date_ordinal(500, ref,
+                             DateTimeResolution.YEAR_OF_MILLENNIUM),
+            date(2499, 1, 1))
+
+    def test_decade_century_millennium_ordinals(self):
+        ref = date(2026, 7, 16)
+        # the 1st decade is years 1-10, the 203rd started in 2020
+        self.assertEqual(get_date_ordinal(1, ref, DateTimeResolution.DECADE),
+                         date(1, 1, 1))
+        self.assertEqual(
+            get_date_ordinal(203, ref, DateTimeResolution.DECADE),
+            date(2020, 1, 1))
+        self.assertEqual(
+            get_date_ordinal(3, ref, DateTimeResolution.DECADE_OF_CENTURY),
+            date(2020, 1, 1))
+        self.assertEqual(get_date_ordinal(21, ref,
+                                          DateTimeResolution.CENTURY),
+                         date(2000, 1, 1))
+        self.assertEqual(
+            get_date_ordinal(1, ref,
+                             DateTimeResolution.CENTURY_OF_MILLENNIUM),
+            date(2000, 1, 1))
+        self.assertEqual(get_date_ordinal(3, ref,
+                                          DateTimeResolution.MILLENNIUM),
+                         date(2000, 1, 1))
+
+    def test_before_present(self):
+        ref = date(2026, 7, 16)
+        self.assertEqual(
+            get_date_ordinal(0, ref, DateTimeResolution.BEFORE_PRESENT_YEAR),
+            date(1950, 1, 1))
+        self.assertEqual(
+            get_date_ordinal(100, ref,
+                             DateTimeResolution.BEFORE_PRESENT_YEAR),
+            date(1850, 1, 1))
+        self.assertEqual(
+            get_date_ordinal(2, ref,
+                             DateTimeResolution.BEFORE_PRESENT_DECADE),
+            date(1930, 1, 1))
+        self.assertEqual(
+            get_date_ordinal(1, ref, DateTimeResolution.BEFORE_PRESENT_DAY),
+            date(1949, 12, 31))
+        with self.assertRaises(OverflowError):
+            get_date_ordinal(-1, ref,
+                             DateTimeResolution.BEFORE_PRESENT_YEAR)
+
+    def test_datetime_ref_is_accepted(self):
+        ref = datetime(2026, 7, 16, 12, 30)
+        self.assertEqual(
+            get_date_ordinal(-1, ref, DateTimeResolution.DAY_OF_MONTH),
+            date(2026, 7, 31))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds `ovos_date_parser/ranges.py` with language-agnostic calendar helpers, exported from the package root. This is the utility toolbox the future datetime scanner builds on; nothing in the existing parsers changes.

## What's included

- `get_week_range` / `get_weekend_range` / `get_month_range` / `get_year_range` / `get_decade_range` / `get_century_range` / `get_millennium_range` — inclusive `(start, end)` tuples for the span containing a reference date. Decades/centuries/millennia follow the calendar convention (1990s = 1990-1999).
- `get_week_number` — ISO-8601 week number.
- Hemisphere-aware meteorological seasons: `date_to_season`, `season_to_date`, `next_season_date`, `last_season_date`, `get_season_range`, with `Season` (`AUTUMN` aliases `FALL`) and `Hemisphere` enums. Season ranges include their final day and handle the December-February wrap across the new year, including February 29th on leap years.
- `get_date_ordinal` + `DateTimeResolution` — resolves "the Nth day/week/month/year/decade/century/millennium of <scope>" into a date (`-1` = last), including before-present resolutions counted back from the 1950-01-01 epoch used in radiocarbon dating.

## Tests

Direct unit tests in `test/test_ranges.py` cover every helper: week/weekend/month (December, leap February), decade/century/millennium ranges, ISO week numbers across year boundaries, both hemispheres, season boundary days, the winter year-wrap, and ordinal resolution at every granularity with hand-computed anchors.

Full suite: 367 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)