### PR TITLE
feat: add Croatian (hr) date support

### DIFF
--- a/ovos_date_parser/__init__.py
+++ b/ovos_date_parser/__init__.py
@@ -45,6 +45,9 @@ from ovos_date_parser.dates_cs import (
 from ovos_date_parser.dates_sk import (
     extract_duration_sk, extract_datetime_sk, nice_time_sk
 )
+from ovos_date_parser.dates_hr import (
+    extract_duration_hr, extract_datetime_hr, nice_time_hr
+)
 from ovos_date_parser.dates_da import (
     extract_datetime_da, extract_duration_da, nice_time_da,
 )
@@ -178,6 +181,8 @@ def nice_time(
         return nice_time_cs(dt, speech, use_24hour, use_ampm)
     if lang.startswith("sk"):
         return nice_time_sk(dt, speech, use_24hour, use_ampm, variant=variant)
+    if lang.startswith("hr"):
+        return nice_time_hr(dt, speech, use_24hour, use_ampm, variant=variant)
     if lang.startswith("da"):
         return nice_time_da(dt, speech, use_24hour, use_ampm)
     if lang.startswith("de"):
@@ -348,6 +353,8 @@ def extract_datetime(
         return extract_datetime_cs(text, anchorDate=anchorDate, default_time=default_time)
     if lang.startswith("sk"):
         return extract_datetime_sk(text, anchorDate=anchorDate, default_time=default_time)
+    if lang.startswith("hr"):
+        return extract_datetime_hr(text, anchorDate=anchorDate, default_time=default_time)
     if lang.startswith("da"):
         return extract_datetime_da(text, anchorDate=anchorDate, default_time=default_time)
     if lang.startswith("de"):

--- a/ovos_date_parser/dates_hr.py
+++ b/ovos_date_parser/dates_hr.py
@@ -1,0 +1,626 @@
+import re
+from datetime import datetime, timedelta
+
+from dateutil.relativedelta import relativedelta
+from ovos_number_parser.numbers_hr import pronounce_number_hr, extract_number_hr
+from ovos_utils.time import now_local
+from ovos_date_parser.duration import (
+    DurationResolution, DURATION_LEXICONS, extract_duration_generic
+)
+
+
+def _int_token_hr(word):
+    """Return the integer a single spelled/digit token denotes, else None."""
+    if not word:
+        return None
+    if word.isdigit():
+        return int(word)
+    n = extract_number_hr(word)
+    if n is False or n is None or isinstance(n, bool):
+        return None
+    if isinstance(n, float) and not n.is_integer():
+        return None
+    return int(n)
+
+
+def _plural_sat_hr(hour):
+    """Return the correct declension of 'sat' (hour) for a cardinal count."""
+    if hour == 1:
+        return "sat"
+    if 2 <= hour <= 4:
+        return "sata"
+    return "sati"
+
+
+def nice_time_hr(dt, speech=True, use_24hour=False, use_ampm=False,
+                 variant=None):
+    """
+    Format a time to a comfortable human format
+
+    For example, generate 'osam i trideset' (default) or 'pola devet'
+    (traditional) for speech, or '8:30' for text display.
+
+    Args:
+        dt (datetime): date to format (assumes already in local timezone)
+        speech (bool): format for speech (default/True) or display (False)
+        use_24hour (bool): output in 24-hour/military or 12-hour format
+        use_ampm (bool): include the am/pm for 12-hour format
+        variant (str): spoken register for the 12-hour clock. The default
+            (None / "default") reads "<hour> i <minutes>". "traditional"
+            uses the analog idiom ("osam i petnaest" = 8:15,
+            "pola devet" = 8:30, "petnaest do devet" = 8:45).
+    Returns:
+        (str): The formatted time string
+    """
+    traditional = variant in ("traditional", "analog")
+    if use_24hour:
+        # e.g. "03:01" or "14:22"
+        string = dt.strftime("%H:%M")
+    else:
+        if use_ampm:
+            # e.g. "3:01 AM" or "2:22 PM"
+            string = dt.strftime("%I:%M %p")
+        else:
+            # e.g. "3:01" or "2:22"
+            string = dt.strftime("%I:%M")
+        if string[0] == '0':
+            string = string[1:]  # strip leading zeros
+
+    if not speech:
+        return string
+
+    # Generate a speakable version of the time
+    if use_24hour:
+        # "trinaest dvadeset dva"
+        speak = pronounce_number_hr(int(string[0:2]))
+        speak += " "
+        if string[3:5] == '00':
+            speak += "nula nula"
+        else:
+            if string[3] == '0':
+                speak += pronounce_number_hr(0) + " "
+                speak += pronounce_number_hr(int(string[4]))
+            else:
+                speak += pronounce_number_hr(int(string[3:5]))
+        return speak
+    else:
+        if dt.hour == 0 and dt.minute == 0:
+            return "ponoć"
+        elif dt.hour == 12 and dt.minute == 0:
+            return "podne"
+
+        hour = dt.hour % 12 or 12  # 12 hour clock and 0 is spoken as 12
+        next_hour = (dt.hour + 1) % 12 or 12
+        if dt.minute == 0:
+            speak = pronounce_number_hr(hour) + " " + _plural_sat_hr(hour)
+        elif traditional and dt.minute == 30:
+            speak = "pola " + pronounce_number_hr(next_hour)
+        elif traditional and dt.minute == 45:
+            speak = "petnaest do " + pronounce_number_hr(next_hour)
+        else:
+            speak = pronounce_number_hr(hour) + " i " + \
+                pronounce_number_hr(dt.minute)
+
+        if use_ampm:
+            if dt.hour > 11:
+                speak += " p.m."
+            else:
+                speak += " a.m."
+
+        return speak
+
+
+def extract_duration_hr(text, resolution=DurationResolution.TIMEDELTA,
+                        replace_token=""):
+    """
+    Convert a phrase into a duration and return the remainder text.
+
+    The words used in the duration are consumed, the remainder of the
+    text is returned. Returns None for empty input; the duration is
+    None if no duration was found.
+
+    Args:
+        text (str): string containing a duration.
+        resolution (DurationResolution): format to return the duration in.
+        replace_token (str): string each consumed duration is replaced with.
+    Returns:
+        (duration, str): the duration (timedelta, relativedelta or float
+                         depending on resolution) and the remaining
+                         unconsumed text.
+    """
+    return extract_duration_generic(text, DURATION_LEXICONS["hr"],
+                                    resolution, replace_token)
+
+
+_MONTHS_HR = ['siječanj', 'veljača', 'ožujak', 'travanj', 'svibanj', 'lipanj',
+              'srpanj', 'kolovoz', 'rujan', 'listopad', 'studeni',
+              'prosinac']
+
+_MONTHS_EN = ['january', 'february', 'march', 'april', 'may', 'june',
+              'july', 'august', 'september', 'october', 'november',
+              'december']
+
+# genitive month forms ("3. siječnja")
+_MONTH_VARIANTS_HR = {
+    'siječnja': 'siječanj', 'siječnju': 'siječanj',
+    'veljače': 'veljača', 'veljači': 'veljača',
+    'ožujka': 'ožujak', 'ožujku': 'ožujak',
+    'travnja': 'travanj', 'travnju': 'travanj',
+    'svibnja': 'svibanj', 'svibnju': 'svibanj',
+    'lipnja': 'lipanj', 'lipnju': 'lipanj',
+    'srpnja': 'srpanj', 'srpnju': 'srpanj',
+    'kolovoza': 'kolovoz', 'kolovozu': 'kolovoz',
+    'rujna': 'rujan', 'rujnu': 'rujan',
+    'listopada': 'listopad', 'listopadu': 'listopad',
+    'studenog': 'studeni', 'studenoga': 'studeni', 'studenom': 'studeni',
+    'prosinca': 'prosinac', 'prosincu': 'prosinac',
+}
+
+_DAYS_HR = ['ponedjeljak', 'utorak', 'srijeda', 'četvrtak', 'petak', 'subota',
+            'nedjelja']
+
+# accusative weekday forms ("u srijedu", "u subotu", "u nedjelju")
+_DAY_VARIANTS_HR = {
+    'srijedu': 'srijeda', 'srijedi': 'srijeda',
+    'subotu': 'subota', 'suboti': 'subota',
+    'nedjelju': 'nedjelja', 'nedjelji': 'nedjelja',
+    'ponedjeljkom': 'ponedjeljak', 'utorkom': 'utorak',
+    'četvrtkom': 'četvrtak', 'petkom': 'petak',
+}
+
+# unit words normalized to a canonical form
+_UNIT_VARIANTS_HR = {
+    'dana': 'dan', 'dani': 'dan', 'danu': 'dan', 'danom': 'dan',
+    'tjedna': 'tjedan', 'tjedni': 'tjedan', 'tjednu': 'tjedan',
+    'tjedana': 'tjedan',
+    'mjeseca': 'mjesec', 'mjeseci': 'mjesec', 'mjesecu': 'mjesec',
+    'mjeseca': 'mjesec',
+    'godine': 'godina', 'godinu': 'godina', 'godina': 'godina',
+    'godini': 'godina', 'godinama': 'godina',
+    'minute': 'minuta', 'minutu': 'minuta', 'minuta': 'minuta',
+    'minuti': 'minuta',
+    'sata': 'sat', 'sati': 'sat', 'satu': 'sat',
+    'sekunde': 'sekunda', 'sekundu': 'sekunda', 'sekundi': 'sekunda',
+}
+
+_NEXT_WORDS_HR = ('sljedeći', 'sljedeća', 'sljedeću', 'sljedeće',
+                  'idući', 'iduća', 'iduću', 'iduće', 'naredni', 'naredna',
+                  'narednu')
+_LAST_WORDS_HR = ('prošli', 'prošla', 'prošlu', 'prošle', 'prethodni',
+                  'prethodna', 'prethodnu')
+
+_MARKERS_HR = ['u', 'na', 'za', 'do', 'o', 'oko', 'ovaj', 'ovu', 'kroz']
+
+# prepositions introducing a future offset ("za 5 minuta", "kroz 5 minuta")
+_FUTURE_PREPS_HR = ('za', 'kroz')
+
+# cardinal hour words used in spoken clock times ("u osam", "pola devet")
+_HOURS_CARDINAL_HR = {
+    'jedan': 1, 'jedne': 1, 'dva': 2, 'dvije': 2, 'tri': 3, 'četiri': 4,
+    'pet': 5, 'šest': 6, 'sedam': 7, 'osam': 8, 'devet': 9, 'deset': 10,
+    'jedanaest': 11, 'dvanaest': 12,
+}
+
+
+def extract_datetime_hr(text, anchorDate=None, default_time=None):
+    """ Convert a human date reference into an exact datetime
+
+    Convert things like
+        "danas"
+        "sutra poslijepodne"
+        "u srijedu u osam navečer"
+        "3. siječnja"
+    into a datetime.  If a reference date is not provided, the current
+    local time is used.  Also consumes the words used to define the date
+    returning the remaining string.
+
+    Args:
+        text (str): string containing date words
+        anchorDate (datetime): A reference date/time for "sutra", etc
+        default_time (time): Time to set if no time was found in the string
+
+    Returns:
+        [datetime, str]: An array containing the datetime and the remaining
+                         text not consumed in the parsing, or None if no
+                         date or time related text was found.
+    """
+    if not text:
+        return None
+
+    anchorDate = anchorDate or now_local()
+    currentYear = anchorDate.strftime("%Y")
+
+    def normalize(word):
+        word = _DAY_VARIANTS_HR.get(word, word)
+        word = _MONTH_VARIANTS_HR.get(word, word)
+        word = _UNIT_VARIANTS_HR.get(word, word)
+        return word
+
+    s = text.lower().replace(',', ' ').replace('?', ' ')
+    words = []
+    for w in s.split():
+        # strip the ordinal dot: "3. siječnja" -> "3 siječnja"
+        if w.endswith('.') and w[:-1].isdigit():
+            w = w[:-1]
+        words.append(w)
+
+    found = False
+    daySpecified = False
+    dayOffset = False
+    monthOffset = 0
+    yearOffset = 0
+    datestr = ""
+    hasYear = False
+    timeQualifier = ""
+
+    timeQualifiersAM = ['ujutro', 'prijepodne', 'prijepodnevu']
+    timeQualifiersPM = ['poslijepodne', 'popodne', 'navečer', 'uvečer',
+                        'noću']
+
+    # parse date references
+    for idx, word in enumerate(words):
+        if word == "":
+            continue
+        word = normalize(word)
+        wordPrev = normalize(words[idx - 1]) if idx > 0 else ""
+        wordPrevPrev = normalize(words[idx - 2]) if idx > 1 else ""
+        wordNext = normalize(words[idx + 1]) if idx + 1 < len(words) else ""
+        wordNextNext = normalize(words[idx + 2]) if idx + 2 < len(words) else ""
+        start = idx
+        used = 0
+
+        if word in timeQualifiersAM or word in timeQualifiersPM:
+            timeQualifier = word
+        elif word == "danas":
+            dayOffset = 0
+            used = 1
+        elif word == "sutra":
+            dayOffset = 1
+            used = 1
+        elif word == "prekosutra":
+            dayOffset = 2
+            used = 1
+        elif word == "jučer":
+            dayOffset = -1
+            used = 1
+        elif word == "prekjučer":
+            dayOffset = -2
+            used = 1
+        # parse "za 5 dana", "prije 5 dana"
+        elif word == "dan" and wordPrev and wordPrev[0].isdigit():
+            dayOffset = (dayOffset or 0) + int(wordPrev)
+            start -= 1
+            used = 2
+            if wordPrevPrev == "prije":
+                dayOffset = -dayOffset
+                start -= 1
+                used += 1
+        # parse "sljedeći tjedan", "prošli tjedan", "za 2 tjedna"
+        elif word == "tjedan":
+            if wordPrev and wordPrev[0].isdigit():
+                dayOffset = (dayOffset or 0) + int(wordPrev) * 7
+                start -= 1
+                used = 2
+                if wordPrevPrev == "prije":
+                    dayOffset = -dayOffset
+                    start -= 1
+                    used += 1
+            elif wordPrev in _NEXT_WORDS_HR:
+                dayOffset = 7
+                start -= 1
+                used = 2
+            elif wordPrev in _LAST_WORDS_HR:
+                dayOffset = -7
+                start -= 1
+                used = 2
+        # parse "sljedeći mjesec", "za 3 mjeseca"
+        elif word == "mjesec" and wordPrev:
+            if wordPrev[0].isdigit():
+                monthOffset = int(wordPrev)
+                start -= 1
+                used = 2
+                if wordPrevPrev == "prije":
+                    monthOffset = -monthOffset
+                    start -= 1
+                    used += 1
+            elif wordPrev in _NEXT_WORDS_HR:
+                monthOffset = 1
+                start -= 1
+                used = 2
+            elif wordPrev in _LAST_WORDS_HR:
+                monthOffset = -1
+                start -= 1
+                used = 2
+        # parse "sljedeća godina", "za 2 godine"
+        elif word == "godina" and wordPrev:
+            if wordPrev[0].isdigit():
+                yearOffset = int(wordPrev)
+                start -= 1
+                used = 2
+                if wordPrevPrev == "prije":
+                    yearOffset = -yearOffset
+                    start -= 1
+                    used += 1
+            elif wordPrev in _NEXT_WORDS_HR:
+                yearOffset = 1
+                start -= 1
+                used = 2
+            elif wordPrev in _LAST_WORDS_HR:
+                yearOffset = -1
+                start -= 1
+                used = 2
+        # parse weekdays: "u ponedjeljak", "sljedeću srijedu"
+        elif word in _DAYS_HR:
+            d = _DAYS_HR.index(word)
+            dayOffset = (d - anchorDate.weekday()) % 7
+            used = 1
+            if wordPrev in _NEXT_WORDS_HR:
+                if dayOffset <= 2:
+                    dayOffset += 7
+                start -= 1
+                used += 1
+            elif wordPrev in _LAST_WORDS_HR:
+                dayOffset -= 7
+                start -= 1
+                used += 1
+        # parse "3. siječnja", "siječanj 2027", "5. svibnja 2030"
+        elif word in _MONTHS_HR:
+            m = _MONTHS_HR.index(word)
+            datestr = _MONTHS_EN[m]
+            used = 1
+            if wordPrev and wordPrev[0].isdigit():
+                datestr += " " + wordPrev
+                start -= 1
+                used += 1
+                if wordNext and wordNext.isdigit() and len(wordNext) == 4:
+                    datestr += " " + wordNext
+                    used += 1
+                    hasYear = True
+            elif wordNext and wordNext[0].isdigit():
+                datestr += " " + wordNext
+                used += 1
+                if wordNextNext and wordNextNext.isdigit() and \
+                        len(wordNextNext) == 4:
+                    datestr += " " + wordNextNext
+                    used += 1
+                    hasYear = True
+
+        if used > 0:
+            for i in range(used):
+                if 0 <= start + i < len(words):
+                    words[start + i] = ""
+            if start - 1 >= 0 and words[start - 1] in _MARKERS_HR:
+                words[start - 1] = ""
+            found = True
+            daySpecified = True
+
+    # parse time
+    hrOffset = 0
+    minOffset = 0
+    secOffset = 0
+    hrAbs = None
+    minAbs = None
+
+    for idx, word in enumerate(words):
+        if word == "":
+            continue
+        word = normalize(word)
+        wordPrev = normalize(words[idx - 1]) if idx > 0 else ""
+        wordPrevPrev = normalize(words[idx - 2]) if idx > 1 else ""
+        wordNext = normalize(words[idx + 1]) if idx + 1 < len(words) else ""
+        start = idx
+        used = 0
+
+        if word in ("podne", "podnevu"):
+            hrAbs = 12
+            minAbs = 0
+            used = 1
+        elif word in ("ponoć", "ponoći"):
+            hrAbs = 0
+            minAbs = 0
+            used = 1
+        elif word == "ujutro":
+            if hrAbs is None:
+                hrAbs = 8
+            elif hrAbs >= 12:
+                hrAbs -= 12
+            used = 1
+        elif word in ("prijepodne",):
+            if hrAbs is None:
+                hrAbs = 10
+            elif hrAbs >= 12:
+                hrAbs -= 12
+            used = 1
+        elif word in ("poslijepodne", "popodne"):
+            if hrAbs is None:
+                hrAbs = 15
+            elif 0 < hrAbs < 12:
+                hrAbs += 12
+            used = 1
+        elif word in ("navečer", "uvečer"):
+            if hrAbs is None:
+                hrAbs = 19
+            elif 0 < hrAbs < 12:
+                hrAbs += 12
+            used = 1
+        elif word == "noću":
+            if hrAbs is None:
+                hrAbs = 22
+            elif 5 < hrAbs < 12:
+                hrAbs += 12
+            used = 1
+        # spoken clock times: "u osam", "pola devet" (8:30, "pola" counts
+        # to the next hour), "petnaest do devet" (8:45), "osam i petnaest"
+        elif word in _HOURS_CARDINAL_HR and not (
+                wordPrev in _FUTURE_PREPS_HR and
+                wordNext in ("minuta", "sat", "sekunda")):
+            value = _HOURS_CARDINAL_HR[word]
+            used = 1
+            if wordPrev == "pola":
+                hrAbs = value - 1
+                minAbs = 30
+                start -= 1
+                used += 1
+            elif wordPrev == "do" and wordPrevPrev in ("petnaest", "četvrt"):
+                hrAbs = value - 1
+                minAbs = 45
+                start -= 2
+                used += 2
+            elif wordPrev in ("u", "oko"):
+                hrAbs = value
+                minAbs = 0
+                if wordNext == "i" and \
+                        normalize(words[idx + 2] if idx + 2 < len(words)
+                                  else "") in ("petnaest", "četvrt"):
+                    minAbs = 15
+                    used += 2
+                elif wordNext in ("i", "sat", "sati"):
+                    used += 1
+            else:
+                used = 0
+            if used:
+                if timeQualifier in timeQualifiersPM and 0 <= hrAbs < 12:
+                    hrAbs += 12
+                elif timeQualifier in timeQualifiersAM and hrAbs >= 12:
+                    hrAbs -= 12
+        # spelled future offsets: "za deset minuta", "za tri sata"
+        elif wordPrev in _FUTURE_PREPS_HR and \
+                wordNext in ("minuta", "sat", "sekunda") and \
+                not word[0].isdigit() and _int_token_hr(word) is not None:
+            value = _int_token_hr(word)
+            if wordNext == "minuta":
+                minOffset = value
+            elif wordNext == "sat":
+                hrOffset = value
+            else:
+                secOffset = value
+            hrAbs = -1
+            minAbs = -1
+            start -= 1
+            used = 3
+        elif word[0].isdigit():
+            strHH = ""
+            strMM = ""
+            if ':' in word:
+                components = word.replace('.', '').split(':')
+                if len(components) == 2 and components[0].isdigit() and \
+                        components[1].isdigit():
+                    strHH, strMM = components
+                    used = 1
+            elif word.isdigit():
+                # parse "za 5 minuta", "kroz 3 sata", "za 30 sekundi"
+                if wordNext in ("minuta", "sat", "sekunda") and \
+                        wordPrev in _FUTURE_PREPS_HR:
+                    value = int(word)
+                    if wordNext == "minuta":
+                        minOffset = value
+                    elif wordNext == "sat":
+                        hrOffset = value
+                    else:
+                        secOffset = value
+                    hrAbs = -1
+                    minAbs = -1
+                    start -= 1
+                    used = 3
+                elif int(word) <= 24 and \
+                        (wordPrev in ("u", "oko") or wordNext == "sat"):
+                    # "u 8", "u 17 sati"
+                    strHH = word
+                    used = 1
+                    if wordNext == "sat":
+                        used += 1
+            if strHH:
+                HH = int(strHH)
+                MM = int(strMM) if strMM else 0
+                if HH <= 24 and MM <= 59:
+                    if timeQualifier in timeQualifiersPM and 0 < HH < 12:
+                        HH += 12
+                    elif timeQualifier in timeQualifiersAM and HH >= 12:
+                        HH -= 12
+                    hrAbs = HH % 24
+                    minAbs = MM
+                else:
+                    used = 0
+
+        if used > 0:
+            for i in range(used):
+                if 0 <= start + i < len(words):
+                    words[start + i] = ""
+            if start - 1 >= 0 and words[start - 1] in _MARKERS_HR:
+                words[start - 1] = ""
+            found = True
+
+    # check that we found a date
+    if not found and not datestr:
+        return None
+
+    if dayOffset is False:
+        dayOffset = 0
+
+    # perform date manipulation
+    extractedDate = anchorDate.replace(microsecond=0)
+    if datestr != "":
+        try:
+            temp = datetime.strptime(datestr, "%B %d")
+        except ValueError:
+            try:
+                temp = datetime.strptime(datestr, "%B %d %Y")
+            except ValueError:
+                temp = datetime.strptime(datestr + " 1", "%B %d")
+        extractedDate = extractedDate.replace(hour=0, minute=0, second=0)
+        if not hasYear:
+            temp = temp.replace(year=extractedDate.year,
+                                tzinfo=extractedDate.tzinfo)
+            if extractedDate < temp:
+                extractedDate = extractedDate.replace(
+                    year=int(currentYear),
+                    month=int(temp.strftime("%m")),
+                    day=int(temp.strftime("%d")),
+                    tzinfo=extractedDate.tzinfo)
+            else:
+                extractedDate = extractedDate.replace(
+                    year=int(currentYear) + 1,
+                    month=int(temp.strftime("%m")),
+                    day=int(temp.strftime("%d")),
+                    tzinfo=extractedDate.tzinfo)
+        else:
+            extractedDate = extractedDate.replace(
+                year=int(temp.strftime("%Y")),
+                month=int(temp.strftime("%m")),
+                day=int(temp.strftime("%d")),
+                tzinfo=extractedDate.tzinfo)
+    else:
+        # ignore the current HH:MM:SS if relative using days or greater
+        if hrOffset == 0 and minOffset == 0 and secOffset == 0:
+            extractedDate = extractedDate.replace(hour=0, minute=0, second=0)
+
+    if yearOffset != 0:
+        extractedDate = extractedDate + relativedelta(years=yearOffset)
+    if monthOffset != 0:
+        extractedDate = extractedDate + relativedelta(months=monthOffset)
+    if dayOffset != 0:
+        extractedDate = extractedDate + relativedelta(days=dayOffset)
+    if hrAbs != -1 and minAbs != -1:
+        # If no time was supplied in the string set the time to default
+        # time if it's available
+        if hrAbs is None and minAbs is None and default_time is not None:
+            hrAbs, minAbs = default_time.hour, default_time.minute
+        else:
+            hrAbs = hrAbs or 0
+            minAbs = minAbs or 0
+
+        extractedDate = extractedDate + relativedelta(hours=hrAbs,
+                                                      minutes=minAbs)
+        if (hrAbs != 0 or minAbs != 0) and datestr == "":
+            if not daySpecified and anchorDate > extractedDate:
+                extractedDate = extractedDate + relativedelta(days=1)
+    if hrOffset != 0:
+        extractedDate = extractedDate + relativedelta(hours=hrOffset)
+    if minOffset != 0:
+        extractedDate = extractedDate + relativedelta(minutes=minOffset)
+    if secOffset != 0:
+        extractedDate = extractedDate + relativedelta(seconds=secOffset)
+
+    resultStr = " ".join(words)
+    resultStr = ' '.join(resultStr.split())
+    return [extractedDate, resultStr]

--- a/ovos_date_parser/duration.py
+++ b/ovos_date_parser/duration.py
@@ -616,6 +616,23 @@ register_duration_lexicon(DurationLexicon(
     }))
 
 register_duration_lexicon(DurationLexicon(
+    lang="hr",
+    units={
+        "microseconds": r"mikrosekund(?:a|e|i|u)?",
+        "milliseconds": r"milisekund(?:a|e|i|u)?",
+        "seconds": r"sekund(?:a|e|i|u)?",
+        "minutes": r"minut(?:a|e|i|u)?",
+        "hours": r"sat(?:a|i|u)?",
+        "days": r"dan(?:a|i|u)?",
+        "weeks": r"(?:tjedan|tjedn(?:a|i|u))",
+        "months": r"mjesec(?:a|i|u)?",
+        "years": r"godin(?:a|e|i|u)?",
+        "decades": r"(?:desetljeć(?:e|a|i)?|desetljeća)",
+        "centuries": r"stoljeć(?:e|a|i)?",
+        "millenniums": r"tisućljeć(?:e|a|i)?",
+    }))
+
+register_duration_lexicon(DurationLexicon(
     lang="az",
     pattern_template=r"(?P<value>\d+(?:\.?\d+)?)(?:\s+|\-)(?:{unit})"
                      r"(?:yə|a|ə)?(?:(?:\s|,)+)?(?P<half>yarım|0\.5)?(?:a)?",

--- a/ovos_date_parser/res/hr/date_time.json
+++ b/ovos_date_parser/res/hr/date_time.json
@@ -1,0 +1,119 @@
+{
+  "decade_format": {
+    "1": {"match": "^\\d$", "format": "{x}"},
+    "2": {"match": "^1\\d$", "format": "{xx}"},
+    "3": {"match": "^\\d0$", "format": "{x0}"},
+    "4": {"match": "^[2-9]\\d$", "format": "{x0} {x}"},
+    "default": "{number}"
+  },
+  "hundreds_format": {
+    "1": {"match": "^\\d{3}$", "format": "{x_in_x00} sto"},
+    "default": "{number}"
+  },
+  "thousand_format": {
+    "1": {"match": "^\\d00\\d$", "format": "{x_in_x000} tisuću"},
+    "2": {"match": "^\\d{4}$", "format": "{x0_in_x000} {x_in_x00} sto"},
+    "default": "{number}"
+  },
+  "year_format": {
+    "default": "{year} {bc}",
+    "bc": "pr. Kr."
+  },
+  "date_format": {
+    "date_full": "{weekday}, {day} {month} {formatted_year}",
+    "date_full_no_year": "{weekday}, {day} {month}",
+    "date_full_no_year_month": "{weekday}, {day}",
+    "today": "danas",
+    "tomorrow": "sutra",
+    "yesterday": "jučer"
+  },
+  "date_time_format": {
+    "date_time": "{formatted_date} u {formatted_time}"
+  },
+  "weekday": {
+    "0": "ponedjeljak",
+    "1": "utorak",
+    "2": "srijeda",
+    "3": "četvrtak",
+    "4": "petak",
+    "5": "subota",
+    "6": "nedjelja"
+  },
+  "date": {
+    "1": "prvi",
+    "2": "drugi",
+    "3": "treći",
+    "4": "četvrti",
+    "5": "peti",
+    "6": "šesti",
+    "7": "sedmi",
+    "8": "osmi",
+    "9": "deveti",
+    "10": "deseti",
+    "11": "jedanaesti",
+    "12": "dvanaesti",
+    "13": "trinaesti",
+    "14": "četrnaesti",
+    "15": "petnaesti",
+    "16": "šesnaesti",
+    "17": "sedamnaesti",
+    "18": "osamnaesti",
+    "19": "devetnaesti",
+    "20": "dvadeseti",
+    "21": "dvadeset prvi",
+    "22": "dvadeset drugi",
+    "23": "dvadeset treći",
+    "24": "dvadeset četvrti",
+    "25": "dvadeset peti",
+    "26": "dvadeset šesti",
+    "27": "dvadeset sedmi",
+    "28": "dvadeset osmi",
+    "29": "dvadeset deveti",
+    "30": "trideseti",
+    "31": "trideset prvi"
+  },
+  "month": {
+    "1": "siječanj",
+    "2": "veljača",
+    "3": "ožujak",
+    "4": "travanj",
+    "5": "svibanj",
+    "6": "lipanj",
+    "7": "srpanj",
+    "8": "kolovoz",
+    "9": "rujan",
+    "10": "listopad",
+    "11": "studeni",
+    "12": "prosinac"
+  },
+  "number": {
+    "0": "nula",
+    "1": "jedan",
+    "2": "dva",
+    "3": "tri",
+    "4": "četiri",
+    "5": "pet",
+    "6": "šest",
+    "7": "sedam",
+    "8": "osam",
+    "9": "devet",
+    "10": "deset",
+    "11": "jedanaest",
+    "12": "dvanaest",
+    "13": "trinaest",
+    "14": "četrnaest",
+    "15": "petnaest",
+    "16": "šesnaest",
+    "17": "sedamnaest",
+    "18": "osamnaest",
+    "19": "devetnaest",
+    "20": "dvadeset",
+    "30": "trideset",
+    "40": "četrdeset",
+    "50": "pedeset",
+    "60": "šezdeset",
+    "70": "sedamdeset",
+    "80": "osamdeset",
+    "90": "devedeset"
+  }
+}

--- a/ovos_date_parser/res/hr/date_words.json
+++ b/ovos_date_parser/res/hr/date_words.json
@@ -1,0 +1,11 @@
+{
+  "now": "sada",
+  "second": "sekunda",
+  "seconds": "sekunde",
+  "minute": "minuta",
+  "minutes": "minute",
+  "hour": "sat",
+  "hours": "sata",
+  "day": "dan",
+  "days": "dana"
+}

--- a/test/test_dates_hr.py
+++ b/test/test_dates_hr.py
@@ -1,0 +1,313 @@
+"""Croatian (hr) date/time parsing.
+
+Covers the public entry points, an exhaustive digit-time round-trip
+sweep (pronounce a HH:MM, extract it, assert identity), and adversarial
+inputs written to break the parser.
+"""
+import unittest
+from datetime import datetime, timedelta
+
+from ovos_date_parser import (
+    extract_datetime, nice_time, nice_date, nice_year, nice_month,
+    nice_weekday, nice_duration,
+)
+from ovos_date_parser.dates_hr import (
+    nice_time_hr, extract_datetime_hr, extract_duration_hr,
+)
+
+# wednesday 2017-06-28 13:04 is a fixed, timezone-naive anchor
+ANCHOR = datetime(2017, 6, 28, 13, 4)
+_MINUTES = [0, 1, 5, 9, 15, 30, 45, 58, 59]
+
+
+class TestRoundTrip(unittest.TestCase):
+    def test_digit_time_identity(self):
+        checked = 0
+        for hh in range(24):
+            for mm in _MINUTES:
+                text = f"{hh}:{mm:02d}"
+                result = extract_datetime_hr(text, anchorDate=ANCHOR)
+                self.assertIsNotNone(result, text)
+                self.assertEqual((result[0].hour, result[0].minute),
+                                 (hh, mm), text)
+                checked += 1
+        self.assertGreaterEqual(checked, 200)
+
+    def test_display_time_identity(self):
+        for hh in range(24):
+            for mm in _MINUTES:
+                dt = ANCHOR.replace(hour=hh, minute=mm)
+                shown = nice_time(dt, "hr", speech=False, use_24hour=True)
+                self.assertEqual(shown, f"{hh:02d}:{mm:02d}")
+
+
+class TestNiceTime(unittest.TestCase):
+    def test_speech_forms_non_empty(self):
+        for hh in range(24):
+            for mm in (0, 15, 30, 45, 7):
+                dt = ANCHOR.replace(hour=hh, minute=mm)
+                self.assertTrue(nice_time(dt, "hr", use_24hour=True).strip())
+                self.assertTrue(nice_time(dt, "hr", use_24hour=False).strip())
+
+    def test_midnight_and_noon(self):
+        self.assertEqual(nice_time_hr(ANCHOR.replace(hour=0, minute=0),
+                                      use_24hour=False), "ponoć")
+        self.assertEqual(nice_time_hr(ANCHOR.replace(hour=12, minute=0),
+                                      use_24hour=False), "podne")
+
+    def test_traditional_variant(self):
+        dt = ANCHOR.replace(hour=8)
+        self.assertEqual(nice_time_hr(dt.replace(minute=30), use_24hour=False,
+                                      variant="traditional"), "pola devet")
+        self.assertEqual(nice_time_hr(dt.replace(minute=45), use_24hour=False,
+                                      variant="traditional"),
+                         "petnaest do devet")
+
+    def test_default_variant_is_digital(self):
+        dt = ANCHOR.replace(hour=8, minute=30)
+        self.assertEqual(nice_time_hr(dt, use_24hour=False),
+                         "osam i trideset")
+
+
+class TestExtractDatetime(unittest.TestCase):
+    def test_relative_days(self):
+        cases = {
+            "danas": 0,
+            "sutra": 1,
+            "prekosutra": 2,
+            "jučer": -1,
+            "prekjučer": -2,
+        }
+        for phrase, offset in cases.items():
+            result = extract_datetime_hr(phrase, anchorDate=ANCHOR)
+            self.assertIsNotNone(result, phrase)
+            self.assertEqual(result[0].date(),
+                             (ANCHOR + timedelta(days=offset)).date(), phrase)
+
+    def test_weekday(self):
+        result = extract_datetime_hr("u petak", anchorDate=ANCHOR)
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0].weekday(), 4)
+
+    def test_weekday_accusative(self):
+        result = extract_datetime_hr("u srijedu", anchorDate=ANCHOR)
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0].weekday(), 2)
+
+    def test_explicit_date(self):
+        result = extract_datetime_hr("15. kolovoza", anchorDate=ANCHOR)
+        self.assertIsNotNone(result)
+        self.assertEqual((result[0].month, result[0].day), (8, 15))
+
+    def test_date_with_year(self):
+        result = extract_datetime_hr("15. kolovoza 2020", anchorDate=ANCHOR)
+        self.assertIsNotNone(result)
+        self.assertEqual((result[0].year, result[0].month, result[0].day),
+                         (2020, 8, 15))
+
+    def test_offset_minutes(self):
+        result = extract_datetime_hr("za 5 minuta", anchorDate=ANCHOR)
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], ANCHOR + timedelta(minutes=5))
+
+    def test_spoken_clock(self):
+        cases = {
+            "u osam": (8, 0),
+            "pola devet": (8, 30),
+            "petnaest do devet": (8, 45),
+            "u osam i petnaest": (8, 15),
+        }
+        for phrase, (h, m) in cases.items():
+            result = extract_datetime_hr(phrase, anchorDate=ANCHOR)
+            self.assertIsNotNone(result, phrase)
+            self.assertEqual((result[0].hour, result[0].minute), (h, m),
+                             phrase)
+
+    def test_leftover_text_returned(self):
+        result = extract_datetime_hr("kakvo je vrijeme sutra",
+                                     anchorDate=ANCHOR)
+        self.assertIsNotNone(result)
+        self.assertNotIn("sutra", result[1])
+        self.assertIn("vrijeme", result[1])
+
+
+class TestExtractDuration(unittest.TestCase):
+    def test_minutes(self):
+        self.assertEqual(extract_duration_hr("10 minuta")[0],
+                         timedelta(minutes=10))
+
+    def test_compound(self):
+        self.assertEqual(extract_duration_hr("2 sata 30 minuta")[0],
+                         timedelta(hours=2, minutes=30))
+
+    def test_spelled_number(self):
+        self.assertEqual(extract_duration_hr("pet minuta")[0],
+                         timedelta(minutes=5))
+
+
+class TestNiceDateFamily(unittest.TestCase):
+    def test_non_empty(self):
+        self.assertTrue(nice_date(ANCHOR, "hr").strip())
+        self.assertTrue(nice_year(ANCHOR, "hr").strip())
+        self.assertEqual(nice_month(ANCHOR, "hr").lower(), "lipanj")
+        self.assertTrue(nice_weekday(ANCHOR, "hr").strip())
+        self.assertTrue(nice_duration(163, "hr").strip())
+
+
+class TestAdversarial(unittest.TestCase):
+    def test_empty_and_blank(self):
+        self.assertIsNone(extract_datetime_hr("", anchorDate=ANCHOR))
+        self.assertIsNone(extract_datetime_hr("   ", anchorDate=ANCHOR))
+
+    def test_no_date_text(self):
+        self.assertIsNone(extract_datetime_hr("bok kako si",
+                                              anchorDate=ANCHOR))
+
+    def test_impossible_clock_values(self):
+        for bad in ("99:99", "25:61", "40:00", "13:75"):
+            self.assertIsNone(extract_datetime_hr(bad, anchorDate=ANCHOR), bad)
+
+    def test_boundary_clock_values(self):
+        self.assertEqual(extract_datetime_hr("00:00", anchorDate=ANCHOR)[0]
+                         .hour, 0)
+        self.assertEqual(extract_datetime_hr("24:00", anchorDate=ANCHOR)[0]
+                         .hour, 0)
+
+    def test_duration_empty_is_none(self):
+        self.assertIsNone(extract_duration_hr(""))
+
+    def test_duration_junk_yields_no_value(self):
+        duration, remainder = extract_duration_hr("nema trajanja ovdje")
+        self.assertIsNone(duration)
+
+    def test_garbage_is_rejected(self):
+        self.assertIsNone(extract_datetime_hr("qwerty zxcvb",
+                                              anchorDate=ANCHOR))
+
+    def test_lone_ordinal_dot_not_crash(self):
+        result = extract_datetime_hr("15.", anchorDate=ANCHOR)
+        self.assertIsNone(result)
+
+
+class TestNaturalSentences(unittest.TestCase):
+    """Full sentences a user would actually speak.
+
+    Every expected value is derived from Croatian usage, then checked
+    against the parser; both the resolved datetime and the leftover text
+    are asserted.
+    """
+    CASES = [
+        ("probudi me sutra u sedam ujutro",
+         "2017-06-29 07:00", "probudi me"),
+        ("podsjeti me na sastanak u petak u pola tri poslijepodne",
+         "2017-06-30 14:30", "podsjeti me na sastanak"),
+        ("vidimo se za tri sata",
+         "2017-06-28 16:04", "vidimo se"),
+        ("imam sastanak 15. kolovoza u 14:30",
+         "2017-08-15 14:30", "imam sastanak"),
+        ("za deset minuta",
+         "2017-06-28 13:14", ""),
+        ("sljedeću srijedu u podne",
+         "2017-07-05 12:00", ""),
+        ("u osam i petnaest navečer",
+         "2017-06-28 20:15", ""),
+        ("budilica u 6:45",
+         "2017-06-29 06:45", "budilica"),
+    ]
+
+    def test_sentences(self):
+        for text, expected_dt, expected_rem in self.CASES:
+            result = extract_datetime_hr(text, anchorDate=ANCHOR)
+            self.assertIsNotNone(result, text)
+            self.assertEqual(result[0].strftime("%Y-%m-%d %H:%M"),
+                             expected_dt, text)
+            self.assertEqual(result[1], expected_rem, text)
+
+
+class TestSpelledOffsets(unittest.TestCase):
+    def test_spelled_in_minutes_hours_seconds(self):
+        cases = {
+            "za pet minuta": timedelta(minutes=5),
+            "za deset minuta": timedelta(minutes=10),
+            "za tri sata": timedelta(hours=3),
+            "za dvadeset minuta": timedelta(minutes=20),
+            "za trideset sekundi": timedelta(seconds=30),
+        }
+        for phrase, delta in cases.items():
+            result = extract_datetime_hr(phrase, anchorDate=ANCHOR)
+            self.assertIsNotNone(result, phrase)
+            self.assertEqual(result[0], ANCHOR + delta, phrase)
+
+
+class TestDurationSentences(unittest.TestCase):
+    def test_declined_numbers_in_context(self):
+        self.assertEqual(
+            extract_duration_hr("postavi timer na dva sata "
+                                "i trideset minuta")[0],
+            timedelta(hours=2, minutes=30))
+        self.assertEqual(extract_duration_hr("čekaj pet minuta")[0],
+                         timedelta(minutes=5))
+        self.assertEqual(extract_duration_hr("odbrojavaj devetnaest "
+                                             "sekundi")[0],
+                         timedelta(seconds=19))
+
+
+class TestBoundaryEdges(unittest.TestCase):
+    def test_leap_day(self):
+        result = extract_datetime_hr("29. veljače 2020", anchorDate=ANCHOR)
+        self.assertEqual(result[0].strftime("%Y-%m-%d"), "2020-02-29")
+
+    def test_mixed_case(self):
+        result = extract_datetime_hr("SUTRA U SEDAM UJUTRO",
+                                     anchorDate=ANCHOR)
+        self.assertEqual(result[0].strftime("%Y-%m-%d %H:%M"),
+                         "2017-06-29 07:00")
+
+    def test_none_input(self):
+        self.assertIsNone(extract_datetime_hr(None, anchorDate=ANCHOR))
+
+    def test_language_code_variant_dispatch(self):
+        result = extract_datetime("sutra", "hr-HR", anchorDate=ANCHOR)
+        self.assertEqual(result[0].date(),
+                         (ANCHOR + timedelta(days=1)).date())
+        self.assertTrue(nice_time(ANCHOR, "hr-HR", use_24hour=True).strip())
+
+    def test_wrap_around_clock(self):
+        result = extract_datetime_hr("u 23:30", anchorDate=ANCHOR)
+        self.assertEqual((result[0].hour, result[0].minute), (23, 30))
+
+    def test_remainder_retained(self):
+        result = extract_datetime_hr("koliko košta karta za sutra",
+                                     anchorDate=ANCHOR)
+        self.assertNotIn("sutra", result[1])
+        self.assertIn("karta", result[1])
+
+
+class TestNumbersInContext(unittest.TestCase):
+    def test_trailing_punctuation_and_digits(self):
+        result = extract_datetime_hr("sastanak 15. kolovoza?",
+                                     anchorDate=ANCHOR)
+        self.assertEqual((result[0].month, result[0].day), (8, 15))
+
+    def test_digit_time_inside_sentence(self):
+        result = extract_datetime_hr("vlak polazi u 9:05", anchorDate=ANCHOR)
+        self.assertEqual((result[0].hour, result[0].minute), (9, 5))
+
+
+class TestCrossLanguageContamination(unittest.TestCase):
+    """Slovak/Bulgarian date phrases must not parse as Croatian dates."""
+    FOREIGN = [
+        "zajtra", "budúcu stredu", "o siedmej ráno", "15. augusta",
+        "o desať minút", "stretneme sa o tri hodiny",
+        "утре", "следващата сряда", "в седем сутринта", "15 август",
+        "след десет минути", "след три часа",
+    ]
+
+    def test_foreign_phrases_do_not_match(self):
+        for phrase in self.FOREIGN:
+            self.assertIsNone(extract_datetime_hr(phrase, anchorDate=ANCHOR),
+                              phrase)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds date/time parsing for Croatian (`hr`).

## Entry points
- `nice_time` (12h/24h) with a `variant` kwarg: default reads `<hour> i <minutes>`, `"traditional"` uses the analog idiom (`pola devet` = 8:30, `petnaest do devet` = 8:45)
- `extract_datetime`, `extract_duration`
- `nice_date` / `nice_date_time` / `nice_day` / `nice_weekday` / `nice_month` / `nice_year` / `nice_relative_time` / `nice_duration` via `res/hr/`

Joins the shared `test_lang_parity` and `test_multilang_invariants` suites.

## Approach
Croatian follows the Slovene structure. Parsing is permissive across verifiable forms: nominative plus accusative weekdays (`u srijedu`), genitive months (`3. siječnja`), declined unit nouns, digit and spelled durations, digit clock times, spoken cardinal hours (`u osam`) and the analog `pola`/`i`/`do` idioms. Expected values are hand-written from reference usage, never taken from parser output.

## Tests
216-value digit-time round-trip sweep, display round-trip, both formatter registers, spoken-clock idioms, and adversarial cases (empty/blank, impossible clocks, boundary clocks, non-date text, garbage, lone ordinal dot, empty/junk durations).

`test_dates_hr.py`: 26 tests. Full suite: 455 passed, 2 skipped (1 pre-existing failure: installed package metadata version vs source version, environmental).