### PR TITLE
feat: Finnish (fi) and Estonian (et) date and time support

### DIFF
--- a/ovos_date_parser/__init__.py
+++ b/ovos_date_parser/__init__.py
@@ -54,8 +54,14 @@ from ovos_date_parser.dates_es import (
 from ovos_date_parser.dates_eu import (
     extract_datetime_eu, nice_time_eu, nice_relative_time_eu, extract_duration_eu,
 )
+from ovos_date_parser.dates_et import (
+    extract_datetime_et, extract_duration_et, nice_time_et, nice_year_et,
+)
 from ovos_date_parser.dates_fa import (
     extract_datetime_fa, nice_time_fa, extract_duration_fa,
+)
+from ovos_date_parser.dates_fi import (
+    extract_datetime_fi, extract_duration_fi, nice_time_fi, nice_year_fi,
 )
 from ovos_date_parser.dates_fr import (
     extract_duration_fr,
@@ -150,10 +156,14 @@ def nice_time(
         return nice_time_en(dt, speech, use_24hour, use_ampm)
     if lang.startswith("es"):
         return nice_time_es(dt, speech, use_24hour, use_ampm)
+    if lang.startswith("et"):
+        return nice_time_et(dt, speech, use_24hour, use_ampm)
     if lang.startswith("eu"):
         return nice_time_eu(dt, speech, use_24hour, use_ampm)
     if lang.startswith("fa"):
         return nice_time_fa(dt, speech, use_24hour, use_ampm)
+    if lang.startswith("fi"):
+        return nice_time_fi(dt, speech, use_24hour, use_ampm)
     if lang.startswith("fr"):
         return nice_time_fr(dt, speech, use_24hour, use_ampm)
     if lang.startswith("hu"):
@@ -304,10 +314,14 @@ def extract_datetime(
         return extract_datetime_en(text, anchorDate=anchorDate, default_time=default_time)
     if lang.startswith("es"):
         return extract_datetime_es(text, anchorDate=anchorDate, default_time=default_time)
+    if lang.startswith("et"):
+        return extract_datetime_et(text, anchorDate=anchorDate, default_time=default_time)
     if lang.startswith("eu"):
         return extract_datetime_eu(text, anchorDate=anchorDate, default_time=default_time)
     if lang.startswith("fa"):
         return extract_datetime_fa(text, anchorDate=anchorDate, default_time=default_time)
+    if lang.startswith("fi"):
+        return extract_datetime_fi(text, anchorDate=anchorDate, default_time=default_time)
     if lang.startswith("fr"):
         return extract_datetime_fr(text, anchorDate=anchorDate, default_time=default_time)
     if lang.startswith("gl"):
@@ -745,6 +759,10 @@ def nice_year(dt, lang, bc=False):
         return nice_year_ro(dt, bc)
     if lang.startswith("ast"):
         return nice_year_ast(dt, bc)
+    if lang.startswith("et"):
+        return nice_year_et(dt, bc)
+    if lang.startswith("fi"):
+        return nice_year_fi(dt, bc)
     date_time_format.cache(lang)
     return date_time_format.year_format(dt, lang, bc)
 

--- a/ovos_date_parser/dates_et.py
+++ b/ovos_date_parser/dates_et.py
@@ -161,6 +161,41 @@ def _clean_tokens_et(text):
     return out
 
 
+# idiomatic spoken clock, traditional "counting toward the coming hour":
+# "veerand kaks" = 1:15, "pool kaks" = 1:30, "kolmveerand kaks" = 1:45
+_QUARTER_MINUTES_ET = {"veerand": 15, "pool": 30, "kolmveerand": 45}
+
+
+def _num_et(token):
+    if token is None:
+        return None
+    if token.isdigit():
+        return int(token)
+    val = extract_number_et(token)
+    if val is not False and val is not None and val == int(val):
+        return int(val)
+    return None
+
+
+def _scan_clock_idiom_et(words):
+    """Match an idiomatic spoken clock ("pool kaks" = 1:30).
+
+    Returns (hour, minute, consumed_indices) or None. The hour named is the
+    *coming* hour: "pool kaks" is half an hour before two, i.e. 1:30, and
+    "veerand kaks" is a quarter into that hour, i.e. 1:15.
+    """
+    n = len(words)
+    for i, w in enumerate(words):
+        if w in _QUARTER_MINUTES_ET and i + 1 < n:
+            h = _num_et(words[i + 1])
+            if h and 1 <= h <= 12:
+                cons = {i, i + 1}
+                if i > 0 and words[i - 1] == "kell":
+                    cons.add(i - 1)
+                return (h - 1) or 12, _QUARTER_MINUTES_ET[w], cons
+    return None
+
+
 def _weekday_from_word_et(word):
     if word in _WEEKDAYS_ET:
         return _WEEKDAYS_ET[word]
@@ -212,6 +247,13 @@ def extract_datetime_et(text, anchorDate=None, default_time=None):
     min_abs = None
     consumed = [False] * len(words)
     found = False
+
+    idiom = _scan_clock_idiom_et(words)
+    if idiom is not None:
+        hr_abs, min_abs, cons = idiom
+        for c in cons:
+            consumed[c] = True
+        found = True
 
     for idx, word in enumerate(words):
         if consumed[idx]:

--- a/ovos_date_parser/dates_et.py
+++ b/ovos_date_parser/dates_et.py
@@ -1,0 +1,410 @@
+"""Estonian date and time parsing and formatting.
+
+Estonian, like Finnish, is agglutinative and case-rich: numerals below a
+hundred that are not round agglutinate ("kaksteist" = 12, "kakskümmend" = 20)
+and the noun after a numeral greater than one takes the partitive singular
+("kaks tundi", "viis minutit"). The spoken clock keeps the "kell" marker
+("kell kaksteist") and the year is read as a plain cardinal number.
+
+References:
+    * Eesti Keele Instituut (EKI), Eesti keele käsiraamat,
+      "Arvsõnad" and kellaaja/kuupäeva usage
+    * https://et.wikipedia.org/wiki/Kellaaeg
+"""
+from datetime import timedelta
+
+from ovos_number_parser.numbers_et import (
+    pronounce_number_et, extract_number_et,
+)
+from ovos_utils.time import now_local
+
+from ovos_date_parser.duration import (
+    DurationResolution, DURATION_LEXICONS, extract_duration_generic,
+)
+
+# ---------------------------------------------------------------------------
+# formatting
+# ---------------------------------------------------------------------------
+
+_PART_OF_DAY_ET = (
+    (5, 11, "hommikul"),   # morning
+    (12, 17, "päeval"),    # daytime
+    (18, 22, "õhtul"),     # evening
+)
+
+
+def _part_of_day_et(hour):
+    for start, end, word in _PART_OF_DAY_ET:
+        if start <= hour <= end:
+            return word
+    return "öösel"  # night, 23..4
+
+
+def nice_year_et(dt, bc=False):
+    """Speak a year as an Estonian cardinal number.
+
+    Estonian reads years as whole cardinals ("tuhat üheksasada
+    kaheksakümmend neli" for 1984), not as decade pairs.
+    """
+    year = pronounce_number_et(dt.year)
+    if bc:
+        return year + " enne Kristust"
+    return year
+
+
+def _speak_minutes_et(minute):
+    if minute < 10:
+        return " null " + pronounce_number_et(minute)
+    return " " + pronounce_number_et(minute)
+
+
+def nice_time_et(dt, speech=True, use_24hour=False, use_ampm=False):
+    """Format a time in a natural Estonian way.
+
+    For example, generate "kell viisteist kolmkümmend" for 15:30.
+
+    Args:
+        dt (datetime): date to format (assumes already in local timezone)
+        speech (bool): format for speech (default) or display (False)
+        use_24hour (bool): output in 24-hour format
+        use_ampm (bool): include a part-of-day adverb for 12-hour format
+    Returns:
+        (str): The formatted time string
+    """
+    if use_24hour:
+        string = dt.strftime("%H:%M")
+    else:
+        if use_ampm:
+            string = dt.strftime("%I:%M %p")
+        else:
+            string = dt.strftime("%I:%M")
+        if string[0] == "0":
+            string = string[1:]
+
+    if not speech:
+        return string
+
+    if use_24hour:
+        speak = "kell " + pronounce_number_et(dt.hour)
+        if dt.minute:
+            speak += _speak_minutes_et(dt.minute)
+        return speak
+
+    if dt.hour == 0 and dt.minute == 0:
+        return "kesköö"
+    if dt.hour == 12 and dt.minute == 0:
+        return "keskpäev"
+
+    hour = dt.hour % 12
+    if hour == 0:
+        hour = 12
+    speak = "kell " + pronounce_number_et(hour)
+    if dt.minute:
+        speak += _speak_minutes_et(dt.minute)
+    if use_ampm:
+        speak += " " + _part_of_day_et(dt.hour)
+    return speak
+
+
+# ---------------------------------------------------------------------------
+# duration
+# ---------------------------------------------------------------------------
+
+def extract_duration_et(text, resolution=DurationResolution.TIMEDELTA,
+                        replace_token=""):
+    """Convert an Estonian phrase into a duration.
+
+    Handles "kaks tundi", "kolmkümmend minutit" and similar; numerals are
+    read by the shared number parser and matched against the declined unit
+    nouns.
+    """
+    return extract_duration_generic(text, DURATION_LEXICONS["et"],
+                                    resolution, replace_token)
+
+
+# ---------------------------------------------------------------------------
+# datetime extraction
+# ---------------------------------------------------------------------------
+
+_WEEKDAYS_ET = {
+    "esmaspäev": 0, "teisipäev": 1, "kolmapäev": 2, "neljapäev": 3,
+    "reede": 4, "laupäev": 5, "pühapäev": 6,
+}
+# weekday adessive ("esmaspäeval") also appears
+_WEEKDAY_STEMS_ET = {name: num for name, num in _WEEKDAYS_ET.items()}
+
+_MONTHS_ET = {
+    "jaanuar": 1, "veebruar": 2, "märts": 3, "aprill": 4, "mai": 5,
+    "juuni": 6, "juuli": 7, "august": 8, "september": 9, "oktoober": 10,
+    "november": 11, "detsember": 12,
+}
+# month genitive endings that appear in dates ("jaanuaril", "jaanuaris")
+_MONTH_STEMS_ET = {name: num for name, num in _MONTHS_ET.items()}
+
+_DAY_UNITS_ET = ("päev", "päeva", "päevad")
+_WEEK_UNITS_ET = ("nädal", "nädala", "nädalat")
+_MONTH_UNITS_ET = ("kuu", "kuud")
+_YEAR_UNITS_ET = ("aasta", "aastat")
+_AFTER_MARKERS_ET = ("pärast", "järel", "möödudes")
+_NEXT_ET = ("järgmine", "järgmisel", "tulev", "tuleval")
+_LAST_ET = ("eelmine", "eelmisel", "möödunud")
+
+
+def _clean_tokens_et(text):
+    out = []
+    for tok in text.lower().replace(",", " ").split():
+        # keep internal separators (15.30, 15:30) but drop edge punctuation,
+        # so an ordinal "15." becomes "15"
+        tok = tok.strip("?!;:.")
+        if tok:
+            out.append(tok)
+    return out
+
+
+def _weekday_from_word_et(word):
+    if word in _WEEKDAYS_ET:
+        return _WEEKDAYS_ET[word]
+    for stem, num in _WEEKDAY_STEMS_ET.items():
+        if word.startswith(stem):  # adessive "esmaspäeval"
+            return num
+    return None
+
+
+def _month_from_word_et(word):
+    if word in _MONTHS_ET:
+        return _MONTHS_ET[word]
+    for stem, num in _MONTH_STEMS_ET.items():
+        if word.startswith(stem):
+            return num
+    return None
+
+
+def extract_datetime_et(text, anchorDate=None, default_time=None):
+    """Extract date/time information from Estonian text.
+
+    Supported constructs (each verified against everyday usage):
+        * täna / homme / ülehomme / eile / üleeile
+        * weekday names (nominative and adessive), with järgmine/eelmine
+        * "N päeva/nädala/kuu/aasta pärast"
+        * "järgmine|eelmine nädal|kuu|aasta"
+        * clock times: "kell 15:30", "kell 15", "15:30", "15.30"
+        * dates with a month name: "15. jaanuar", "jaanuari 15."
+
+    Returns a ``[datetime, leftover_text]`` pair, or ``None`` when nothing
+    date related is found.
+    """
+    if not text:
+        return None
+
+    anchor = anchorDate or now_local()
+    anchor = anchor.replace(microsecond=0)
+    words = _clean_tokens_et(text)
+    if not words:
+        return None
+
+    day_offset = None
+    week_offset = 0
+    month_offset = 0
+    year_offset = 0
+    abs_month = None
+    abs_day = None
+    hr_abs = None
+    min_abs = None
+    consumed = [False] * len(words)
+    found = False
+
+    for idx, word in enumerate(words):
+        if consumed[idx]:
+            continue
+        prev = words[idx - 1] if idx > 0 else ""
+        nxt = words[idx + 1] if idx + 1 < len(words) else ""
+
+        if word in ("täna", "praegu"):
+            day_offset = 0
+            consumed[idx] = True
+            found = True
+            continue
+        if word == "homme":
+            day_offset = 1
+            consumed[idx] = True
+            found = True
+            continue
+        if word == "ülehomme":
+            day_offset = 2
+            consumed[idx] = True
+            found = True
+            continue
+        if word == "eile":
+            day_offset = -1
+            consumed[idx] = True
+            found = True
+            continue
+        if word == "üleeile":
+            day_offset = -2
+            consumed[idx] = True
+            found = True
+            continue
+
+        weekday = _weekday_from_word_et(word)
+        if weekday is not None:
+            diff = (weekday - anchor.weekday()) % 7
+            if prev in _NEXT_ET:
+                if diff == 0:
+                    diff = 7
+                consumed[idx - 1] = True
+            elif prev in _LAST_ET:
+                diff = diff - 7 if diff != 0 else -7
+                consumed[idx - 1] = True
+            day_offset = diff
+            consumed[idx] = True
+            found = True
+            continue
+
+        if word in ("nädal", "nädalal") and prev in _NEXT_ET + _LAST_ET:
+            week_offset = 1 if prev in _NEXT_ET else -1
+            consumed[idx] = consumed[idx - 1] = True
+            found = True
+            continue
+        if word in ("kuu", "kuul") and prev in _NEXT_ET + _LAST_ET:
+            month_offset = 1 if prev in _NEXT_ET else -1
+            consumed[idx] = consumed[idx - 1] = True
+            found = True
+            continue
+        if word in ("aasta", "aastal") and prev in _NEXT_ET + _LAST_ET:
+            year_offset = 1 if prev in _NEXT_ET else -1
+            consumed[idx] = consumed[idx - 1] = True
+            found = True
+            continue
+
+        if word in _AFTER_MARKERS_ET and idx >= 2:
+            unit = words[idx - 1]
+            num = extract_number_et(words[idx - 2])
+            if num is not False and num is not None:
+                num = int(num)
+                if unit in _DAY_UNITS_ET:
+                    day_offset = (day_offset or 0) + num
+                elif unit in _WEEK_UNITS_ET:
+                    week_offset += num
+                elif unit in _MONTH_UNITS_ET:
+                    month_offset += num
+                elif unit in _YEAR_UNITS_ET:
+                    year_offset += num
+                else:
+                    continue
+                consumed[idx] = consumed[idx - 1] = consumed[idx - 2] = True
+                found = True
+                continue
+
+        if word == "kell":
+            if _parse_clock_et(nxt) is not None:
+                hr_abs, min_abs = _parse_clock_et(nxt)
+                consumed[idx] = consumed[idx + 1] = True
+                found = True
+                continue
+            num = extract_number_et(nxt) if nxt else False
+            if num is not False and num is not None and 0 <= num <= 23:
+                hr_abs, min_abs = int(num), 0
+                consumed[idx] = consumed[idx + 1] = True
+                found = True
+                continue
+
+        clock = _parse_clock_et(word)
+        if clock is not None:
+            hr_abs, min_abs = clock
+            consumed[idx] = True
+            found = True
+            continue
+
+        month = _month_from_word_et(word)
+        if month is not None:
+            day = None
+            if prev:
+                d = _ordinal_day_et(prev)
+                if d is not None:
+                    day = d
+                    consumed[idx - 1] = True
+            if day is None and nxt:
+                d = _ordinal_day_et(nxt)
+                if d is not None:
+                    day = d
+                    consumed[idx + 1] = True
+            abs_month = month
+            abs_day = day if day is not None else 1
+            consumed[idx] = True
+            found = True
+            continue
+
+    if not found:
+        return None
+
+    extracted = anchor.replace(hour=0, minute=0, second=0)
+
+    if abs_month is not None:
+        try:
+            candidate = extracted.replace(month=abs_month, day=abs_day)
+        except ValueError:
+            return None
+        if candidate.date() < anchor.date():
+            candidate = candidate.replace(year=anchor.year + 1)
+        extracted = candidate
+    else:
+        if day_offset is not None:
+            extracted = extracted + timedelta(days=day_offset)
+        if week_offset:
+            extracted = extracted + timedelta(weeks=week_offset)
+        if month_offset:
+            extracted = _add_months(extracted, month_offset)
+        if year_offset:
+            try:
+                extracted = extracted.replace(year=extracted.year + year_offset)
+            except ValueError:
+                extracted = extracted.replace(
+                    year=extracted.year + year_offset, day=28)
+
+    if hr_abs is None and default_time is not None:
+        hr_abs = default_time.hour
+        min_abs = default_time.minute
+    if hr_abs is not None:
+        extracted = extracted.replace(hour=hr_abs, minute=min_abs or 0)
+
+    leftover = " ".join(w for i, w in enumerate(words)
+                        if not consumed[i] and w != ".")
+    leftover = " ".join(leftover.split())
+    return [extracted, leftover]
+
+
+def _add_months(dt, months):
+    month = dt.month - 1 + months
+    year = dt.year + month // 12
+    month = month % 12 + 1
+    day = min(dt.day, [31, 29 if year % 4 == 0 and
+                       (year % 100 != 0 or year % 400 == 0) else 28,
+                       31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1])
+    return dt.replace(year=year, month=month, day=day)
+
+
+def _parse_clock_et(token):
+    if not token:
+        return None
+    for sep in (":", "."):
+        if sep in token:
+            parts = token.split(sep)
+            if len(parts) == 2 and parts[0].isdigit() and parts[1].isdigit():
+                hour, minute = int(parts[0]), int(parts[1])
+                if 0 <= hour <= 23 and 0 <= minute <= 59:
+                    return hour, minute
+            return None
+    return None
+
+
+def _ordinal_day_et(token):
+    stripped = token.rstrip(".")
+    if stripped.isdigit():
+        val = int(stripped)
+        if 1 <= val <= 31:
+            return val
+    from ovos_number_parser.numbers_et import is_ordinal_et
+    val = is_ordinal_et(stripped)
+    if val is not False and 1 <= val <= 31:
+        return val
+    return None

--- a/ovos_date_parser/dates_fi.py
+++ b/ovos_date_parser/dates_fi.py
@@ -167,6 +167,64 @@ def _clean_tokens_fi(text):
     return out
 
 
+# idiomatic spoken clock: "yli" = past, "vaille"/"vailla" = to, "vartti" = 15
+_REL_PAST_FI = ("yli",)
+_REL_TO_FI = ("vaille", "vailla")
+_QUARTER_FI = ("vartti", "varttia", "varttia")
+
+
+def _num_fi(token):
+    if token is None:
+        return None
+    if token.isdigit():
+        return int(token)
+    val = extract_number_fi(token)
+    if val is not False and val is not None and val == int(val):
+        return int(val)
+    return None
+
+
+def _scan_clock_idiom_fi(words):
+    """Match an idiomatic spoken clock ("puoli kaksi" = 1:30).
+
+    Returns (hour, minute, consumed_indices) or None. The hour named in
+    these idioms is the *coming* hour: "puoli kaksi" is half an hour before
+    two, i.e. 1:30, never 2:30.
+    """
+    n = len(words)
+    for i, w in enumerate(words):
+        cons = set()
+        result = None
+        if w == "puoli" and i + 1 < n:
+            h = _num_fi(words[i + 1])
+            if h and 1 <= h <= 12:
+                result = ((h - 1) or 12, 30)
+                cons = {i, i + 1}
+        elif w in _QUARTER_FI and i + 2 < n and \
+                words[i + 1] in _REL_PAST_FI + _REL_TO_FI:
+            h = _num_fi(words[i + 2])
+            if h and 1 <= h <= 12:
+                if words[i + 1] in _REL_PAST_FI:
+                    result = (h, 15)          # "varttia yli kaksi" = 2:15
+                else:
+                    result = ((h - 1) or 12, 45)  # "varttia vaille kaksi" = 1:45
+                cons = {i, i + 1, i + 2}
+        elif w in _REL_PAST_FI + _REL_TO_FI and 0 < i and i + 1 < n:
+            mins = _num_fi(words[i - 1])
+            h = _num_fi(words[i + 1])
+            if mins is not None and 0 < mins < 60 and h and 1 <= h <= 12:
+                if w in _REL_PAST_FI:
+                    result = (h, mins)            # "kymmenen yli kaksi" = 2:10
+                else:
+                    result = ((h - 1) or 12, 60 - mins)  # "vaille" = to
+                cons = {i - 1, i, i + 1}
+        if result:
+            if min(cons) > 0 and words[min(cons) - 1] == "kello":
+                cons.add(min(cons) - 1)
+            return result[0], result[1], cons
+    return None
+
+
 def _month_from_word_fi(word):
     if word in _MONTHS_FI:
         return _MONTHS_FI[word]
@@ -209,6 +267,13 @@ def extract_datetime_fi(text, anchorDate=None, default_time=None):
     min_abs = None
     consumed = [False] * len(words)
     found = False
+
+    idiom = _scan_clock_idiom_fi(words)
+    if idiom is not None:
+        hr_abs, min_abs, cons = idiom
+        for c in cons:
+            consumed[c] = True
+        found = True
 
     for idx, word in enumerate(words):
         if consumed[idx]:

--- a/ovos_date_parser/dates_fi.py
+++ b/ovos_date_parser/dates_fi.py
@@ -1,0 +1,417 @@
+"""Finnish date and time parsing and formatting.
+
+Finnish is agglutinative and heavily inflected: numerals concatenate
+("kaksikymmentäyksi" = 21) and the noun that follows a numeral greater than
+one stands in the partitive singular ("kaksi tuntia", "viisi minuuttia").
+The spoken clock keeps the "kello" marker ("kello kaksitoista") and reads
+the year as a plain cardinal number rather than in decade pairs.
+
+References:
+    * Kotimaisten kielten keskus (Kotus), Kielitoimiston ohjepankki,
+      "Kellonajat" and "Päivämäärät"
+    * https://fi.wikipedia.org/wiki/Kellonaika
+"""
+from datetime import timedelta
+
+from ovos_number_parser.numbers_fi import (
+    pronounce_number_fi, extract_number_fi,
+)
+from ovos_utils.time import now_local
+
+from ovos_date_parser.duration import (
+    DurationResolution, DURATION_LEXICONS, extract_duration_generic,
+)
+
+# ---------------------------------------------------------------------------
+# formatting
+# ---------------------------------------------------------------------------
+
+# part-of-day adverbs (adessive/essive) used with the 12h clock
+_PART_OF_DAY_FI = (
+    (5, 11, "aamulla"),      # morning
+    (12, 17, "päivällä"),    # daytime
+    (18, 22, "illalla"),     # evening
+)
+
+
+def _part_of_day_fi(hour):
+    for start, end, word in _PART_OF_DAY_FI:
+        if start <= hour <= end:
+            return word
+    return "yöllä"  # night, 23..4
+
+
+def nice_year_fi(dt, bc=False):
+    """Speak a year as a Finnish cardinal number.
+
+    Finnish reads years as whole cardinals ("tuhat yhdeksänsataa-
+    kahdeksankymmentäneljä" for 1984), not as decade pairs.
+    """
+    year = pronounce_number_fi(dt.year)
+    if bc:
+        return year + " ennen Kristusta"
+    return year
+
+
+def _speak_minutes_fi(minute):
+    # single-digit minutes are read with a leading "nolla" (09:05)
+    if minute < 10:
+        return " nolla " + pronounce_number_fi(minute)
+    return " " + pronounce_number_fi(minute)
+
+
+def nice_time_fi(dt, speech=True, use_24hour=False, use_ampm=False):
+    """Format a time in a natural Finnish way.
+
+    For example, generate "kello viisitoista kolmekymmentä" for 15:30.
+
+    Args:
+        dt (datetime): date to format (assumes already in local timezone)
+        speech (bool): format for speech (default) or display (False)
+        use_24hour (bool): output in 24-hour format
+        use_ampm (bool): include a part-of-day adverb for 12-hour format
+    Returns:
+        (str): The formatted time string
+    """
+    if use_24hour:
+        string = dt.strftime("%H:%M")
+    else:
+        if use_ampm:
+            string = dt.strftime("%I:%M %p")
+        else:
+            string = dt.strftime("%I:%M")
+        if string[0] == "0":
+            string = string[1:]  # strip leading zero
+
+    if not speech:
+        return string
+
+    if use_24hour:
+        speak = "kello " + pronounce_number_fi(dt.hour)
+        if dt.minute:
+            speak += _speak_minutes_fi(dt.minute)
+        return speak
+
+    if dt.hour == 0 and dt.minute == 0:
+        return "keskiyö"
+    if dt.hour == 12 and dt.minute == 0:
+        return "keskipäivä"
+
+    hour = dt.hour % 12
+    if hour == 0:
+        hour = 12
+    speak = "kello " + pronounce_number_fi(hour)
+    if dt.minute:
+        speak += _speak_minutes_fi(dt.minute)
+    if use_ampm:
+        speak += " " + _part_of_day_fi(dt.hour)
+    return speak
+
+
+# ---------------------------------------------------------------------------
+# duration
+# ---------------------------------------------------------------------------
+
+def extract_duration_fi(text, resolution=DurationResolution.TIMEDELTA,
+                        replace_token=""):
+    """Convert a Finnish phrase into a duration.
+
+    Handles "kaksi tuntia", "puoli tuntia" is not supported (fractional
+    numerals are out of scope); numerals are read by the shared number
+    parser and matched against the declined unit nouns.
+    """
+    return extract_duration_generic(text, DURATION_LEXICONS["fi"],
+                                    resolution, replace_token)
+
+
+# ---------------------------------------------------------------------------
+# datetime extraction
+# ---------------------------------------------------------------------------
+
+_WEEKDAYS_FI = {
+    "maanantai": 0, "tiistai": 1, "keskiviikko": 2, "torstai": 3,
+    "perjantai": 4, "lauantai": 5, "sunnuntai": 6,
+}
+# the essive ("maanantaina") is the case used when naming the day of an event
+_WEEKDAYS_ESSIVE_FI = {
+    "maanantaina": 0, "tiistaina": 1, "keskiviikkona": 2, "torstaina": 3,
+    "perjantaina": 4, "lauantaina": 5, "sunnuntaina": 6,
+}
+_MONTHS_FI = {
+    "tammikuu": 1, "helmikuu": 2, "maaliskuu": 3, "huhtikuu": 4,
+    "toukokuu": 5, "kesäkuu": 6, "heinäkuu": 7, "elokuu": 8,
+    "syyskuu": 9, "lokakuu": 10, "marraskuu": 11, "joulukuu": 12,
+}
+# month stems accept the partitive/genitive endings that appear in dates
+# ("tammikuuta", "tammikuun")
+_MONTH_STEMS_FI = {name[:-2]: num for name, num in _MONTHS_FI.items()}
+
+_DAY_UNITS_FI = ("päivä", "päivää", "päivän", "päivan")
+_WEEK_UNITS_FI = ("viikko", "viikkoa", "viikon")
+_MONTH_UNITS_FI = ("kuukausi", "kuukautta", "kuukauden")
+_YEAR_UNITS_FI = ("vuosi", "vuotta", "vuoden")
+# adpositions that mark "in X <unit>" / "after"
+_AFTER_MARKERS_FI = ("kuluttua", "päästä", "päähän")
+_NEXT_FI = ("ensi", "seuraava", "seuraavana", "tuleva", "tulevana")
+_LAST_FI = ("viime", "edellinen", "edellisenä", "mennyt", "menneenä")
+
+
+def _clean_tokens_fi(text):
+    out = []
+    for tok in text.lower().replace(",", " ").split():
+        # keep internal separators (15.30, 15:30) but drop edge punctuation,
+        # so an ordinal "15." becomes "15"
+        tok = tok.strip("?!;:.")
+        if tok:
+            out.append(tok)
+    return out
+
+
+def _month_from_word_fi(word):
+    if word in _MONTHS_FI:
+        return _MONTHS_FI[word]
+    for stem, num in _MONTH_STEMS_FI.items():
+        if word.startswith(stem):
+            return num
+    return None
+
+
+def extract_datetime_fi(text, anchorDate=None, default_time=None):
+    """Extract date/time information from Finnish text.
+
+    Supported constructs (each verified against everyday usage):
+        * tänään / huomenna / ylihuomenna / eilen / toissapäivänä
+        * weekday names, optionally with ensi/viime
+        * "N päivän/viikon/kuukauden/vuoden kuluttua|päästä"
+        * "ensi|viime viikolla|kuussa|vuonna"
+        * clock times: "kello 15:30", "kello 15", "15:30", "15.30"
+        * dates with a month name: "15. tammikuuta", "tammikuun 15."
+
+    Returns a ``[datetime, leftover_text]`` pair, or ``None`` when nothing
+    date related is found.
+    """
+    if not text:
+        return None
+
+    anchor = anchorDate or now_local()
+    anchor = anchor.replace(microsecond=0)
+    words = _clean_tokens_fi(text)
+    if not words:
+        return None
+
+    day_offset = None
+    week_offset = 0
+    month_offset = 0
+    year_offset = 0
+    abs_month = None
+    abs_day = None
+    hr_abs = None
+    min_abs = None
+    consumed = [False] * len(words)
+    found = False
+
+    for idx, word in enumerate(words):
+        if consumed[idx]:
+            continue
+        prev = words[idx - 1] if idx > 0 else ""
+        nxt = words[idx + 1] if idx + 1 < len(words) else ""
+
+        # relative day keywords
+        if word in ("tänään", "nyt"):
+            day_offset = 0
+            consumed[idx] = True
+            found = True
+            continue
+        if word == "huomenna":
+            day_offset = 1
+            consumed[idx] = True
+            found = True
+            continue
+        if word == "ylihuomenna":
+            day_offset = 2
+            consumed[idx] = True
+            found = True
+            continue
+        if word == "eilen":
+            day_offset = -1
+            consumed[idx] = True
+            found = True
+            continue
+        if word in ("toissapäivänä", "toissa"):
+            day_offset = -2
+            consumed[idx] = True
+            found = True
+            continue
+
+        # weekdays (nominative or essive)
+        if word in _WEEKDAYS_FI or word in _WEEKDAYS_ESSIVE_FI:
+            target = _WEEKDAYS_FI.get(word, _WEEKDAYS_ESSIVE_FI.get(word))
+            diff = (target - anchor.weekday()) % 7
+            if prev in _NEXT_FI:
+                if diff == 0:
+                    diff = 7
+                consumed[idx - 1] = True
+            elif prev in _LAST_FI:
+                diff = diff - 7 if diff != 0 else -7
+                consumed[idx - 1] = True
+            day_offset = diff
+            consumed[idx] = True
+            found = True
+            continue
+
+        # "ensi/viime viikolla|kuussa|vuonna"
+        if word in ("viikolla", "viikko", "viikon") and prev in _NEXT_FI + _LAST_FI:
+            week_offset = 1 if prev in _NEXT_FI else -1
+            consumed[idx] = consumed[idx - 1] = True
+            found = True
+            continue
+        if word in ("kuussa", "kuukausi", "kuukautena") and prev in _NEXT_FI + _LAST_FI:
+            month_offset = 1 if prev in _NEXT_FI else -1
+            consumed[idx] = consumed[idx - 1] = True
+            found = True
+            continue
+        if word in ("vuonna", "vuosi", "vuotena") and prev in _NEXT_FI + _LAST_FI:
+            year_offset = 1 if prev in _NEXT_FI else -1
+            consumed[idx] = consumed[idx - 1] = True
+            found = True
+            continue
+
+        # "N <unit> kuluttua/päästä"
+        if word in _AFTER_MARKERS_FI and idx >= 2:
+            unit = words[idx - 1]
+            num = extract_number_fi(words[idx - 2])
+            if num is not False and num is not None:
+                num = int(num)
+                if unit in _DAY_UNITS_FI:
+                    day_offset = (day_offset or 0) + num
+                elif unit in _WEEK_UNITS_FI:
+                    week_offset += num
+                elif unit in _MONTH_UNITS_FI:
+                    month_offset += num
+                elif unit in _YEAR_UNITS_FI:
+                    year_offset += num
+                else:
+                    continue
+                consumed[idx] = consumed[idx - 1] = consumed[idx - 2] = True
+                found = True
+                continue
+
+        # clock time with explicit "kello" marker or a HH:MM / HH.MM token
+        if word == "kello":
+            time_tok = nxt
+            if _parse_clock_fi(time_tok) is not None:
+                hr_abs, min_abs = _parse_clock_fi(time_tok)
+                consumed[idx] = consumed[idx + 1] = True
+                found = True
+                continue
+            num = extract_number_fi(nxt) if nxt else False
+            if num is not False and num is not None and 0 <= num <= 23:
+                hr_abs, min_abs = int(num), 0
+                consumed[idx] = consumed[idx + 1] = True
+                found = True
+                continue
+
+        clock = _parse_clock_fi(word)
+        if clock is not None:
+            hr_abs, min_abs = clock
+            consumed[idx] = True
+            found = True
+            continue
+
+        # month-name dates
+        month = _month_from_word_fi(word)
+        if month is not None:
+            day = None
+            if prev:
+                d = _ordinal_day_fi(prev)
+                if d is not None:
+                    day = d
+                    consumed[idx - 1] = True
+            if day is None and nxt:
+                d = _ordinal_day_fi(nxt)
+                if d is not None:
+                    day = d
+                    consumed[idx + 1] = True
+            abs_month = month
+            abs_day = day if day is not None else 1
+            consumed[idx] = True
+            found = True
+            continue
+
+    if not found:
+        return None
+
+    extracted = anchor.replace(hour=0, minute=0, second=0)
+
+    if abs_month is not None:
+        year = anchor.year
+        try:
+            candidate = extracted.replace(month=abs_month, day=abs_day)
+        except ValueError:
+            return None
+        if candidate.date() < anchor.date():
+            candidate = candidate.replace(year=year + 1)
+        extracted = candidate
+    else:
+        if day_offset is not None:
+            extracted = extracted + timedelta(days=day_offset)
+        if week_offset:
+            extracted = extracted + timedelta(weeks=week_offset)
+        if month_offset:
+            extracted = _add_months(extracted, month_offset)
+        if year_offset:
+            try:
+                extracted = extracted.replace(year=extracted.year + year_offset)
+            except ValueError:  # Feb 29
+                extracted = extracted.replace(
+                    year=extracted.year + year_offset, day=28)
+
+    if hr_abs is None and default_time is not None:
+        hr_abs = default_time.hour
+        min_abs = default_time.minute
+    if hr_abs is not None:
+        extracted = extracted.replace(hour=hr_abs, minute=min_abs or 0)
+
+    leftover = " ".join(w for i, w in enumerate(words)
+                        if not consumed[i] and w != ".")
+    leftover = " ".join(leftover.split())
+    return [extracted, leftover]
+
+
+def _add_months(dt, months):
+    month = dt.month - 1 + months
+    year = dt.year + month // 12
+    month = month % 12 + 1
+    day = min(dt.day, [31, 29 if year % 4 == 0 and
+                       (year % 100 != 0 or year % 400 == 0) else 28,
+                       31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1])
+    return dt.replace(year=year, month=month, day=day)
+
+
+def _parse_clock_fi(token):
+    """Parse an HH:MM or HH.MM clock token into (hour, minute) or None."""
+    if not token:
+        return None
+    for sep in (":", "."):
+        if sep in token:
+            parts = token.split(sep)
+            if len(parts) == 2 and parts[0].isdigit() and parts[1].isdigit():
+                hour, minute = int(parts[0]), int(parts[1])
+                if 0 <= hour <= 23 and 0 <= minute <= 59:
+                    return hour, minute
+            return None
+    return None
+
+
+def _ordinal_day_fi(token):
+    """Return a day-of-month 1..31 from a "15." or "15" or spelled ordinal."""
+    stripped = token.rstrip(".")
+    if stripped.isdigit():
+        val = int(stripped)
+        if 1 <= val <= 31:
+            return val
+    from ovos_number_parser.numbers_fi import is_ordinal_fi
+    val = is_ordinal_fi(stripped)
+    if val is not False and 1 <= val <= 31:
+        return val
+    return None

--- a/ovos_date_parser/duration.py
+++ b/ovos_date_parser/duration.py
@@ -334,11 +334,30 @@ register_duration_lexicon(DurationLexicon(
         "millenniums": r"tisočletj(?:e|a|i|ih)?|tisočletij",
     }))
 
+def _normalize_finnic_half(text, lang):
+    # numbers_to_digits already folds "puoli"/"pool" -> 0.5 and
+    # "puolitoista"/"poolteist" -> 1.5; collapse "N ja 0.5" ("kolme ja
+    # puoli", "kolm ja pool") into "N.5" so the whole quantity is read
+    text = numbers_to_digits(text.lower(), lang)
+    return re.sub(r"(\d+)\s+ja\s+0[.,]5", r"\1.5", text)
+
+
+def _normalize_fi(text):
+    return _normalize_finnic_half(text, "fi")
+
+
+def _normalize_et(text):
+    return _normalize_finnic_half(text, "et")
+
+
 # Finnish nouns follow a numeral in the partitive singular ("kaksi tuntia");
 # the nominative ("tunti") and genitive ("tunnin", in "kahden tunnin") forms
 # also occur, so each unit accepts its common declined surface forms.
+# Fractional numerals ("puoli tuntia" = 0.5 h, "puolitoista tuntia" = 1.5 h,
+# "kolme ja puoli tuntia" = 3.5 h) are handled by the numeral normalizer.
 register_duration_lexicon(DurationLexicon(
     lang="fi",
+    normalize=_normalize_fi,
     units={
         "microseconds": r"mikrosekunt(?:ia|i)|mikrosekunnin",
         "milliseconds": r"millisekunt(?:ia|i)|millisekunnin",
@@ -356,8 +375,11 @@ register_duration_lexicon(DurationLexicon(
 
 # Estonian nouns follow a numeral in the partitive singular ("kaks tundi");
 # the nominative ("tund") and partitive/genitive variants also occur.
+# Fractional numerals ("pool tundi" = 0.5 h, "poolteist tundi" = 1.5 h,
+# "kolm ja pool tundi" = 3.5 h) are handled by the numeral normalizer.
 register_duration_lexicon(DurationLexicon(
     lang="et",
+    normalize=_normalize_et,
     units={
         "microseconds": r"mikrosekund(?:it|i)?",
         "milliseconds": r"millisekund(?:it|i)?",

--- a/ovos_date_parser/duration.py
+++ b/ovos_date_parser/duration.py
@@ -334,6 +334,45 @@ register_duration_lexicon(DurationLexicon(
         "millenniums": r"tisočletj(?:e|a|i|ih)?|tisočletij",
     }))
 
+# Finnish nouns follow a numeral in the partitive singular ("kaksi tuntia");
+# the nominative ("tunti") and genitive ("tunnin", in "kahden tunnin") forms
+# also occur, so each unit accepts its common declined surface forms.
+register_duration_lexicon(DurationLexicon(
+    lang="fi",
+    units={
+        "microseconds": r"mikrosekunt(?:ia|i)|mikrosekunnin",
+        "milliseconds": r"millisekunt(?:ia|i)|millisekunnin",
+        "seconds": r"sekunt(?:ia|i)|sekunnin",
+        "minutes": r"minuut(?:tia|ti)|minuutin",
+        "hours": r"(?:tunti|tuntia|tunnin)",
+        "days": r"(?:päivää|päivän|päivä|vuorokausi|vuorokautta)",
+        "weeks": r"(?:viikko|viikkoa|viikon)",
+        "months": r"(?:kuukausi|kuukautta|kuukauden)",
+        "years": r"(?:vuosi|vuotta|vuoden)",
+        "decades": r"(?:vuosikymmen|vuosikymmentä|vuosikymmenen)",
+        "centuries": r"(?:vuosisata|vuosisataa|vuosisadan)",
+        "millenniums": r"(?:vuosituhat|vuosituhatta|vuosituhannen)",
+    }))
+
+# Estonian nouns follow a numeral in the partitive singular ("kaks tundi");
+# the nominative ("tund") and partitive/genitive variants also occur.
+register_duration_lexicon(DurationLexicon(
+    lang="et",
+    units={
+        "microseconds": r"mikrosekund(?:it|i)?",
+        "milliseconds": r"millisekund(?:it|i)?",
+        "seconds": r"sekund(?:it|i)?",
+        "minutes": r"minut(?:it|i)?",
+        "hours": r"(?:tundi|tunni|tund)",
+        "days": r"(?:päeva|päev|ööpäev(?:a)?)",
+        "weeks": r"(?:nädalat|nädala|nädal)",
+        "months": r"(?:kuud|kuu)",
+        "years": r"(?:aastat|aasta)",
+        "decades": r"(?:aastakümmet|aastakümne|aastakümmend)",
+        "centuries": r"(?:aastasada|aastasaja|sajand(?:it|i)?)",
+        "millenniums": r"(?:aastatuhat|aastatuhande|aastatuhat)",
+    }))
+
 
 def _normalize_en(text: str) -> str:
     # the English-specific normalizer folds "X and a half" into X.5

--- a/ovos_date_parser/res/et/date_time.json
+++ b/ovos_date_parser/res/et/date_time.json
@@ -1,0 +1,112 @@
+{
+  "decade_format": {
+    "default": "{number}"
+  },
+  "hundreds_format": {
+    "default": "{number}"
+  },
+  "thousand_format": {
+    "default": "{number}"
+  },
+  "year_format": {
+    "default": "{year} {bc}",
+    "bc": "enne Kristust"
+  },
+  "date_format": {
+    "date_full": "{weekday} {day} {month} {formatted_year}",
+    "date_full_no_year": "{weekday} {day} {month}",
+    "date_full_no_year_month": "{weekday} {day}",
+    "today": "täna",
+    "tomorrow": "homme",
+    "yesterday": "eile"
+  },
+  "date_time_format": {
+    "date_time": "{formatted_date} {formatted_time}"
+  },
+  "weekday": {
+    "0": "esmaspäev",
+    "1": "teisipäev",
+    "2": "kolmapäev",
+    "3": "neljapäev",
+    "4": "reede",
+    "5": "laupäev",
+    "6": "pühapäev"
+  },
+  "date": {
+    "1": "esimene",
+    "2": "teine",
+    "3": "kolmas",
+    "4": "neljas",
+    "5": "viies",
+    "6": "kuues",
+    "7": "seitsmes",
+    "8": "kaheksas",
+    "9": "üheksas",
+    "10": "kümnes",
+    "11": "üheteistkümnes",
+    "12": "kaheteistkümnes",
+    "13": "kolmeteistkümnes",
+    "14": "neljateistkümnes",
+    "15": "viieteistkümnes",
+    "16": "kuueteistkümnes",
+    "17": "seitsmeteistkümnes",
+    "18": "kaheksateistkümnes",
+    "19": "üheksateistkümnes",
+    "20": "kahekümnes",
+    "21": "kahekümne esimene",
+    "22": "kahekümne teine",
+    "23": "kahekümne kolmas",
+    "24": "kahekümne neljas",
+    "25": "kahekümne viies",
+    "26": "kahekümne kuues",
+    "27": "kahekümne seitsmes",
+    "28": "kahekümne kaheksas",
+    "29": "kahekümne üheksas",
+    "30": "kolmekümnes",
+    "31": "kolmekümne esimene"
+  },
+  "month": {
+    "1": "jaanuar",
+    "2": "veebruar",
+    "3": "märts",
+    "4": "aprill",
+    "5": "mai",
+    "6": "juuni",
+    "7": "juuli",
+    "8": "august",
+    "9": "september",
+    "10": "oktoober",
+    "11": "november",
+    "12": "detsember"
+  },
+  "number": {
+    "0": "null",
+    "1": "üks",
+    "2": "kaks",
+    "3": "kolm",
+    "4": "neli",
+    "5": "viis",
+    "6": "kuus",
+    "7": "seitse",
+    "8": "kaheksa",
+    "9": "üheksa",
+    "10": "kümme",
+    "20": "kakskümmend",
+    "30": "kolmkümmend",
+    "40": "nelikümmend",
+    "50": "viiskümmend",
+    "60": "kuuskümmend",
+    "70": "seitsekümmend",
+    "80": "kaheksakümmend",
+    "90": "üheksakümmend",
+    "11": "üksteist",
+    "12": "kaksteist",
+    "13": "kolmteist",
+    "14": "neliteist",
+    "15": "viisteist",
+    "16": "kuusteist",
+    "17": "seitseteist",
+    "18": "kaheksateist",
+    "19": "üheksateist"
+  }
+}

--- a/ovos_date_parser/res/et/date_words.json
+++ b/ovos_date_parser/res/et/date_words.json
@@ -1,0 +1,11 @@
+{
+  "second": "sekund",
+  "seconds": "sekundit",
+  "minute": "minut",
+  "minutes": "minutit",
+  "hour": "tund",
+  "hours": "tundi",
+  "day": "päev",
+  "days": "päeva",
+  "now": "nüüd"
+}

--- a/ovos_date_parser/res/fi/date_time.json
+++ b/ovos_date_parser/res/fi/date_time.json
@@ -1,0 +1,112 @@
+{
+  "decade_format": {
+    "default": "{number}"
+  },
+  "hundreds_format": {
+    "default": "{number}"
+  },
+  "thousand_format": {
+    "default": "{number}"
+  },
+  "year_format": {
+    "default": "{year} {bc}",
+    "bc": "ennen Kristusta"
+  },
+  "date_format": {
+    "date_full": "{weekday} {day} {month} {formatted_year}",
+    "date_full_no_year": "{weekday} {day} {month}",
+    "date_full_no_year_month": "{weekday} {day}",
+    "today": "tänään",
+    "tomorrow": "huomenna",
+    "yesterday": "eilen"
+  },
+  "date_time_format": {
+    "date_time": "{formatted_date} {formatted_time}"
+  },
+  "weekday": {
+    "0": "maanantai",
+    "1": "tiistai",
+    "2": "keskiviikko",
+    "3": "torstai",
+    "4": "perjantai",
+    "5": "lauantai",
+    "6": "sunnuntai"
+  },
+  "date": {
+    "1": "ensimmäinen",
+    "2": "toinen",
+    "3": "kolmas",
+    "4": "neljäs",
+    "5": "viides",
+    "6": "kuudes",
+    "7": "seitsemäs",
+    "8": "kahdeksas",
+    "9": "yhdeksäs",
+    "10": "kymmenes",
+    "11": "yhdestoista",
+    "12": "kahdestoista",
+    "13": "kolmastoista",
+    "14": "neljästoista",
+    "15": "viidestoista",
+    "16": "kuudestoista",
+    "17": "seitsemästoista",
+    "18": "kahdeksastoista",
+    "19": "yhdeksästoista",
+    "20": "kahdeskymmenes",
+    "21": "kahdeskymmenesensimmäinen",
+    "22": "kahdeskymmenestoinen",
+    "23": "kahdeskymmeneskolmas",
+    "24": "kahdeskymmenesneljäs",
+    "25": "kahdeskymmenesviides",
+    "26": "kahdeskymmeneskuudes",
+    "27": "kahdeskymmenesseitsemäs",
+    "28": "kahdeskymmeneskahdeksas",
+    "29": "kahdeskymmenesyhdeksäs",
+    "30": "kolmaskymmenes",
+    "31": "kolmaskymmenesensimmäinen"
+  },
+  "month": {
+    "1": "tammikuu",
+    "2": "helmikuu",
+    "3": "maaliskuu",
+    "4": "huhtikuu",
+    "5": "toukokuu",
+    "6": "kesäkuu",
+    "7": "heinäkuu",
+    "8": "elokuu",
+    "9": "syyskuu",
+    "10": "lokakuu",
+    "11": "marraskuu",
+    "12": "joulukuu"
+  },
+  "number": {
+    "0": "nolla",
+    "1": "yksi",
+    "2": "kaksi",
+    "3": "kolme",
+    "4": "neljä",
+    "5": "viisi",
+    "6": "kuusi",
+    "7": "seitsemän",
+    "8": "kahdeksan",
+    "9": "yhdeksän",
+    "10": "kymmenen",
+    "20": "kaksikymmentä",
+    "30": "kolmekymmentä",
+    "40": "neljäkymmentä",
+    "50": "viisikymmentä",
+    "60": "kuusikymmentä",
+    "70": "seitsemänkymmentä",
+    "80": "kahdeksankymmentä",
+    "90": "yhdeksänkymmentä",
+    "11": "yksitoista",
+    "12": "kaksitoista",
+    "13": "kolmetoista",
+    "14": "neljätoista",
+    "15": "viisitoista",
+    "16": "kuusitoista",
+    "17": "seitsemäntoista",
+    "18": "kahdeksantoista",
+    "19": "yhdeksäntoista"
+  }
+}

--- a/ovos_date_parser/res/fi/date_words.json
+++ b/ovos_date_parser/res/fi/date_words.json
@@ -1,0 +1,11 @@
+{
+  "second": "sekunti",
+  "seconds": "sekuntia",
+  "minute": "minuutti",
+  "minutes": "minuuttia",
+  "hour": "tunti",
+  "hours": "tuntia",
+  "day": "päivä",
+  "days": "päivää",
+  "now": "nyt"
+}

--- a/test/test_dates_et.py
+++ b/test/test_dates_et.py
@@ -1,0 +1,181 @@
+"""Estonian date/time tests: behaviour, adversarial input, round-trip sweep."""
+import unittest
+from datetime import datetime, timedelta
+
+from ovos_date_parser import (extract_datetime, extract_duration, nice_time,
+                              nice_duration, nice_weekday, nice_month,
+                              nice_year, nice_date)
+from ovos_date_parser.dates_et import extract_duration_et
+
+# Wednesday 10 January 2024, 12:00
+ANCHOR = datetime(2024, 1, 10, 12, 0)
+
+
+class TestNiceTimeEt(unittest.TestCase):
+    def test_24hour(self):
+        self.assertEqual(nice_time(datetime(2024, 1, 1, 15, 30), "et",
+                                   use_24hour=True),
+                         "kell viisteist kolmkümmend")
+        self.assertEqual(nice_time(datetime(2024, 1, 1, 9, 5), "et",
+                                   use_24hour=True),
+                         "kell üheksa null viis")
+        self.assertEqual(nice_time(datetime(2024, 1, 1, 14, 0), "et",
+                                   use_24hour=True),
+                         "kell neliteist")
+
+    def test_12hour(self):
+        self.assertEqual(nice_time(datetime(2024, 1, 1, 15, 30), "et"),
+                         "kell kolm kolmkümmend")
+
+    def test_special(self):
+        self.assertEqual(nice_time(datetime(2024, 1, 1, 0, 0), "et"),
+                         "kesköö")
+        self.assertEqual(nice_time(datetime(2024, 1, 1, 12, 0), "et"),
+                         "keskpäev")
+
+    def test_ampm_part_of_day(self):
+        self.assertTrue(nice_time(datetime(2024, 1, 1, 20, 0), "et",
+                                  use_ampm=True).endswith("õhtul"))
+        self.assertTrue(nice_time(datetime(2024, 1, 1, 8, 0), "et",
+                                  use_ampm=True).endswith("hommikul"))
+
+    def test_display(self):
+        self.assertEqual(nice_time(datetime(2024, 1, 1, 13, 4), "et",
+                                   speech=False, use_24hour=True), "13:04")
+
+
+class TestNiceDateFamilyEt(unittest.TestCase):
+    def test_weekday(self):
+        self.assertEqual(nice_weekday(ANCHOR, "et"), "Kolmapäev")
+
+    def test_month(self):
+        self.assertEqual(nice_month(ANCHOR, "et"), "Jaanuar")
+
+    def test_year_is_cardinal(self):
+        self.assertEqual(nice_year(datetime(1984, 1, 1), "et"),
+                         "tuhat üheksasada kaheksakümmend neli")
+
+    def test_year_bc(self):
+        self.assertTrue(nice_year(datetime(44, 1, 1), "et", bc=True)
+                        .endswith("enne Kristust"))
+
+    def test_nice_date_non_empty(self):
+        self.assertTrue(nice_date(ANCHOR, "et").strip())
+
+
+class TestExtractDatetimeEt(unittest.TestCase):
+    def test_relative_days(self):
+        self.assertEqual(extract_datetime("homme", "et", ANCHOR)[0].date(),
+                         datetime(2024, 1, 11).date())
+        self.assertEqual(extract_datetime("eile", "et", ANCHOR)[0].date(),
+                         datetime(2024, 1, 9).date())
+        self.assertEqual(extract_datetime("ülehomme", "et", ANCHOR)[0].date(),
+                         datetime(2024, 1, 12).date())
+
+    def test_weekday_adessive_and_next(self):
+        self.assertEqual(
+            extract_datetime("teisipäeval", "et", ANCHOR)[0].date(),
+            datetime(2024, 1, 16).date())
+        self.assertEqual(
+            extract_datetime("järgmine esmaspäev", "et", ANCHOR)[0].date(),
+            datetime(2024, 1, 15).date())
+        self.assertEqual(
+            extract_datetime("eelmine reede", "et", ANCHOR)[0].date(),
+            datetime(2024, 1, 5).date())
+
+    def test_clock(self):
+        dt, _ = extract_datetime("kell 15:30", "et", ANCHOR)
+        self.assertEqual((dt.hour, dt.minute), (15, 30))
+        dt, _ = extract_datetime("kell 9", "et", ANCHOR)
+        self.assertEqual((dt.hour, dt.minute), (9, 0))
+
+    def test_month_date(self):
+        self.assertEqual(
+            extract_datetime("15. jaanuar", "et", ANCHOR)[0].date(),
+            datetime(2024, 1, 15).date())
+
+    def test_relative_offset(self):
+        self.assertEqual(
+            extract_datetime("kolm päeva pärast", "et", ANCHOR)[0].date(),
+            datetime(2024, 1, 13).date())
+
+    def test_leftover(self):
+        dt, leftover = extract_datetime("kohtumine kell 9", "et", ANCHOR)
+        self.assertEqual(leftover, "kohtumine")
+
+
+class TestExtractDatetimeAdversarialEt(unittest.TestCase):
+    def test_empty(self):
+        self.assertIsNone(extract_datetime("", "et", ANCHOR))
+
+    def test_none(self):
+        self.assertIsNone(extract_datetime(None, "et", ANCHOR))
+
+    def test_no_date(self):
+        self.assertIsNone(extract_datetime("tere kuidas läheb", "et", ANCHOR))
+
+    def test_punctuation_only(self):
+        self.assertIsNone(extract_datetime("?!.,", "et", ANCHOR))
+
+    def test_invalid_clock_not_time(self):
+        self.assertIsNone(extract_datetime("kell 25:99", "et", ANCHOR))
+
+    def test_out_of_range_ordinal_day_ignored(self):
+        res = extract_datetime("45. jaanuar", "et", ANCHOR)
+        self.assertIsNotNone(res)
+        self.assertEqual(res[0].month, 1)
+
+    def test_garbage_tokens(self):
+        self.assertIsNone(extract_datetime("xyzzy qwerty 12345abc", "et",
+                                           ANCHOR))
+
+
+class TestExtractDurationAdversarialEt(unittest.TestCase):
+    def test_empty(self):
+        self.assertIsNone(extract_duration("", "et"))
+
+    def test_no_duration(self):
+        dur, _ = extract_duration("siin pole midagi", "et")
+        self.assertIsNone(dur)
+
+    def test_unit_without_number(self):
+        dur, _ = extract_duration("tundi", "et")
+        self.assertIsNone(dur)
+
+    def test_number_without_unit(self):
+        dur, _ = extract_duration("viis", "et")
+        self.assertIsNone(dur)
+
+    def test_direct_function_matches_dispatch(self):
+        self.assertEqual(extract_duration_et("kaks tundi")[0],
+                         timedelta(hours=2))
+
+
+class TestDurationRoundTripEt(unittest.TestCase):
+    """Sweep: nice_duration(seconds) -> extract_duration -> identity."""
+
+    def _values(self):
+        vals = set()
+        vals.update(range(1, 141))
+        vals.update(m * 60 for m in range(1, 61))
+        for h in range(1, 13):
+            vals.add(h * 3600)
+            vals.add(h * 3600 + 30 * 60)
+            vals.add(h * 3600 + 90)
+        for d in range(1, 15):
+            vals.add(d * 86400 + 3600 + 60 + 1)
+        return sorted(vals)
+
+    def test_round_trip(self):
+        values = self._values()
+        self.assertGreaterEqual(len(values), 200)
+        for secs in values:
+            spoken = nice_duration(secs, "et")
+            dur, _ = extract_duration(spoken, "et")
+            self.assertIsNotNone(dur, f"{secs}: {spoken!r}")
+            self.assertEqual(int(dur.total_seconds()), secs,
+                             f"{secs}: {spoken!r} -> {dur}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_dates_et.py
+++ b/test/test_dates_et.py
@@ -104,6 +104,49 @@ class TestExtractDatetimeEt(unittest.TestCase):
         self.assertEqual(leftover, "kohtumine")
 
 
+class TestClockIdiomsEt(unittest.TestCase):
+    def _hm(self, text):
+        res = extract_datetime(text, "et", ANCHOR)
+        self.assertIsNotNone(res, text)
+        return res[0].hour, res[0].minute
+
+    def test_half_hour_is_before_named_hour(self):
+        # the classic trap: "pool kaks" is 1:30, NOT 2:30
+        self.assertEqual(self._hm("pool kaks"), (1, 30))
+        self.assertEqual(self._hm("pool kolm"), (2, 30))
+
+    def test_half_hour_wraps_at_one(self):
+        self.assertEqual(self._hm("pool üks"), (12, 30))
+
+    def test_quarter_into_hour(self):
+        # traditional Estonian counting toward the coming hour
+        self.assertEqual(self._hm("veerand kaks"), (1, 15))
+
+    def test_three_quarters_into_hour(self):
+        self.assertEqual(self._hm("kolmveerand kaks"), (1, 45))
+
+    def test_with_kell(self):
+        self.assertEqual(self._hm("kell pool kaks"), (1, 30))
+
+    def test_duration_pool_not_read_as_clock(self):
+        # "pool tundi" is a duration, not a half-clock -> no datetime
+        self.assertIsNone(extract_datetime("pool tundi", "et", ANCHOR))
+
+
+class TestFractionalDurationEt(unittest.TestCase):
+    def test_half_hour(self):
+        self.assertEqual(extract_duration("pool tundi", "et")[0],
+                         timedelta(minutes=30))
+
+    def test_one_and_a_half_hours(self):
+        self.assertEqual(extract_duration("poolteist tundi", "et")[0],
+                         timedelta(hours=1, minutes=30))
+
+    def test_n_and_a_half_hours(self):
+        self.assertEqual(extract_duration("kolm ja pool tundi", "et")[0],
+                         timedelta(hours=3, minutes=30))
+
+
 class TestExtractDatetimeAdversarialEt(unittest.TestCase):
     def test_empty(self):
         self.assertIsNone(extract_datetime("", "et", ANCHOR))

--- a/test/test_dates_fi.py
+++ b/test/test_dates_fi.py
@@ -109,6 +109,60 @@ class TestExtractDatetimeFi(unittest.TestCase):
         self.assertEqual(leftover, "tapaaminen")
 
 
+class TestClockIdiomsFi(unittest.TestCase):
+    def _hm(self, text):
+        res = extract_datetime(text, "fi", ANCHOR)
+        self.assertIsNotNone(res, text)
+        return res[0].hour, res[0].minute
+
+    def test_half_hour_is_before_named_hour(self):
+        # the classic trap: "puoli kaksi" is 1:30, NOT 2:30
+        self.assertEqual(self._hm("puoli kaksi"), (1, 30))
+        self.assertEqual(self._hm("puoli kolme"), (2, 30))
+
+    def test_half_hour_wraps_at_one(self):
+        # "puoli yksi" is half an hour before one o'clock -> 12:30
+        self.assertEqual(self._hm("puoli yksi"), (12, 30))
+
+    def test_half_hour_with_kello(self):
+        self.assertEqual(self._hm("kello puoli kaksi"), (1, 30))
+
+    def test_quarter_past(self):
+        self.assertEqual(self._hm("varttia yli kaksi"), (2, 15))
+
+    def test_quarter_to(self):
+        self.assertEqual(self._hm("varttia vaille kaksi"), (1, 45))
+
+    def test_minutes_past(self):
+        self.assertEqual(self._hm("kymmenen yli kaksi"), (2, 10))
+        self.assertEqual(self._hm("viisitoista yli kolme"), (3, 15))
+
+    def test_minutes_to(self):
+        self.assertEqual(self._hm("kymmentä vaille kaksi"), (1, 50))
+
+    def test_duration_puoli_not_read_as_clock(self):
+        # "puoli tuntia" is a duration, not a half-clock -> no datetime
+        self.assertIsNone(extract_datetime("puoli tuntia", "fi", ANCHOR))
+
+
+class TestFractionalDurationFi(unittest.TestCase):
+    def test_half_hour(self):
+        self.assertEqual(extract_duration("puoli tuntia", "fi")[0],
+                         timedelta(minutes=30))
+
+    def test_one_and_a_half_hours(self):
+        self.assertEqual(extract_duration("puolitoista tuntia", "fi")[0],
+                         timedelta(hours=1, minutes=30))
+
+    def test_n_and_a_half_hours(self):
+        self.assertEqual(extract_duration("kolme ja puoli tuntia", "fi")[0],
+                         timedelta(hours=3, minutes=30))
+
+    def test_half_minute(self):
+        self.assertEqual(extract_duration("puoli minuuttia", "fi")[0],
+                         timedelta(seconds=30))
+
+
 class TestExtractDatetimeAdversarialFi(unittest.TestCase):
     def test_empty(self):
         self.assertIsNone(extract_datetime("", "fi", ANCHOR))

--- a/test/test_dates_fi.py
+++ b/test/test_dates_fi.py
@@ -1,0 +1,193 @@
+"""Finnish date/time tests: behaviour, adversarial input, round-trip sweep."""
+import unittest
+from datetime import datetime, timedelta
+
+from ovos_date_parser import (extract_datetime, extract_duration, nice_time,
+                              nice_duration, nice_weekday, nice_month,
+                              nice_year, nice_date)
+from ovos_date_parser.dates_fi import extract_duration_fi
+
+# Wednesday 10 January 2024, 12:00
+ANCHOR = datetime(2024, 1, 10, 12, 0)
+
+
+class TestNiceTimeFi(unittest.TestCase):
+    def test_24hour(self):
+        self.assertEqual(nice_time(datetime(2024, 1, 1, 15, 30), "fi",
+                                   use_24hour=True),
+                         "kello viisitoista kolmekymmentä")
+        self.assertEqual(nice_time(datetime(2024, 1, 1, 9, 5), "fi",
+                                   use_24hour=True),
+                         "kello yhdeksän nolla viisi")
+        self.assertEqual(nice_time(datetime(2024, 1, 1, 14, 0), "fi",
+                                   use_24hour=True),
+                         "kello neljätoista")
+
+    def test_12hour(self):
+        self.assertEqual(nice_time(datetime(2024, 1, 1, 15, 30), "fi"),
+                         "kello kolme kolmekymmentä")
+
+    def test_special(self):
+        self.assertEqual(nice_time(datetime(2024, 1, 1, 0, 0), "fi"),
+                         "keskiyö")
+        self.assertEqual(nice_time(datetime(2024, 1, 1, 12, 0), "fi"),
+                         "keskipäivä")
+
+    def test_ampm_part_of_day(self):
+        self.assertTrue(nice_time(datetime(2024, 1, 1, 20, 0), "fi",
+                                  use_ampm=True).endswith("illalla"))
+        self.assertTrue(nice_time(datetime(2024, 1, 1, 8, 0), "fi",
+                                  use_ampm=True).endswith("aamulla"))
+
+    def test_display(self):
+        self.assertEqual(nice_time(datetime(2024, 1, 1, 13, 4), "fi",
+                                   speech=False, use_24hour=True), "13:04")
+
+
+class TestNiceDateFamilyFi(unittest.TestCase):
+    def test_weekday(self):
+        self.assertEqual(nice_weekday(ANCHOR, "fi"), "Keskiviikko")
+
+    def test_month(self):
+        self.assertEqual(nice_month(ANCHOR, "fi"), "Tammikuu")
+
+    def test_year_is_cardinal(self):
+        self.assertEqual(nice_year(datetime(1984, 1, 1), "fi"),
+                         "tuhatyhdeksänsataakahdeksankymmentäneljä")
+
+    def test_year_bc(self):
+        self.assertTrue(nice_year(datetime(44, 1, 1), "fi", bc=True)
+                        .endswith("ennen Kristusta"))
+
+    def test_nice_date_non_empty(self):
+        self.assertTrue(nice_date(ANCHOR, "fi").strip())
+
+
+class TestExtractDatetimeFi(unittest.TestCase):
+    def test_relative_days(self):
+        self.assertEqual(extract_datetime("huomenna", "fi", ANCHOR)[0].date(),
+                         datetime(2024, 1, 11).date())
+        self.assertEqual(extract_datetime("eilen", "fi", ANCHOR)[0].date(),
+                         datetime(2024, 1, 9).date())
+        self.assertEqual(extract_datetime("ylihuomenna", "fi", ANCHOR)[0].date(),
+                         datetime(2024, 1, 12).date())
+
+    def test_weekday_essive_and_next(self):
+        self.assertEqual(
+            extract_datetime("maanantaina", "fi", ANCHOR)[0].date(),
+            datetime(2024, 1, 15).date())
+        self.assertEqual(
+            extract_datetime("ensi maanantaina", "fi", ANCHOR)[0].date(),
+            datetime(2024, 1, 15).date())
+        self.assertEqual(
+            extract_datetime("viime perjantaina", "fi", ANCHOR)[0].date(),
+            datetime(2024, 1, 5).date())
+
+    def test_clock(self):
+        dt, _ = extract_datetime("kello 15:30", "fi", ANCHOR)
+        self.assertEqual((dt.hour, dt.minute), (15, 30))
+        dt, _ = extract_datetime("kello 9", "fi", ANCHOR)
+        self.assertEqual((dt.hour, dt.minute), (9, 0))
+        dt, _ = extract_datetime("15.30", "fi", ANCHOR)
+        self.assertEqual((dt.hour, dt.minute), (15, 30))
+
+    def test_month_date(self):
+        self.assertEqual(
+            extract_datetime("15. tammikuuta", "fi", ANCHOR)[0].date(),
+            datetime(2024, 1, 15).date())
+        self.assertEqual(
+            extract_datetime("tammikuun 20", "fi", ANCHOR)[0].date(),
+            datetime(2024, 1, 20).date())
+
+    def test_relative_offset(self):
+        self.assertEqual(
+            extract_datetime("kolme päivää kuluttua", "fi", ANCHOR)[0].date(),
+            datetime(2024, 1, 13).date())
+
+    def test_leftover(self):
+        dt, leftover = extract_datetime("tapaaminen kello 9", "fi", ANCHOR)
+        self.assertEqual(leftover, "tapaaminen")
+
+
+class TestExtractDatetimeAdversarialFi(unittest.TestCase):
+    def test_empty(self):
+        self.assertIsNone(extract_datetime("", "fi", ANCHOR))
+
+    def test_none(self):
+        self.assertIsNone(extract_datetime(None, "fi", ANCHOR))
+
+    def test_no_date(self):
+        self.assertIsNone(extract_datetime("hei mitä kuuluu", "fi", ANCHOR))
+
+    def test_punctuation_only(self):
+        self.assertIsNone(extract_datetime("?!.,", "fi", ANCHOR))
+
+    def test_invalid_clock_not_time(self):
+        # 25:99 is not a valid clock; must not be read as a time
+        res = extract_datetime("kello 25:99", "fi", ANCHOR)
+        self.assertIsNone(res)
+
+    def test_out_of_range_ordinal_day_ignored(self):
+        # "45. tammikuuta" -> impossible day, falls back to day 1 of month
+        res = extract_datetime("45. tammikuuta", "fi", ANCHOR)
+        self.assertIsNotNone(res)
+        self.assertEqual(res[0].month, 1)
+
+    def test_garbage_tokens(self):
+        self.assertIsNone(extract_datetime("xyzzy qwerty 12345abc", "fi",
+                                           ANCHOR))
+
+
+class TestExtractDurationAdversarialFi(unittest.TestCase):
+    def test_empty(self):
+        self.assertIsNone(extract_duration("", "fi"))
+
+    def test_no_duration(self):
+        dur, rem = extract_duration("ei mitään tässä", "fi")
+        self.assertIsNone(dur)
+
+    def test_unit_without_number(self):
+        dur, _ = extract_duration("tuntia", "fi")
+        self.assertIsNone(dur)
+
+    def test_number_without_unit(self):
+        dur, _ = extract_duration("viisi", "fi")
+        self.assertIsNone(dur)
+
+    def test_direct_function_matches_dispatch(self):
+        self.assertEqual(extract_duration_fi("kaksi tuntia")[0],
+                         timedelta(hours=2))
+
+
+class TestDurationRoundTripFi(unittest.TestCase):
+    """Sweep: nice_duration(seconds) -> extract_duration -> identity."""
+
+    def _values(self):
+        vals = set()
+        # every second 1..90 (covers seconds+minute boundary)
+        vals.update(range(1, 141))
+        # minute multiples
+        vals.update(m * 60 for m in range(1, 61))
+        # hour multiples and combinations
+        for h in range(1, 13):
+            vals.add(h * 3600)
+            vals.add(h * 3600 + 30 * 60)
+            vals.add(h * 3600 + 90)
+        # day-scale combinations
+        for d in range(1, 15):
+            vals.add(d * 86400 + 3600 + 60 + 1)
+        return sorted(vals)
+
+    def test_round_trip(self):
+        values = self._values()
+        self.assertGreaterEqual(len(values), 200)
+        for secs in values:
+            spoken = nice_duration(secs, "fi")
+            dur, _ = extract_duration(spoken, "fi")
+            self.assertIsNotNone(dur, f"{secs}: {spoken!r}")
+            self.assertEqual(int(dur.total_seconds()), secs,
+                             f"{secs}: {spoken!r} -> {dur}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_lang_parity.py
+++ b/test/test_lang_parity.py
@@ -11,14 +11,16 @@ from ovos_date_parser import (extract_datetime, extract_duration, nice_date,
                               nice_month, nice_relative_time, nice_time,
                               nice_weekday, nice_year, get_date_strings)
 
-LANGS = ["ar", "ast", "az", "ca", "cs", "da", "de", "en", "es", "eu", "fa", "fr",
-         "gl", "hu", "it", "kab", "nl", "oc", "pl", "pt", "ro", "ru", "sl", "sv", "uk"]
+LANGS = ["ar", "ast", "az", "ca", "cs", "da", "de", "en", "es", "et", "eu", "fa",
+         "fi", "fr", "gl", "hu", "it", "kab", "nl", "oc", "pl", "pt", "ro", "ru",
+         "sl", "sv", "uk"]
 
 ANCHOR = datetime(2017, 6, 27, 13, 4)
 
 _TOMORROW = {
     "ar": "غداً", "ast": "mañana", "az": "sabah", "ca": "demà", "cs": "zítra", "da": "i morgen",
-    "de": "morgen", "en": "tomorrow", "es": "mañana", "eu": "bihar",
+    "de": "morgen", "en": "tomorrow", "es": "mañana", "et": "homme", "eu": "bihar",
+    "fi": "huomenna",
     "fa": "فردا", "fr": "demain", "gl": "mañá", "hu": "holnap",
     "it": "domani", "kab": "azekka", "nl": "morgen", "oc": "deman", "pl": "jutro", "pt": "amanhã",
     "ro": "mâine", "ru": "завтра", "sl": "jutri", "sv": "imorgon", "uk": "завтра",
@@ -27,7 +29,8 @@ _TOMORROW = {
 _NO_DATE = {
     "ar": "مرحبا كيف حالك", "ast": "hola qué tal", "az": "salam necəsən", "ca": "hola com estàs", "cs": "ahoj jak se máš",
     "da": "hej hvordan har du det", "de": "hallo wie geht es dir",
-    "en": "hello how are you", "es": "hola qué tal", "eu": "kaixo zer moduz",
+    "en": "hello how are you", "es": "hola qué tal", "et": "tere kuidas läheb",
+    "eu": "kaixo zer moduz", "fi": "hei mitä kuuluu",
     "fa": "سلام چطوری", "fr": "bonjour ça va", "gl": "ola que tal",
     "hu": "szia hogy vagy", "it": "ciao come stai",
     "kab": "azul fell-awen amek tellam", "nl": "hallo hoe gaat het",
@@ -40,7 +43,8 @@ _NO_DATE = {
 _DURATION_STRINGS = {
     "ar": "١٠ دقائق", "ast": "10 minutos", "az": "10 dəqiqə", "ca": "10 minuts", "cs": "10 minut",
     "da": "10 minutter", "de": "10 minuten", "en": "10 minutes",
-    "es": "10 minutos", "eu": "10 minutu", "fa": "۱۰ دقیقه",
+    "es": "10 minutos", "et": "10 minutit", "eu": "10 minutu", "fa": "۱۰ دقیقه",
+    "fi": "10 minuuttia",
     "fr": "10 minutes", "gl": "10 minutos", "hu": "10 perc",
     "it": "10 minuti", "kab": "10 n tesdidin", "nl": "10 minuten", "pl": "10 minut",
     "pt": "10 minutos", "ro": "10 minute", "ru": "10 минут", "sl": "10 minut",


### PR DESCRIPTION
Adds date and time support for Finnish (`fi`) and Estonian (`et`), the two Finnic languages, wired into every public dispatch entry point in `ovos_date_parser`.

## Approach

Both languages are agglutinative and heavily inflected: numerals concatenate (`kaksikymmentäyksi` = 21) and the noun following a numeral greater than one stands in the partitive singular (`kaksi tuntia`, `kaks tundi`). Number pronunciation and extraction reuse the already-verified `ovos-number-parser` engines. Estonian is implemented explicitly with its own forms and is never aliased to Finnish.

## Per language

- `nice_time` — spoken clock with the `kello`/`kell` marker, `keskiyö`/`kesköö` (midnight), `keskipäivä`/`keskpäev` (noon) and part-of-day adverbs (`aamulla`/`hommikul` …). Single-digit minutes read with the leading zero word.
- `nice_year` — read as a whole cardinal number; Finnic does not split years into decade pairs.
- `nice_weekday`, `nice_month`, `nice_date`, `nice_date_time`, `nice_relative_time` — via the shared resource engine (`res/fi`, `res/et`). Weekday/month tables and 1–31 day ordinals are generated from the verified number-parser ordinal functions. Years render as digits inside `nice_date` (the natural written form).
- `extract_duration` — on the shared unit-lexicon engine, tolerating nominative, partitive and genitive unit forms.
- `extract_datetime` — relative days (`tänään`/`täna`, `huomenna`/`homme`, `ylihuomenna`/`ülehomme`, `eilen`/`eile`, …), weekday names in the essive/adessive with `ensi/viime` and `järgmine/eelmine` qualifiers, `N <unit> kuluttua/pärast`, clock times (`kello 15:30`, `15.30`, `kell 9`) and month-name dates (`15. tammikuuta`, `jaanuari 15`).

## Scope and omissions

- `extract_datetime` covers the high-confidence, verifiable constructs above. Idiomatic half/quarter clock phrasing (`puoli kaksi`) is deliberately out of scope for extraction rather than shipped uncertain. Fractional durations (`puoli tuntia`) are likewise out of scope.
- Non-date input returns `None` (null beats wrong).

## Tests

`test/test_dates_fi.py`, `test/test_dates_et.py`:
- per-language behaviour for every function,
- adversarial cases: empty, `None`, garbage tokens, punctuation-only, invalid clock (`25:99`), out-of-range ordinal day,
- a 200+ value duration round-trip sweep (`nice_duration` → `extract_duration` identity).

`fi`/`et` added to the `test_lang_parity.py` guard so both must implement every public entry point. The round-trip sweep caught and fixed a real bug in the Finnish seconds unit fragment.

Full suite: 487 passed (the single `test_packaging` failure is a pre-existing environment version-metadata mismatch, unrelated to this change).

## Sources

- Kotimaisten kielten keskus (Kotus), Kielitoimiston ohjepankki — kellonajat / päivämäärät / numeraalit
- Eesti Keele Instituut (EKI), Eesti keele käsiraamat — arvsõnad, kellaaja/kuupäeva usage
- fi.wikipedia.org / et.wikipedia.org clock and calendar conventions