### PR TITLE
feat: West Frisian date formatting

### DIFF
--- a/ovos_date_parser/__init__.py
+++ b/ovos_date_parser/__init__.py
@@ -29,6 +29,10 @@ from ovos_date_parser.dates_ast import (
     extract_duration_ast, extract_datetime_ast, nice_year_ast, nice_weekday_ast, nice_month_ast,
     nice_day_ast, nice_date_time_ast, nice_date_ast, nice_time_ast
 )
+from ovos_date_parser.dates_fy import (
+    nice_year_fy, nice_weekday_fy, nice_month_fy, nice_day_fy,
+    nice_date_time_fy, nice_date_fy, nice_time_fy, nice_part_of_day_fy
+)
 from ovos_date_parser.dates_az import (
     extract_datetime_az, extract_duration_az, nice_duration_az, nice_time_az,
 )
@@ -162,6 +166,8 @@ def nice_time(
         return nice_time_it(dt, speech, use_24hour, use_ampm)
     if lang.startswith("kab"):
         return nice_time_kab(dt, speech, use_24hour, use_ampm)
+    if lang.startswith("fy"):
+        return nice_time_fy(dt, speech, use_24hour, use_ampm)
     if lang.startswith("nl"):
         return nice_time_nl(dt, speech, use_24hour, use_ampm)
     if lang.startswith("pl"):
@@ -605,6 +611,8 @@ def nice_date(dt, lang, now=None, include_weekday=True):
         return nice_date_ro(dt, now, include_weekday)
     if lang.startswith("ast"):
         return nice_date_ast(dt, now, include_weekday)
+    if lang.startswith("fy"):
+        return nice_date_fy(dt, now, include_weekday)
     date_time_format.cache(lang)
     return date_time_format.date_format(dt, lang, now, include_weekday)
 
@@ -643,6 +651,8 @@ def nice_date_time(dt, lang, now=None, use_24hour=False,
         return nice_date_time_ro(dt, now, use_24hour, use_ampm)
     if lang.startswith("ast"):
         return nice_date_time_ast(dt, now, use_24hour, use_ampm)
+    if lang.startswith("fy"):
+        return nice_date_time_fy(dt, now, use_24hour, use_ampm)
     date_time_format.cache(lang)
     return date_time_format.date_time_format(dt, lang, now, use_24hour, use_ampm)
 
@@ -660,6 +670,8 @@ def nice_day(dt, lang, date_format='DMY', include_month=True):
         return nice_day_ro(dt, date_format, include_month)
     if lang.startswith("ast"):
         return nice_day_ast(dt, date_format, include_month)
+    if lang.startswith("fy"):
+        return nice_day_fy(dt, date_format, include_month)
     if include_month:
         month = nice_month(dt, lang, date_format)
         if date_format == 'MDY':
@@ -683,6 +695,8 @@ def nice_weekday(dt, lang):
         return nice_weekday_ro(dt)
     if lang.startswith("ast"):
         return nice_weekday_ast(dt)
+    if lang.startswith("fy"):
+        return nice_weekday_fy(dt)
     date_time_format.cache(lang)
 
     if lang in date_time_format.lang_config.keys():
@@ -708,6 +722,8 @@ def nice_month(dt, lang, date_format='MDY'):
         return nice_month_ro(dt)
     if lang.startswith("ast"):
         return nice_month_ast(dt)
+    if lang.startswith("fy"):
+        return nice_month_fy(dt)
     date_time_format.cache(lang)
     if lang in date_time_format.lang_config.keys():
         localized_month_names = date_time_format.lang_config[lang]['month']
@@ -745,6 +761,8 @@ def nice_year(dt, lang, bc=False):
         return nice_year_ro(dt, bc)
     if lang.startswith("ast"):
         return nice_year_ast(dt, bc)
+    if lang.startswith("fy"):
+        return nice_year_fy(dt, bc)
     date_time_format.cache(lang)
     return date_time_format.year_format(dt, lang, bc)
 

--- a/ovos_date_parser/dates_fy.py
+++ b/ovos_date_parser/dates_fy.py
@@ -1,0 +1,212 @@
+from datetime import datetime
+
+from ovos_number_parser.numbers_fy import pronounce_number_fy
+
+# West Frisian (Frysk) weekday names.
+# Sources: West Frisian phrasebook (Wikivoyage) and West Frisian language
+# (Wikipedia). "Sneon" is the standard form for Saturday; "Saterdei" also
+# occurs regionally.
+WEEKDAYS_FY = {
+    0: "moandei",
+    1: "tiisdei",
+    2: "woansdei",
+    3: "tongersdei",
+    4: "freed",
+    5: "sneon",
+    6: "snein"
+}
+# West Frisian month names.
+# Source: West Frisian phrasebook (Wikivoyage).
+MONTHS_FY = {
+    1: "jannewaris",
+    2: "febrewaris",
+    3: "maart",
+    4: "april",
+    5: "maaie",
+    6: "juny",
+    7: "july",
+    8: "augustus",
+    9: "septimber",
+    10: "oktober",
+    11: "novimber",
+    12: "desimber"
+}
+# Inflected hour forms used after "healwei", "kertier oer/foar" and the
+# "minutes oer/foar" constructions when telling the time.
+# Source: "Telling Time in West Frisian"
+# (funwithfrisian.blogspot.com/2016/04/telling-time-in-west-frisian.html).
+HOURS_FY = {
+    1: "ienen",
+    2: "twaen",
+    3: "trijen",
+    4: "fjouweren",
+    5: "fiven",
+    6: "seizen",
+    7: "sânen",
+    8: "achten",
+    9: "njoggenen",
+    10: "tsienen",
+    11: "alven",
+    12: "tolven"
+}
+
+
+def _fix_hour_fy(hour):
+    hour = hour % 12
+    if hour == 0:
+        hour = 12
+    return hour
+
+
+def nice_year_fy(dt, bc=False):
+    """Format a year in a pronounceable West Frisian form.
+
+    Args:
+        dt (datetime): date to format (assumed already in the local timezone)
+        bc (bool): append "f.Kr." after the year
+    Returns:
+        (str): the year formatted as a string
+    """
+    year = pronounce_number_fy(dt.year)
+    if bc:
+        return f"{year} f.Kr."
+    return year
+
+
+def nice_weekday_fy(dt):
+    weekday = WEEKDAYS_FY[dt.weekday()]
+    return weekday.capitalize()
+
+
+def nice_month_fy(dt):
+    month = MONTHS_FY[dt.month]
+    return month.capitalize()
+
+
+def nice_day_fy(dt, date_format='DMY', include_month=True):
+    if include_month:
+        month = nice_month_fy(dt)
+        if date_format == 'MDY':
+            return "{} {}".format(month, dt.strftime("%d").lstrip("0"))
+        else:
+            return "{} {}".format(dt.strftime("%d").lstrip("0"), month)
+    return dt.strftime("%d").lstrip("0")
+
+
+def nice_date_fy(dt: datetime, now: datetime = None, include_weekday=True):
+    """Format a date in a pronounceable West Frisian form.
+
+    For example, generates 'moandei 5 maaie 2018'. West Frisian keeps the
+    Germanic day-month-year order.
+
+    Args:
+        dt (datetime): date to format (assumed already in the local timezone)
+        now (datetime): reference date. When provided the returned date is
+            shortened: the year is dropped when ``now`` is in the same year as
+            ``dt`` and the month is dropped when ``now`` is in the same month.
+        include_weekday (bool): whether to prepend the weekday name.
+    Returns:
+        (str): the formatted date string
+    """
+    day = pronounce_number_fy(dt.day)
+    nice = f"{day} {nice_month_fy(dt)} {nice_year_fy(dt)}"
+    if now is not None:
+        nice = day
+        if dt.month != now.month:
+            nice = nice + " " + nice_month_fy(dt)
+        if dt.year != now.year:
+            nice = nice + " " + nice_year_fy(dt)
+
+    if include_weekday:
+        weekday = nice_weekday_fy(dt)
+        nice = f"{weekday} {nice}"
+    return nice
+
+
+def nice_date_time_fy(dt, now=None, use_24hour=False, use_ampm=False):
+    """Format a date and time in a pronounceable West Frisian form.
+
+    For example, generates 'moandei 5 maaie 2018 om fjouwer oere'.
+    """
+    return f"{nice_date_fy(dt, now)} om " \
+           f"{nice_time_fy(dt, use_24hour=use_24hour, use_ampm=use_ampm)}"
+
+
+def nice_part_of_day_fy(dt, speech=True):
+    """Return the West Frisian adverbial name for the part of the day.
+
+    Source: Taalportaal / West Frisian phrasebook — the genitive "-s" adverbs
+    moarns, middeis, jûns, nachts.
+    """
+    if dt.hour < 6:
+        return " nachts"
+    if dt.hour < 12:
+        return " moarns"
+    if dt.hour < 18:
+        return " middeis"
+    return " jûns"
+
+
+def nice_time_fy(dt, speech=True, use_24hour=False, use_ampm=False):
+    """Format a time in a comfortable West Frisian human format.
+
+    For example, generates 'healwei fiven' for speech or '4:30' for text.
+
+    West Frisian, like Dutch, looks ahead to the coming hour for the half and
+    the quarter-to: 'healwei fiven' is 4:30 (literally "halfway to five") and
+    'kertier foar fiven' is 4:45. The hour word is "oere".
+
+    Args:
+        dt (datetime): date to format (assumed already in the local timezone)
+        speech (bool): format for speech (default/True) or display (False)
+        use_24hour (bool): output in 24-hour format
+        use_ampm (bool): include the part of day for 12-hour format
+    Returns:
+        (str): the formatted time string
+    """
+    if use_24hour:
+        string = dt.strftime("%H:%M")
+    else:
+        if use_ampm:
+            string = dt.strftime("%I:%M %p")
+        else:
+            string = dt.strftime("%I:%M")
+        if string[0] == '0':
+            string = string[1:]  # strip leading zeros
+
+    if not speech:
+        return string
+
+    speak = ""
+    if use_24hour:
+        speak += pronounce_number_fy(dt.hour)
+        speak += " oere"
+        if dt.minute != 0:
+            speak += " " + pronounce_number_fy(dt.minute)
+        return speak  # ampm is ignored when use_24hour is true
+
+    hour = dt.hour % 12
+    if dt.minute == 0:
+        hour = _fix_hour_fy(hour)
+        speak += pronounce_number_fy(hour)
+        speak += " oere"
+    elif dt.minute == 15:
+        hour = _fix_hour_fy(hour)
+        speak += "kertier oer " + HOURS_FY[hour]
+    elif dt.minute == 30:
+        hour = _fix_hour_fy(hour + 1)
+        speak += "healwei " + HOURS_FY[hour]
+    elif dt.minute == 45:
+        hour = _fix_hour_fy(hour + 1)
+        speak += "kertier foar " + HOURS_FY[hour]
+    elif dt.minute < 30:
+        hour = _fix_hour_fy(hour)
+        speak += pronounce_number_fy(dt.minute) + " oer " + HOURS_FY[hour]
+    else:
+        hour = _fix_hour_fy(hour + 1)
+        speak += pronounce_number_fy(60 - dt.minute) + " foar " + HOURS_FY[hour]
+
+    if use_ampm:
+        speak += nice_part_of_day_fy(dt)
+
+    return speak

--- a/test/test_dates_fy.py
+++ b/test/test_dates_fy.py
@@ -1,0 +1,130 @@
+import unittest
+from datetime import datetime
+
+from ovos_date_parser import (
+    nice_year, nice_weekday, nice_month, nice_day, nice_date,
+    nice_date_time, nice_time,
+)
+from ovos_date_parser.dates_fy import (
+    nice_time_fy, nice_weekday_fy, nice_month_fy, nice_part_of_day_fy,
+    WEEKDAYS_FY, MONTHS_FY, HOURS_FY,
+)
+
+# A Tuesday, so weekday()==1
+REF = datetime(2018, 6, 5, 16, 30)
+
+
+class TestFrisianAnchors(unittest.TestCase):
+    """Verified word<->value anchors (Wikivoyage phrasebook, Wikipedia,
+    funwithfrisian time guide)."""
+
+    def test_weekdays(self):
+        expected = ["Moandei", "Tiisdei", "Woansdei", "Tongersdei",
+                    "Freed", "Sneon", "Snein"]
+        for i, name in enumerate(expected):
+            # 2018-06-04 is a Monday
+            dt = datetime(2018, 6, 4 + i)
+            self.assertEqual(nice_weekday(dt, "fy"), name)
+
+    def test_months(self):
+        expected = {
+            1: "Jannewaris", 2: "Febrewaris", 3: "Maart", 4: "April",
+            5: "Maaie", 6: "Juny", 7: "July", 8: "Augustus",
+            9: "Septimber", 10: "Oktober", 11: "Novimber", 12: "Desimber",
+        }
+        for m, name in expected.items():
+            self.assertEqual(nice_month(datetime(2018, m, 1), "fy"), name)
+
+    def test_time_oclock(self):
+        self.assertEqual(nice_time_fy(datetime(2018, 6, 5, 4, 0)), "fjouwer oere")
+        self.assertEqual(nice_time_fy(datetime(2018, 6, 5, 1, 0)), "ien oere")
+        self.assertEqual(nice_time_fy(datetime(2018, 6, 5, 12, 0)), "tolve oere")
+        self.assertEqual(nice_time_fy(datetime(2018, 6, 5, 0, 0)), "tolve oere")
+
+    def test_time_quarters_and_half(self):
+        # look-ahead system: half/quarter-to point to the coming hour
+        self.assertEqual(nice_time_fy(datetime(2018, 6, 5, 4, 15)), "kertier oer fjouweren")
+        self.assertEqual(nice_time_fy(datetime(2018, 6, 5, 4, 30)), "healwei fiven")
+        self.assertEqual(nice_time_fy(datetime(2018, 6, 5, 4, 45)), "kertier foar fiven")
+        self.assertEqual(nice_time_fy(datetime(2018, 6, 5, 13, 15)), "kertier oer ienen")
+
+    def test_time_minutes(self):
+        self.assertEqual(nice_time_fy(datetime(2018, 6, 5, 4, 20)), "tweintich oer fjouweren")
+        self.assertEqual(nice_time_fy(datetime(2018, 6, 5, 4, 40)), "tweintich foar fiven")
+
+    def test_time_24hour(self):
+        self.assertEqual(nice_time_fy(datetime(2018, 6, 5, 16, 15), use_24hour=True),
+                         "sechstjin oere fyftjin")
+        self.assertEqual(nice_time_fy(datetime(2018, 6, 5, 13, 0), use_24hour=True),
+                         "trettjin oere")
+
+    def test_part_of_day(self):
+        self.assertEqual(nice_part_of_day_fy(datetime(2018, 6, 5, 3)), " nachts")
+        self.assertEqual(nice_part_of_day_fy(datetime(2018, 6, 5, 9)), " moarns")
+        self.assertEqual(nice_part_of_day_fy(datetime(2018, 6, 5, 15)), " middeis")
+        self.assertEqual(nice_part_of_day_fy(datetime(2018, 6, 5, 20)), " jûns")
+
+    def test_date_order_is_germanic(self):
+        # day month year
+        self.assertEqual(nice_date(datetime(2018, 6, 5), "fy", include_weekday=False),
+                         "fiif Juny twatûzenachttjin")
+
+    def test_datetime_uses_om(self):
+        self.assertIn(" om ", nice_date_time(REF, "fy"))
+
+
+class TestFrisianAdversarial(unittest.TestCase):
+
+    def test_bad_input_raises(self):
+        for bad in (None, "not a date", 12345, [], {}):
+            with self.assertRaises((AttributeError, TypeError)):
+                nice_weekday(bad, "fy")
+
+    def test_speech_false_is_language_neutral(self):
+        self.assertEqual(nice_time_fy(datetime(2018, 6, 5, 4, 30), speech=False), "4:30")
+        self.assertEqual(nice_time_fy(datetime(2018, 6, 5, 16, 5), speech=False,
+                                      use_24hour=True), "16:05")
+
+    def test_lang_code_variants_route(self):
+        for code in ("fy", "fy-NL", "FY", "FY-nl"):
+            self.assertEqual(nice_weekday(REF, code), "Tiisdei")
+
+    def test_leap_day(self):
+        self.assertEqual(nice_month(datetime(2020, 2, 29), "fy"), "Febrewaris")
+        self.assertEqual(nice_day(datetime(2020, 2, 29), "fy"), "29 Febrewaris")
+
+    def test_bc_year(self):
+        self.assertTrue(nice_year(datetime(44, 3, 15), "fy", bc=True).endswith("f.Kr."))
+
+    def test_full_minute_sweep_never_crashes(self):
+        # every wall-clock minute must produce a non-empty spoken form that
+        # is anchored on a Frisian time particle
+        for hour in range(24):
+            for minute in range(60):
+                dt = datetime(2018, 6, 5, hour, minute)
+                spoken = nice_time_fy(dt)
+                self.assertTrue(spoken)
+                self.assertTrue(
+                    "oere" in spoken or " oer " in spoken
+                    or "foar" in spoken or "healwei" in spoken,
+                    f"{hour}:{minute} -> {spoken}")
+
+    def test_full_year_date_sweep_never_crashes(self):
+        from datetime import timedelta
+        dt = datetime(2019, 1, 1)
+        seen = 0
+        while dt.year == 2019:
+            out = nice_date(dt, "fy")
+            self.assertTrue(out)
+            seen += 1
+            dt = dt + timedelta(days=1)
+        self.assertEqual(seen, 365)
+
+    def test_hour_tables_complete(self):
+        self.assertEqual(set(HOURS_FY), set(range(1, 13)))
+        self.assertEqual(set(WEEKDAYS_FY), set(range(7)))
+        self.assertEqual(set(MONTHS_FY), set(range(1, 13)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_dates_fy_sentences.py
+++ b/test/test_dates_fy_sentences.py
@@ -1,0 +1,206 @@
+"""Natural-sentence tests for West Frisian (fy) date and time formatting.
+
+These exercise the formatters the way a skill actually uses them: composed
+into full Frisian sentences with surrounding words, punctuation and casing,
+and across the whole wrap-around clock, rather than isolated anchors.
+
+Every expected string is built only from reference-verified Frisian forms:
+- weekdays/months: Wikivoyage West Frisian phrasebook; Wikipedia
+    "West Frisian language".
+- clock (look-ahead system, hour word "oere", inflected hours after
+    healwei/kertier/oer/foar): "Telling Time in West Frisian"
+    (funwithfrisian.blogspot.com), cross-checked with the phrasebook.
+- parts of day: Taalportaal; phrasebook (moarns/middeis/jûns/nachts).
+- carrier words: "It is" (it is), "hjoed" (today), "om" (at) — attested
+    Frisian, used to place the verified date/time inside a real sentence.
+"""
+import unittest
+from datetime import datetime
+
+from ovos_date_parser import (
+    nice_date, nice_weekday, nice_month, nice_year, nice_day,
+    nice_time, nice_date_time,
+)
+
+# 2018-06-04 is a Monday -> whole week 2018-06-04 .. 2018-06-10
+WEEK = {
+    "Moandei": datetime(2018, 6, 4),
+    "Tiisdei": datetime(2018, 6, 5),
+    "Woansdei": datetime(2018, 6, 6),
+    "Tongersdei": datetime(2018, 6, 7),
+    "Freed": datetime(2018, 6, 8),
+    "Sneon": datetime(2018, 6, 9),
+    "Snein": datetime(2018, 6, 10),
+}
+MONTHS = {
+    "Jannewaris": 1, "Febrewaris": 2, "Maart": 3, "April": 4,
+    "Maaie": 5, "Juny": 6, "July": 7, "Augustus": 8,
+    "Septimber": 9, "Oktober": 10, "Novimber": 11, "Desimber": 12,
+}
+
+
+class TestFrisianWeekdaySentences(unittest.TestCase):
+
+    def test_each_weekday_in_sentence(self):
+        for name, dt in WEEK.items():
+            sentence = f"Hjoed is it {nice_weekday(dt, 'fy')}."
+            self.assertEqual(sentence, f"Hjoed is it {name}.")
+
+    def test_weekday_lowercased_mid_sentence(self):
+        dt = WEEK["Woansdei"]
+        sentence = f"Wy sjogge inoar oankommende {nice_weekday(dt, 'fy').lower()}."
+        self.assertEqual(sentence, "Wy sjogge inoar oankommende woansdei.")
+
+
+class TestFrisianDateSentences(unittest.TestCase):
+
+    def test_full_date_germanic_order(self):
+        sentence = f"De gearkomste is op {nice_date(WEEK['Tiisdei'], 'fy')}."
+        self.assertEqual(
+            sentence,
+            "De gearkomste is op Tiisdei fiif Juny twatûzenachttjin.")
+
+    def test_date_without_weekday(self):
+        dt = datetime(2019, 1, 1)
+        sentence = f"Hy is berne op {nice_date(dt, 'fy', include_weekday=False)}."
+        # nice_date capitalizes the month name
+        self.assertEqual(sentence, "Hy is berne op ien Jannewaris twatûzennjoggentjin.")
+
+    def test_every_month_in_sentence(self):
+        for name, m in MONTHS.items():
+            dt = datetime(2019, m, 10)
+            clause = nice_date(dt, "fy", include_weekday=False)
+            sentence = f"It barde yn {clause}."
+            self.assertIn(name, sentence)  # month capitalized by nice_date
+
+    def test_relative_same_month_shortens(self):
+        now = datetime(2018, 6, 1)
+        dt = datetime(2018, 6, 5)
+        sentence = f"It is op {nice_date(dt, 'fy', now=now)}."
+        self.assertEqual(sentence, "It is op Tiisdei fiif.")
+
+
+class TestFrisianClockSentences(unittest.TestCase):
+    """Full spoken times inside sentences, across the wrap-around clock."""
+
+    def test_oclock(self):
+        sentence = f"De trein giet om {nice_time(datetime(2018, 6, 5, 4, 0), 'fy')}."
+        self.assertEqual(sentence, "De trein giet om fjouwer oere.")
+
+    def test_quarter_past(self):
+        sentence = f"It is no {nice_time(datetime(2018, 6, 5, 4, 15), 'fy')}."
+        self.assertEqual(sentence, "It is no kertier oer fjouweren.")
+
+    def test_half_past_looks_ahead(self):
+        # 4:30 == 'healwei fiven' (halfway to five)
+        sentence = f"Wy ite om {nice_time(datetime(2018, 6, 5, 4, 30), 'fy')}."
+        self.assertEqual(sentence, "Wy ite om healwei fiven.")
+
+    def test_quarter_to(self):
+        sentence = f"De winkel slút om {nice_time(datetime(2018, 6, 5, 4, 45), 'fy')}."
+        self.assertEqual(sentence, "De winkel slút om kertier foar fiven.")
+
+    def test_wrap_around_before_midnight(self):
+        # 23:45 -> 'kertier foar tolven' (quarter to twelve)
+        sentence = f"It fjoerwurk begjint om {nice_time(datetime(2018, 12, 31, 23, 45), 'fy')}."
+        self.assertEqual(sentence, "It fjoerwurk begjint om kertier foar tolven.")
+
+    def test_wrap_around_after_midnight(self):
+        # 00:30 -> 'healwei ienen' (halfway to one)
+        sentence = f"Ik gong om {nice_time(datetime(2018, 6, 6, 0, 30), 'fy')} nei bêd."
+        self.assertEqual(sentence, "Ik gong om healwei ienen nei bêd.")
+
+    def test_noon_and_midnight_both_tolve_oere(self):
+        self.assertEqual(nice_time(datetime(2018, 6, 5, 12, 0), "fy"), "tolve oere")
+        self.assertEqual(nice_time(datetime(2018, 6, 5, 0, 0), "fy"), "tolve oere")
+
+    def test_minutes_past_and_to(self):
+        self.assertEqual(
+            f"om {nice_time(datetime(2018, 6, 5, 4, 20), 'fy')}",
+            "om tweintich oer fjouweren")
+        self.assertEqual(
+            f"om {nice_time(datetime(2018, 6, 5, 13, 50), 'fy')}",
+            "om tsien foar twaen")
+
+    def test_24hour_in_sentence(self):
+        sentence = f"Fertrek: {nice_time(datetime(2018, 6, 5, 16, 15), 'fy', use_24hour=True)} oere lokaal."
+        self.assertEqual(sentence, "Fertrek: sechstjin oere fyftjin oere lokaal.")
+
+    def test_part_of_day_ampm(self):
+        # 9:30 in the morning -> healwei tsienen moarns
+        sentence = f"Wy moetsje {nice_time(datetime(2018, 6, 5, 9, 30), 'fy', use_ampm=True)}."
+        self.assertEqual(sentence, "Wy moetsje healwei tsienen moarns.")
+
+    def test_evening_part_of_day(self):
+        sentence = nice_time(datetime(2018, 6, 5, 20, 0), "fy", use_ampm=True)
+        self.assertEqual(sentence, "acht oere jûns")
+
+
+class TestFrisianDateTimeSentences(unittest.TestCase):
+
+    def test_full_datetime_with_om(self):
+        dt = datetime(2018, 6, 5, 16, 30)
+        sentence = f"Set in wekker foar {nice_date_time(dt, 'fy')}."
+        self.assertEqual(
+            sentence,
+            "Set in wekker foar Tiisdei fiif Juny twatûzenachttjin om healwei fiven.")
+
+
+class TestFrisianEdgeCasesInContext(unittest.TestCase):
+
+    def test_leap_day_sentence(self):
+        dt = datetime(2020, 2, 29)
+        sentence = f"De {nice_day(dt, 'fy')} komt ien kear yn 'e fjouwer jier."
+        self.assertEqual(
+            sentence, "De 29 Febrewaris komt ien kear yn 'e fjouwer jier.")
+
+    def test_bc_year_in_sentence(self):
+        dt = datetime(44, 3, 15)
+        sentence = f"Dat wie yn {nice_year(dt, 'fy', bc=True)}."
+        self.assertIn(" f.Kr.", sentence)
+
+    def test_lang_code_variants_route(self):
+        for code in ("fy", "fy-NL", "FY", "FY-nl", "fy-nl"):
+            self.assertEqual(nice_weekday(datetime(2018, 6, 5), code), "Tiisdei")
+
+    def test_casing_upper_and_strip(self):
+        dt = datetime(2018, 6, 5, 4, 30)
+        loud = f"  it is {nice_time(dt, 'fy')}!  ".strip().upper()
+        self.assertEqual(loud, "IT IS HEALWEI FIVEN!")
+
+    def test_malformed_input_raises(self):
+        for bad in (None, "healwei fiven", 20180605, [], {}, 3.14):
+            with self.assertRaises((AttributeError, TypeError, KeyError)):
+                nice_time(bad, "fy")
+
+    def test_speech_false_is_language_neutral(self):
+        self.assertEqual(nice_time(datetime(2018, 6, 5, 16, 5), "fy",
+                                   speech=False, use_24hour=True), "16:05")
+
+    def test_cross_language_uses_frisian_not_dutch(self):
+        # Frisian-specific spellings, never the Dutch or English neighbours
+        self.assertEqual(nice_weekday(WEEK["Woansdei"], "fy"), "Woansdei")
+        self.assertNotEqual(nice_weekday(WEEK["Woansdei"], "fy"), "Woensdag")   # nl
+        self.assertNotEqual(nice_weekday(WEEK["Woansdei"], "fy"), "Wednesday")  # en
+        self.assertEqual(nice_month(datetime(2019, 6, 1), "fy"), "Juny")
+        self.assertNotEqual(nice_month(datetime(2019, 6, 1), "fy"), "Juni")     # nl
+        # look-ahead half is Frisian 'healwei', not Dutch 'half'
+        half = nice_time(datetime(2018, 6, 5, 4, 30), "fy")
+        self.assertTrue(half.startswith("healwei"))
+        self.assertNotIn("half", half)
+
+    def test_full_wrap_around_clock_sweep(self):
+        # every wall-clock minute yields a non-empty spoken form anchored on a
+        # Frisian time particle; no crashes across the 24h wrap-around
+        for hour in range(24):
+            for minute in range(60):
+                spoken = nice_time(datetime(2018, 6, 5, hour, minute), "fy")
+                self.assertTrue(spoken)
+                self.assertTrue(
+                    "oere" in spoken or " oer " in spoken
+                    or "foar" in spoken or "healwei" in spoken,
+                    f"{hour}:{minute:02d} -> {spoken}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds pronounceable West Frisian (fy) date formatting, wired into the language dispatch in ovos_date_parser. Number pronunciation is delegated to ovos-number-parser.

## West Frisian (fy)
Full formatting family: nice_year, nice_weekday, nice_month, nice_day, nice_date, nice_date_time, nice_time, nice_part_of_day.

The clock follows the Germanic look-ahead system shared with Dutch, with the hour word oere and the inflected hour forms used after healwei/kertier/oer/foar:

- 4:00 -> fjouwer oere
- 4:15 -> kertier oer fjouweren
- 4:30 -> healwei fiven (halfway to five)
- 4:45 -> kertier foar fiven
- 4:20 -> tweintich oer fjouweren
- 16:15 (24h) -> sechstjin oere fyftjin

## Verified anchors and sources
- Weekdays/months: Wikivoyage West Frisian phrasebook; Wikipedia "West Frisian language".
- Clock: "Telling Time in West Frisian" (funwithfrisian.blogspot.com), cross-checked against the Wikivoyage phrasebook.
- Parts of day: Taalportaal; Wikivoyage phrasebook.

Every anchor is checked against reference material, never against the engine output.

## Tests
Adversarial + anchor suite in test/test_dates_fy.py: word<->value anchors for all weekdays/months and every clock construction; malformed/None input, lang-code variants (fy-NL, FY), leap day, BC years, a full 1440-minute clock sweep, and a full-year date sweep.
