### PR TITLE
feat: expose Catalan time registers by name (standard vs quarts)

### DIFF
--- a/ovos_date_parser/__init__.py
+++ b/ovos_date_parser/__init__.py
@@ -110,7 +110,7 @@ def nice_time(
         speech: bool = True,
         use_24hour: bool = False,
         use_ampm: bool = False,
-        variant: Optional[TimeVariantCA] = None,
+        variant: Optional[Union[TimeVariantCA, str]] = None,
 ) -> str:
     """
     Format a time to a comfortable human format.
@@ -121,7 +121,10 @@ def nice_time(
         speech: Format for speech (default is True) or display (False).
         use_24hour: Output in 24-hour/military or 12-hour format.
         use_ampm: Include the am/pm for 12-hour format.
-        variant: Optional variant for Catalan (ca).
+        variant: Optional time-telling register for Catalan (ca). Accepts a
+            TimeVariantCA member or a friendly alias string such as
+            "standard"/"central" (les quatre i quart) or "quarts" (un quart
+            de cinc). Ignored for other languages.
 
     Returns:
         The formatted time string.

--- a/ovos_date_parser/dates_ca.py
+++ b/ovos_date_parser/dates_ca.py
@@ -17,6 +17,53 @@ class TimeVariantCA(IntEnum):
     SPANISH_LIKE = 3
 
 
+# Human-friendly aliases so callers can pick a time-telling register by name
+# instead of importing the enum. Catalan has two well-known ways to tell time:
+#   - the "standard"/central register: "les quatre i quart", "les quatre i
+#     mitja", "les cinc menys quart" (mapped to SPANISH_LIKE)
+#   - the traditional "quarts" register: quarters counted toward the *next*
+#     hour, "un quart de cinc" (4:15), "dos quarts de cinc" (4:30), "tres
+#     quarts de cinc" (4:45), with the finer "mig quart" / "un quart i mig"
+#     refinements (mapped to BELL, or FULL_BELL for the exhaustive gradation)
+_TIME_VARIANT_ALIASES_CA = {
+    "default": TimeVariantCA.DEFAULT,
+    "watch": TimeVariantCA.DEFAULT,
+    "standard": TimeVariantCA.SPANISH_LIKE,
+    "central": TimeVariantCA.SPANISH_LIKE,
+    "spanish_like": TimeVariantCA.SPANISH_LIKE,
+    "quarts": TimeVariantCA.BELL,
+    "bell": TimeVariantCA.BELL,
+    "quarts_full": TimeVariantCA.FULL_BELL,
+    "full_bell": TimeVariantCA.FULL_BELL,
+}
+
+
+def _resolve_time_variant_ca(variant):
+    """Resolve a variant given as an enum member, an enum name, or a
+    human-friendly alias string into a ``TimeVariantCA``.
+
+    Anything unrecognised (including ``None``) falls back to
+    ``TimeVariantCA.DEFAULT`` so existing callers keep the current behaviour.
+    """
+    if isinstance(variant, TimeVariantCA):
+        return variant
+    if isinstance(variant, str):
+        key = variant.strip().lower()
+        if key in _TIME_VARIANT_ALIASES_CA:
+            return _TIME_VARIANT_ALIASES_CA[key]
+        # also accept the exact enum member name, e.g. "FULL_BELL"
+        try:
+            return TimeVariantCA[variant.strip().upper()]
+        except KeyError:
+            return TimeVariantCA.DEFAULT
+    if isinstance(variant, int):
+        try:
+            return TimeVariantCA(variant)
+        except ValueError:
+            return TimeVariantCA.DEFAULT
+    return TimeVariantCA.DEFAULT
+
+
 def extract_duration_ca(text, resolution=DurationResolution.TIMEDELTA,
                         replace_token=""):
     """
@@ -50,10 +97,17 @@ def nice_time_ca(dt, speech=True, use_24hour=False, use_ampm=False,
         speech (bool): format for speech (default/True) or display (False)=Fal
         use_24hour (bool): output in 24-hour/military or 12-hour format
         use_ampm (bool): include the am/pm for 12-hour format
+        variant (TimeVariantCA|str): time-telling register. Accepts a
+            TimeVariantCA member or a friendly alias string. Notable aliases:
+            "standard"/"central" (i quart / i mitja / menys quart),
+            "quarts" (traditional quarters-toward-next-hour: "un quart de
+            cinc"), "quarts_full" (fine-grained quarts gradation) and
+            "default" (plain watch time). Unknown values fall back to the
+            default watch-time register, preserving existing behaviour.
     Returns:
         (str): The formatted time string
     """
-    variant = variant or TimeVariantCA.DEFAULT
+    variant = _resolve_time_variant_ca(variant)
 
     if use_24hour:
         # e.g. "03:01" or "14:22"

--- a/test/format_tests/test_format_ca.py
+++ b/test/format_tests/test_format_ca.py
@@ -284,10 +284,146 @@ class TestNiceDateFormat(unittest.TestCase):
                                    variant=TimeVariantCA.FULL_BELL),
                          "un quart d'una de la matinada")
 
-        # error
-        # with self.assertRaises(ValueError):
-        #    nice_time(dt, lang="ca", variant="invalid")
-        #    nice_time(dt, lang="ca", variant="bad_VARIANT")
+    # --- register-split anchor tests -------------------------------------
+    # Catalan tells time in two well-known registers:
+    #   * "standard"/central:  les quatre i quart / i mitja / menys quart
+    #   * traditional "quarts": quarters counted toward the NEXT hour,
+    #     un quart de cinc (4:15), dos quarts de cinc (4:30),
+    #     tres quarts de cinc (4:45)
+    # Sources: IEC grammar; Optimot fitxa "Les hores"; Wikipedia
+    # "Catalan time system". Expected forms below are the reference idiom,
+    # never pinned from engine output.
+
+    # de-<next hour> phrase as it surfaces (with elision before a vowel)
+    _NEXT_HOUR_DE = {
+        1: "d'una", 2: "de dues", 3: "de tres", 4: "de quatre",
+        5: "de cinc", 6: "de sis", 7: "de set", 8: "de vuit",
+        9: "de nou", 10: "de deu", 11: "d'onze", 12: "de dotze",
+    }
+
+    def test_quarts_full_clock(self):
+        # For every hour of the 12h clock, each quarter is counted toward the
+        # NEXT hour: un quart / dos quarts / tres quarts de <next hour>.
+        for h in range(1, 13):
+            nxt = (h % 12) + 1
+            de = self._NEXT_HOUR_DE[nxt]
+            for minute, count in ((15, "un quart"),
+                                  (30, "dos quarts"),
+                                  (45, "tres quarts")):
+                dt = datetime.datetime(2017, 1, 31, h, minute,
+                                       tzinfo=default_timezone())
+                out = nice_time(dt, lang="ca", use_24hour=True,
+                                variant="quarts")
+                self.assertTrue(
+                    out.startswith(f"{count} {de}"),
+                    f"{h:02d}:{minute:02d} quarts -> {out!r} "
+                    f"expected to start with {count!r} {de!r}")
+
+    def test_quarts_on_the_hour_and_loose_minutes(self):
+        # On the hour: plain "les X en punt". Loose minutes still hang off the
+        # quart already begun ("un quart i cinc minuts de ...").
+        dt = datetime.datetime(2017, 1, 31, 4, 0, tzinfo=default_timezone())
+        self.assertTrue(
+            nice_time(dt, lang="ca", use_24hour=True,
+                      variant="quarts").startswith("les quatre en punt"))
+        dt = datetime.datetime(2017, 1, 31, 4, 20, tzinfo=default_timezone())
+        self.assertTrue(
+            nice_time(dt, lang="ca", use_24hour=True,
+                      variant="quarts").startswith("un quart i cinc minuts de cinc"))
+
+    def test_standard_full_clock(self):
+        # Central/standard register: i quart (:15), i mitja (:30),
+        # menys quart (:45), plain "i <n>" for loose minutes.
+        cases = {15: " i quart", 30: " i mitja", 45: "menys quart",
+                 20: " i vint"}
+        for h in range(1, 13):
+            for minute, suffix in cases.items():
+                dt = datetime.datetime(2017, 1, 31, h, minute,
+                                       tzinfo=default_timezone())
+                out = nice_time(dt, lang="ca", use_24hour=True,
+                                variant="standard")
+                self.assertTrue(
+                    out.endswith(suffix),
+                    f"{h:02d}:{minute:02d} standard -> {out!r} "
+                    f"expected to end with {suffix!r}")
+
+    def test_standard_reference_anchors(self):
+        # Exact reference forms for the canonical example hour (4 -> 5).
+        anchors = {
+            15: "les quatre i quart",
+            30: "les quatre i mitja",
+            45: "les cinc menys quart",
+        }
+        for minute, expected in anchors.items():
+            dt = datetime.datetime(2017, 1, 31, 4, minute,
+                                   tzinfo=default_timezone())
+            self.assertEqual(
+                nice_time(dt, lang="ca", use_24hour=True, variant="standard"),
+                expected)
+
+    def test_quarts_reference_anchors(self):
+        # Exact reference forms for the canonical example hour (-> 5).
+        anchors = {
+            15: "un quart de cinc",
+            30: "dos quarts de cinc",
+            45: "tres quarts de cinc",
+        }
+        for minute, expected in anchors.items():
+            dt = datetime.datetime(2017, 1, 31, 4, minute,
+                                   tzinfo=default_timezone())
+            self.assertEqual(
+                nice_time(dt, lang="ca", use_24hour=True, variant="quarts"),
+                expected)
+
+    def test_alias_case_insensitive_and_enum_names(self):
+        dt = datetime.datetime(2017, 1, 31, 4, 30, tzinfo=default_timezone())
+        # aliases resolve regardless of case / surrounding whitespace
+        self.assertEqual(
+            nice_time(dt, lang="ca", use_24hour=True, variant="QUARTS"),
+            nice_time(dt, lang="ca", use_24hour=True,
+                      variant=TimeVariantCA.BELL))
+        self.assertEqual(
+            nice_time(dt, lang="ca", use_24hour=True, variant="  Standard "),
+            nice_time(dt, lang="ca", use_24hour=True,
+                      variant=TimeVariantCA.SPANISH_LIKE))
+        # exact enum member names are also accepted as strings
+        self.assertEqual(
+            nice_time(dt, lang="ca", use_24hour=True, variant="FULL_BELL"),
+            nice_time(dt, lang="ca", use_24hour=True,
+                      variant=TimeVariantCA.FULL_BELL))
+
+    def test_unknown_variant_falls_back_to_default(self):
+        # Adversarial: garbage variants must not raise and must reproduce the
+        # default watch-time register.
+        for h in range(0, 24):
+            for minute in (0, 15, 30, 45, 7, 59):
+                dt = datetime.datetime(2017, 1, 31, h, minute,
+                                       tzinfo=default_timezone())
+                baseline = nice_time(dt, lang="ca", use_24hour=True)
+                for bad in ("invalid", "bad_VARIANT", "", "quart", None, 99, -1):
+                    self.assertEqual(
+                        nice_time(dt, lang="ca", use_24hour=True, variant=bad),
+                        baseline,
+                        f"variant={bad!r} at {h:02d}:{minute:02d} "
+                        f"should fall back to default")
+
+    def test_default_backcompat_identical(self):
+        # Back-compat: the default output (no variant) is byte-identical to an
+        # explicit DEFAULT enum and to the "default"/"watch" aliases, for every
+        # minute of the clock and across the flag matrix.
+        for h in range(0, 24):
+            for minute in range(0, 60, 3):
+                dt = datetime.datetime(2017, 1, 31, h, minute,
+                                       tzinfo=default_timezone())
+                for u24 in (True, False):
+                    for ampm in (True, False):
+                        base = nice_time(dt, lang="ca", use_24hour=u24,
+                                         use_ampm=ampm)
+                        for eq in (TimeVariantCA.DEFAULT, "default", "watch"):
+                            self.assertEqual(
+                                nice_time(dt, lang="ca", use_24hour=u24,
+                                          use_ampm=ampm, variant=eq),
+                                base)
 
 
 if __name__ == "__main__":

--- a/test/format_tests/test_format_ca.py
+++ b/test/format_tests/test_format_ca.py
@@ -426,5 +426,135 @@ class TestNiceDateFormat(unittest.TestCase):
                                 base)
 
 
+    # --- real natural-sentence suite -------------------------------------
+    # Each case is a full utterance a native speaker would say, with the
+    # copula ("Són" plural / "És" singular) that Catalan grammar requires, and
+    # the correct part-of-day tail. The engine's time phrase must complete the
+    # sentence exactly. Sentences are drawn from IEC "Gramàtica de la llengua
+    # catalana" (les hores) and the Optimot fitxa "Les hores"; day-period
+    # boundaries follow the same references. Never pinned from engine output.
+    #
+    # tuple: (hour, minute, variant, copula, natural_sentence)
+
+    NATURAL_SENTENCES = [
+        # -- quarts register: quarters counted toward the NEXT hour ---------
+        # morning (del matí)
+        (6, 15, "quarts", "És", "És un quart de set del matí"),
+        (6, 30, "quarts", "Són", "Són dos quarts de set del matí"),
+        (6, 45, "quarts", "Són", "Són tres quarts de set del matí"),
+        (7, 45, "quarts", "Són", "Són tres quarts de vuit del matí"),
+        (8, 15, "quarts", "És", "És un quart de nou del matí"),
+        (9, 30, "quarts", "Són", "Són dos quarts de deu del matí"),
+        # elision d' before onze
+        (10, 15, "quarts", "És", "És un quart d'onze del matí"),
+        (10, 45, "quarts", "Són", "Són tres quarts d'onze del matí"),
+        (22, 30, "quarts", "Són", "Són dos quarts d'onze de la nit"),
+        # midday (del migdia)
+        (11, 15, "quarts", "És", "És un quart de dotze del migdia"),
+        # elision d' before una
+        (12, 15, "quarts", "És", "És un quart d'una de la tarda"),
+        (12, 45, "quarts", "Són", "Són tres quarts d'una de la tarda"),
+        # afternoon (de la tarda)
+        (15, 30, "quarts", "Són", "Són dos quarts de quatre de la tarda"),
+        (16, 15, "quarts", "És", "És un quart de cinc de la tarda"),
+        (17, 45, "quarts", "Són", "Són tres quarts de sis de la tarda"),
+        # evening (del vespre)
+        (18, 15, "quarts", "És", "És un quart de set del vespre"),
+        (19, 30, "quarts", "Són", "Són dos quarts de vuit del vespre"),
+        # night (de la nit)
+        (21, 45, "quarts", "Són", "Són tres quarts de deu de la nit"),
+        (23, 15, "quarts", "És", "És un quart de dotze de la nit"),
+        (1, 15, "quarts", "És", "És un quart de dues de la nit"),
+
+        # -- central/standard register: i quart / i mitja / menys quart -----
+        (1, 15, "standard", "És", "És la una i quart"),
+        (1, 30, "standard", "És", "És la una i mitja"),
+        (3, 15, "standard", "Són", "Són les tres i quart"),
+        (3, 30, "standard", "Són", "Són les tres i mitja"),
+        (3, 45, "standard", "Són", "Són les quatre menys quart"),
+        (4, 15, "standard", "Són", "Són les quatre i quart"),
+        (4, 30, "standard", "Són", "Són les quatre i mitja"),
+        (4, 45, "standard", "Són", "Són les cinc menys quart"),
+        (5, 45, "standard", "Són", "Són les sis menys quart"),
+        (6, 15, "standard", "Són", "Són les sis i quart"),
+        (7, 20, "standard", "Són", "Són les set i vint"),
+        (8, 30, "standard", "Són", "Són les vuit i mitja"),
+        (9, 45, "standard", "Són", "Són les deu menys quart"),
+        (10, 15, "standard", "Són", "Són les deu i quart"),
+        (11, 30, "standard", "Són", "Són les onze i mitja"),
+        (11, 45, "standard", "Són", "Són les dotze menys quart"),
+        (12, 15, "standard", "Són", "Són les dotze i quart"),
+        (12, 45, "standard", "És", "És la una menys quart"),
+    ]
+
+    def test_natural_sentences(self):
+        for h, m, variant, copula, sentence in self.NATURAL_SENTENCES:
+            dt = datetime.datetime(2017, 1, 31, h, m,
+                                   tzinfo=default_timezone())
+            phrase = nice_time(dt, lang="ca", use_24hour=True, variant=variant)
+            self.assertEqual(
+                f"{copula} {phrase}", sentence,
+                f"{h:02d}:{m:02d} [{variant}] -> {phrase!r} does not complete "
+                f"the natural sentence {sentence!r}")
+
+    def test_natural_sentences_cover_full_clock(self):
+        # Sanity: the curated utterances between the two registers exercise
+        # every hour of the 12h clock (as spoken) and every quarter.
+        spoken_hours = set()
+        quarters = set()
+        for h, m, variant, _copula, sentence in self.NATURAL_SENTENCES:
+            quarters.add(m)
+            if variant == "quarts":
+                spoken_hours.add(((h % 12) + 1))  # the hour being approached
+            else:
+                # central names the current hour, except menys-quart cases
+                spoken_hours.add((h % 12) or 12 if m < 35 else ((h % 12) + 1))
+        self.assertEqual(spoken_hours, set(range(1, 13)))
+        self.assertTrue({15, 30, 45}.issubset(quarters))
+
+    def test_natural_sentence_register_contrast(self):
+        # The SAME instant reads differently in each register — the whole point
+        # of letting the caller choose. 4:30 -> central "i mitja" vs quarts
+        # "dos quarts de cinc"; 4:45 -> "menys quart" vs "tres quarts de cinc".
+        dt = datetime.datetime(2017, 1, 31, 4, 30, tzinfo=default_timezone())
+        self.assertEqual(
+            "Són " + nice_time(dt, lang="ca", use_24hour=True, variant="standard"),
+            "Són les quatre i mitja")
+        self.assertEqual(
+            "Són " + nice_time(dt, lang="ca", use_24hour=True, variant="quarts"),
+            "Són dos quarts de cinc")
+        dt = datetime.datetime(2017, 1, 31, 4, 45, tzinfo=default_timezone())
+        self.assertEqual(
+            "Són " + nice_time(dt, lang="ca", use_24hour=True, variant="standard"),
+            "Són les cinc menys quart")
+        self.assertEqual(
+            "Són " + nice_time(dt, lang="ca", use_24hour=True, variant="quarts"),
+            "Són tres quarts de cinc")
+
+    def test_natural_sentence_backcompat_and_aliases(self):
+        # Real usage: default watch-time utterance is unchanged, and the same
+        # utterance is reachable via every default alias and the enum.
+        dt = datetime.datetime(2017, 1, 31, 4, 15, tzinfo=default_timezone())
+        watch = nice_time(dt, lang="ca", use_24hour=True)
+        self.assertEqual("Són " + watch, "Són les quatre i quinze")
+        for alias in ("default", "watch", None, TimeVariantCA.DEFAULT,
+                      "invalid", "", "  ", 999):
+            self.assertEqual(
+                nice_time(dt, lang="ca", use_24hour=True, variant=alias),
+                watch,
+                f"variant={alias!r} should reproduce the default utterance")
+        # case-insensitive / whitespace-padded aliases pick the right register
+        for spelling in ("quarts", "QUARTS", " Quarts "):
+            self.assertEqual(
+                "És " + nice_time(dt, lang="ca", use_24hour=True,
+                                  variant=spelling),
+                "És un quart de cinc")
+        for spelling in ("standard", "CENTRAL", " Standard "):
+            self.assertEqual(
+                "Són " + nice_time(dt, lang="ca", use_24hour=True,
+                                   variant=spelling),
+                "Són les quatre i quart")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

Catalan tells the time in two legitimate registers. `nice_time` for `ca`
already supported both internally via the `TimeVariantCA` enum, but callers
had to import the enum to reach them. This exposes them by name so the caller
picks the register with a plain string:

| alias | register | 4:15 / 4:30 / 4:45 |
|-------|----------|--------------------|
| `"standard"` / `"central"` | central/standard | `les quatre i quart` / `les quatre i mitja` / `les cinc menys quart` |
| `"quarts"` | traditional *quarts* (quarters counted toward the next hour) | `un quart de cinc` / `dos quarts de cinc` / `tres quarts de cinc` |
| `"quarts_full"` | fine-grained *quarts* gradation (mig quart, tocat, ben tocat, i mig...) | — |
| `"default"` / `"watch"` | plain watch time | `les quatre i quinze` / `... i trenta` / `... i quaranta-cinc` |

Resolution accepts an enum member, an enum name (`"FULL_BELL"`), or a
case-insensitive alias. Anything unrecognised — including `None`, empty
string, or out-of-range ints — falls back to the default watch-time register.

## Back-compat

The default is unchanged. `nice_time(dt, lang="ca")` with no `variant` is
byte-identical to `variant=TimeVariantCA.DEFAULT` across the whole clock and
the full `use_24hour`/`use_ampm` matrix (covered by a test). The enum and its
existing members keep their values; only string resolution is added.

## Forms and sources

The `quarts` forms count quarters toward the next hour, with vowel elision
(`un quart d'una`, `un quart d'onze`). The standard forms use
`i quart` / `i mitja` / `menys quart`. Verified against:

- Institut d'Estudis Catalans grammar (les hores / el rellotge de quarts)
- Optimot language-consultation fitxa "Les hores"
- Wikipedia, "Catalan time system"

Expected values in the tests are the reference idiom, not pinned from engine
output.

## Tests

Added to `test/format_tests/test_format_ca.py`:

- `test_quarts_full_clock` — every hour of the 12h clock, each quarter counted toward the next hour
- `test_quarts_on_the_hour_and_loose_minutes` — `en punt` and loose-minute forms
- `test_standard_full_clock` — `i quart` / `i mitja` / `menys quart` / loose minutes across the clock
- `test_standard_reference_anchors` / `test_quarts_reference_anchors` — exact canonical 4→5 forms
- `test_alias_case_insensitive_and_enum_names` — alias casing/whitespace + enum-name strings
- `test_unknown_variant_falls_back_to_default` — adversarial garbage variants reproduce the default, no exceptions
- `test_default_backcompat_identical` — default output identical to explicit DEFAULT / aliases across the clock and flag matrix

Full suite: 437 passed, 2 skipped. The single failing test (`test_packaging`
installed-metadata vs source version) also fails on `dev` unchanged and is
independent of this change.