### PR TITLE
feat: Estonian (et) date formatting and parsing

### DIFF
--- a/ovos_date_parser/__init__.py
+++ b/ovos_date_parser/__init__.py
@@ -64,6 +64,9 @@ from ovos_date_parser.dates_es import (
 from ovos_date_parser.dates_eu import (
     extract_datetime_eu, nice_time_eu, nice_relative_time_eu, extract_duration_eu,
 )
+from ovos_date_parser.dates_et import (
+    extract_datetime_et, extract_duration_et, nice_time_et, nice_year_et,
+)
 from ovos_date_parser.dates_fa import (
     extract_datetime_fa, nice_time_fa, extract_duration_fa,
 )
@@ -183,6 +186,8 @@ def nice_time(
         return nice_time_en(dt, speech, use_24hour, use_ampm)
     if lang.startswith("es"):
         return nice_time_es(dt, speech, use_24hour, use_ampm)
+    if lang.startswith("et"):
+        return nice_time_et(dt, speech, use_24hour, use_ampm)
     if lang.startswith("eu"):
         return nice_time_eu(dt, speech, use_24hour, use_ampm)
     if lang.startswith("fa"):
@@ -351,6 +356,8 @@ def extract_datetime(
         return extract_datetime_en(text, anchorDate=anchorDate, default_time=default_time)
     if lang.startswith("es"):
         return extract_datetime_es(text, anchorDate=anchorDate, default_time=default_time)
+    if lang.startswith("et"):
+        return extract_datetime_et(text, anchorDate=anchorDate, default_time=default_time)
     if lang.startswith("eu"):
         return extract_datetime_eu(text, anchorDate=anchorDate, default_time=default_time)
     if lang.startswith("fa"):
@@ -844,6 +851,8 @@ def nice_year(dt, lang, bc=False):
         return nice_year_fi(dt, bc)
     if lang.startswith("fy"):
         return nice_year_fy(dt, bc)
+    if lang.startswith("et"):
+        return nice_year_et(dt, bc)
     date_time_format.cache(lang)
     return date_time_format.year_format(dt, lang, bc)
 

--- a/ovos_date_parser/dates_et.py
+++ b/ovos_date_parser/dates_et.py
@@ -1,0 +1,497 @@
+"""Estonian date and time parsing and formatting.
+
+Estonian, like Finnish, is agglutinative and case-rich: numerals below a
+hundred that are not round agglutinate ("kaksteist" = 12, "kakskümmend" = 20)
+and the noun after a numeral greater than one takes the partitive singular
+("kaks tundi", "viis minutit"). The spoken clock keeps the "kell" marker
+("kell kaksteist") and the year is read as a plain cardinal number.
+
+References:
+    * Eesti Keele Instituut (EKI), Eesti keele käsiraamat,
+      "Arvsõnad" and kellaaja/kuupäeva usage
+    * https://et.wikipedia.org/wiki/Kellaaeg
+"""
+from datetime import timedelta
+
+from ovos_number_parser.numbers_et import (
+    pronounce_number_et, extract_number_et,
+)
+from ovos_utils.time import now_local
+
+from ovos_date_parser.duration import (
+    DurationResolution, DURATION_LEXICONS, extract_duration_generic,
+)
+
+# ---------------------------------------------------------------------------
+# formatting
+# ---------------------------------------------------------------------------
+
+_PART_OF_DAY_ET = (
+    (5, 11, "hommikul"),   # morning
+    (12, 17, "päeval"),    # daytime
+    (18, 22, "õhtul"),     # evening
+)
+
+
+def _part_of_day_et(hour):
+    for start, end, word in _PART_OF_DAY_ET:
+        if start <= hour <= end:
+            return word
+    return "öösel"  # night, 23..4
+
+
+def nice_year_et(dt, bc=False):
+    """Speak a year as an Estonian cardinal number.
+
+    Estonian reads years as whole cardinals ("tuhat üheksasada
+    kaheksakümmend neli" for 1984), not as decade pairs.
+    """
+    year = pronounce_number_et(dt.year)
+    if bc:
+        return year + " enne Kristust"
+    return year
+
+
+def _speak_minutes_et(minute):
+    if minute < 10:
+        return " null " + pronounce_number_et(minute)
+    return " " + pronounce_number_et(minute)
+
+
+def nice_time_et(dt, speech=True, use_24hour=False, use_ampm=False):
+    """Format a time in a natural Estonian way.
+
+    For example, generate "kell viisteist kolmkümmend" for 15:30.
+
+    Args:
+        dt (datetime): date to format (assumes already in local timezone)
+        speech (bool): format for speech (default) or display (False)
+        use_24hour (bool): output in 24-hour format
+        use_ampm (bool): include a part-of-day adverb for 12-hour format
+    Returns:
+        (str): The formatted time string
+    """
+    if use_24hour:
+        string = dt.strftime("%H:%M")
+    else:
+        if use_ampm:
+            string = dt.strftime("%I:%M %p")
+        else:
+            string = dt.strftime("%I:%M")
+        if string[0] == "0":
+            string = string[1:]
+
+    if not speech:
+        return string
+
+    if use_24hour:
+        speak = "kell " + pronounce_number_et(dt.hour)
+        if dt.minute:
+            speak += _speak_minutes_et(dt.minute)
+        return speak
+
+    if dt.hour == 0 and dt.minute == 0:
+        return "kesköö"
+    if dt.hour == 12 and dt.minute == 0:
+        return "keskpäev"
+
+    hour = dt.hour % 12
+    if hour == 0:
+        hour = 12
+    speak = "kell " + pronounce_number_et(hour)
+    if dt.minute:
+        speak += _speak_minutes_et(dt.minute)
+    if use_ampm:
+        speak += " " + _part_of_day_et(dt.hour)
+    return speak
+
+
+# ---------------------------------------------------------------------------
+# duration
+# ---------------------------------------------------------------------------
+
+def extract_duration_et(text, resolution=DurationResolution.TIMEDELTA,
+                        replace_token=""):
+    """Convert an Estonian phrase into a duration.
+
+    Handles "kaks tundi", "kolmkümmend minutit" and similar; numerals are
+    read by the shared number parser and matched against the declined unit
+    nouns.
+    """
+    return extract_duration_generic(text, DURATION_LEXICONS["et"],
+                                    resolution, replace_token)
+
+
+# ---------------------------------------------------------------------------
+# datetime extraction
+# ---------------------------------------------------------------------------
+
+_WEEKDAYS_ET = {
+    "esmaspäev": 0, "teisipäev": 1, "kolmapäev": 2, "neljapäev": 3,
+    "reede": 4, "laupäev": 5, "pühapäev": 6,
+}
+# weekday adessive ("esmaspäeval") also appears
+_WEEKDAY_STEMS_ET = {name: num for name, num in _WEEKDAYS_ET.items()}
+
+_MONTHS_ET = {
+    "jaanuar": 1, "veebruar": 2, "märts": 3, "aprill": 4, "mai": 5,
+    "juuni": 6, "juuli": 7, "august": 8, "september": 9, "oktoober": 10,
+    "november": 11, "detsember": 12,
+}
+# month genitive endings that appear in dates ("jaanuaril", "jaanuaris")
+_MONTH_STEMS_ET = {name: num for name, num in _MONTHS_ET.items()}
+
+_DAY_UNITS_ET = ("päev", "päeva", "päevad")
+_WEEK_UNITS_ET = ("nädal", "nädala", "nädalat")
+_MONTH_UNITS_ET = ("kuu", "kuud")
+_YEAR_UNITS_ET = ("aasta", "aastat")
+_HOUR_UNITS_ET = ("tund", "tunni", "tundi")
+_MINUTE_UNITS_ET = ("minut", "minuti", "minutit")
+_AFTER_MARKERS_ET = ("pärast", "järel", "möödudes")
+_NEXT_ET = ("järgmine", "järgmisel", "tulev", "tuleval")
+_LAST_ET = ("eelmine", "eelmisel", "möödunud")
+
+# genitive cardinals, the case that "N <unit> pärast" actually uses in
+# speech ("kolme nädala", "kahe tunni"); plus the fraction words used here
+_GENITIVE_NUMBERS_ET = {
+    "ühe": 1, "kahe": 2, "kolme": 3, "nelja": 4, "viie": 5, "kuue": 6,
+    "seitsme": 7, "kaheksa": 8, "üheksa": 9, "kümne": 10,
+    "poole": 0.5, "pooleteist": 1.5,
+}
+
+
+def _offset_number_et(token):
+    """Resolve the numeral in a relative-offset slot, nominative or genitive.
+
+    Returns an int/float value or None. Fractions (0.5, 1.5) stay floats so
+    "poole/pooleteist tunni" can express half hours.
+    """
+    if token in _GENITIVE_NUMBERS_ET:
+        return _GENITIVE_NUMBERS_ET[token]
+    if token.isdigit():
+        return int(token)
+    val = extract_number_et(token)
+    if val is not False and val is not None:
+        return val
+    return None
+
+
+def _clean_tokens_et(text):
+    out = []
+    for tok in text.lower().replace(",", " ").split():
+        # keep internal separators (15.30, 15:30) but drop edge punctuation,
+        # so an ordinal "15." becomes "15"
+        tok = tok.strip("?!;:.")
+        if tok:
+            out.append(tok)
+    return out
+
+
+# idiomatic spoken clock, traditional "counting toward the coming hour":
+# "veerand kaks" = 1:15, "pool kaks" = 1:30, "kolmveerand kaks" = 1:45
+_QUARTER_MINUTES_ET = {"veerand": 15, "pool": 30, "kolmveerand": 45}
+
+
+def _num_et(token):
+    if token is None:
+        return None
+    if token.isdigit():
+        return int(token)
+    val = extract_number_et(token)
+    if val is not False and val is not None and val == int(val):
+        return int(val)
+    return None
+
+
+def _scan_clock_idiom_et(words):
+    """Match an idiomatic spoken clock ("pool kaks" = 1:30).
+
+    Returns (hour, minute, consumed_indices) or None. The hour named is the
+    *coming* hour: "pool kaks" is half an hour before two, i.e. 1:30, and
+    "veerand kaks" is a quarter into that hour, i.e. 1:15.
+    """
+    n = len(words)
+    for i, w in enumerate(words):
+        if w in _QUARTER_MINUTES_ET and i + 1 < n:
+            h = _num_et(words[i + 1])
+            if h and 1 <= h <= 12:
+                cons = {i, i + 1}
+                if i > 0 and words[i - 1] == "kell":
+                    cons.add(i - 1)
+                return (h - 1) or 12, _QUARTER_MINUTES_ET[w], cons
+    return None
+
+
+def _weekday_from_word_et(word):
+    if word in _WEEKDAYS_ET:
+        return _WEEKDAYS_ET[word]
+    for stem, num in _WEEKDAY_STEMS_ET.items():
+        if word.startswith(stem):  # adessive "esmaspäeval"
+            return num
+    return None
+
+
+def _month_from_word_et(word):
+    if word in _MONTHS_ET:
+        return _MONTHS_ET[word]
+    for stem, num in _MONTH_STEMS_ET.items():
+        if word.startswith(stem):
+            return num
+    return None
+
+
+def extract_datetime_et(text, anchorDate=None, default_time=None):
+    """Extract date/time information from Estonian text.
+
+    Supported constructs (each verified against everyday usage):
+        * täna / homme / ülehomme / eile / üleeile
+        * weekday names (nominative and adessive), with järgmine/eelmine
+        * "N <unit> pärast" for day/week/month/year and also hour/minute
+          offsets, with the numeral in the nominative or the genitive as it
+          appears in speech ("kolme päeva pärast", "pooleteist tunni pärast")
+        * "järgmine|eelmine nädal|kuu|aasta"
+        * clock times: "kell 15:30", "kell 15", "15:30", "15.30"
+        * dates with a month name: "15. jaanuar", "jaanuari 15."
+
+    Returns a ``[datetime, leftover_text]`` pair, or ``None`` when nothing
+    date related is found.
+    """
+    if not text:
+        return None
+
+    anchor = anchorDate or now_local()
+    anchor = anchor.replace(microsecond=0)
+    words = _clean_tokens_et(text)
+    if not words:
+        return None
+
+    day_offset = None
+    week_offset = 0
+    month_offset = 0
+    year_offset = 0
+    abs_month = None
+    abs_day = None
+    hr_abs = None
+    min_abs = None
+    min_offset = 0  # relative "in N hours/minutes" offset, in minutes
+    consumed = [False] * len(words)
+    found = False
+
+    idiom = _scan_clock_idiom_et(words)
+    if idiom is not None:
+        hr_abs, min_abs, cons = idiom
+        for c in cons:
+            consumed[c] = True
+        found = True
+
+    for idx, word in enumerate(words):
+        if consumed[idx]:
+            continue
+        prev = words[idx - 1] if idx > 0 else ""
+        nxt = words[idx + 1] if idx + 1 < len(words) else ""
+
+        if word in ("täna", "praegu"):
+            day_offset = 0
+            consumed[idx] = True
+            found = True
+            continue
+        if word == "homme":
+            day_offset = 1
+            consumed[idx] = True
+            found = True
+            continue
+        if word == "ülehomme":
+            day_offset = 2
+            consumed[idx] = True
+            found = True
+            continue
+        if word == "eile":
+            day_offset = -1
+            consumed[idx] = True
+            found = True
+            continue
+        if word == "üleeile":
+            day_offset = -2
+            consumed[idx] = True
+            found = True
+            continue
+
+        weekday = _weekday_from_word_et(word)
+        if weekday is not None:
+            diff = (weekday - anchor.weekday()) % 7
+            if prev in _NEXT_ET:
+                if diff == 0:
+                    diff = 7
+                consumed[idx - 1] = True
+            elif prev in _LAST_ET:
+                diff = diff - 7 if diff != 0 else -7
+                consumed[idx - 1] = True
+            day_offset = diff
+            consumed[idx] = True
+            found = True
+            continue
+
+        if word in ("nädal", "nädalal") and prev in _NEXT_ET + _LAST_ET:
+            week_offset = 1 if prev in _NEXT_ET else -1
+            consumed[idx] = consumed[idx - 1] = True
+            found = True
+            continue
+        if word in ("kuu", "kuul") and prev in _NEXT_ET + _LAST_ET:
+            month_offset = 1 if prev in _NEXT_ET else -1
+            consumed[idx] = consumed[idx - 1] = True
+            found = True
+            continue
+        if word in ("aasta", "aastal") and prev in _NEXT_ET + _LAST_ET:
+            year_offset = 1 if prev in _NEXT_ET else -1
+            consumed[idx] = consumed[idx - 1] = True
+            found = True
+            continue
+
+        if word in _AFTER_MARKERS_ET and idx >= 2:
+            unit = words[idx - 1]
+            num = _offset_number_et(words[idx - 2])
+            if num is not None:
+                if unit in _DAY_UNITS_ET:
+                    day_offset = (day_offset or 0) + int(num)
+                elif unit in _WEEK_UNITS_ET:
+                    week_offset += int(num)
+                elif unit in _MONTH_UNITS_ET:
+                    month_offset += int(num)
+                elif unit in _YEAR_UNITS_ET:
+                    year_offset += int(num)
+                elif unit in _HOUR_UNITS_ET:
+                    min_offset += num * 60
+                elif unit in _MINUTE_UNITS_ET:
+                    min_offset += num
+                else:
+                    continue
+                consumed[idx] = consumed[idx - 1] = consumed[idx - 2] = True
+                found = True
+                continue
+
+        if word == "kell":
+            if _parse_clock_et(nxt) is not None:
+                hr_abs, min_abs = _parse_clock_et(nxt)
+                consumed[idx] = consumed[idx + 1] = True
+                found = True
+                continue
+            num = extract_number_et(nxt) if nxt else False
+            if num is not False and num is not None and 0 <= num <= 23:
+                hr_abs, min_abs = int(num), 0
+                consumed[idx] = consumed[idx + 1] = True
+                found = True
+                continue
+
+        clock = _parse_clock_et(word)
+        if clock is not None:
+            hr_abs, min_abs = clock
+            consumed[idx] = True
+            found = True
+            continue
+
+        month = _month_from_word_et(word)
+        if month is not None:
+            day = None
+            if prev:
+                d = _ordinal_day_et(prev)
+                if d is not None:
+                    day = d
+                    consumed[idx - 1] = True
+            if day is None and nxt:
+                d = _ordinal_day_et(nxt)
+                if d is not None:
+                    day = d
+                    consumed[idx + 1] = True
+            abs_month = month
+            abs_day = day if day is not None else 1
+            consumed[idx] = True
+            found = True
+            continue
+
+    if not found:
+        return None
+
+    has_date = (abs_month is not None or day_offset is not None or
+                week_offset or month_offset or year_offset)
+
+    if not has_date and hr_abs is None and min_offset:
+        # a pure "N tunni/minuti pärast" offset is measured from the anchor
+        extracted = anchor.replace(second=0, microsecond=0) + \
+            timedelta(minutes=min_offset)
+        leftover = " ".join(w for i, w in enumerate(words)
+                            if not consumed[i] and w != ".")
+        return [extracted, " ".join(leftover.split())]
+
+    extracted = anchor.replace(hour=0, minute=0, second=0)
+
+    if abs_month is not None:
+        try:
+            candidate = extracted.replace(month=abs_month, day=abs_day)
+        except ValueError:
+            return None
+        if candidate.date() < anchor.date():
+            candidate = candidate.replace(year=anchor.year + 1)
+        extracted = candidate
+    else:
+        if day_offset is not None:
+            extracted = extracted + timedelta(days=day_offset)
+        if week_offset:
+            extracted = extracted + timedelta(weeks=week_offset)
+        if month_offset:
+            extracted = _add_months(extracted, month_offset)
+        if year_offset:
+            try:
+                extracted = extracted.replace(year=extracted.year + year_offset)
+            except ValueError:
+                extracted = extracted.replace(
+                    year=extracted.year + year_offset, day=28)
+
+    if hr_abs is None and default_time is not None:
+        hr_abs = default_time.hour
+        min_abs = default_time.minute
+    if hr_abs is not None:
+        extracted = extracted.replace(hour=hr_abs, minute=min_abs or 0)
+    if min_offset:
+        extracted = extracted + timedelta(minutes=min_offset)
+
+    leftover = " ".join(w for i, w in enumerate(words)
+                        if not consumed[i] and w != ".")
+    leftover = " ".join(leftover.split())
+    return [extracted, leftover]
+
+
+def _add_months(dt, months):
+    month = dt.month - 1 + months
+    year = dt.year + month // 12
+    month = month % 12 + 1
+    day = min(dt.day, [31, 29 if year % 4 == 0 and
+                       (year % 100 != 0 or year % 400 == 0) else 28,
+                       31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1])
+    return dt.replace(year=year, month=month, day=day)
+
+
+def _parse_clock_et(token):
+    if not token:
+        return None
+    for sep in (":", "."):
+        if sep in token:
+            parts = token.split(sep)
+            if len(parts) == 2 and parts[0].isdigit() and parts[1].isdigit():
+                hour, minute = int(parts[0]), int(parts[1])
+                if 0 <= hour <= 23 and 0 <= minute <= 59:
+                    return hour, minute
+            return None
+    return None
+
+
+def _ordinal_day_et(token):
+    stripped = token.rstrip(".")
+    if stripped.isdigit():
+        val = int(stripped)
+        if 1 <= val <= 31:
+            return val
+    from ovos_number_parser.numbers_et import is_ordinal_et
+    val = is_ordinal_et(stripped)
+    if val is not False and 1 <= val <= 31:
+        return val
+    return None

--- a/ovos_date_parser/duration.py
+++ b/ovos_date_parser/duration.py
@@ -701,3 +701,34 @@ register_duration_lexicon(DurationLexicon(
         "centuries": r"(?:vuosisata|vuosisataa|vuosisadan)",
         "millenniums": r"(?:vuosituhat|vuosituhatta|vuosituhannen)",
     }))
+
+
+def _normalize_et(text):
+    # numbers_to_digits already folds "pool" -> 0.5 and "poolteist" -> 1.5;
+    # collapse "N ja 0.5" ("kolm ja pool") into "N.5" so the whole quantity
+    # is read as a single fractional value
+    text = numbers_to_digits(text.lower(), "et")
+    return re.sub(r"(\d+)\s+ja\s+0[.,]5", r"\1.5", text)
+
+
+# Estonian nouns follow a numeral in the partitive singular ("kaks tundi");
+# the nominative ("tund") and partitive/genitive variants also occur.
+# Fractional numerals ("pool tundi" = 0.5 h, "poolteist tundi" = 1.5 h,
+# "kolm ja pool tundi" = 3.5 h) are handled by the numeral normalizer.
+register_duration_lexicon(DurationLexicon(
+    lang="et",
+    normalize=_normalize_et,
+    units={
+        "microseconds": r"mikrosekund(?:it|i)?",
+        "milliseconds": r"millisekund(?:it|i)?",
+        "seconds": r"sekund(?:it|i)?",
+        "minutes": r"minut(?:it|i)?",
+        "hours": r"(?:tundi|tunni|tund)",
+        "days": r"(?:päeva|päev|ööpäev(?:a)?)",
+        "weeks": r"(?:nädalat|nädala|nädal)",
+        "months": r"(?:kuud|kuu)",
+        "years": r"(?:aastat|aasta)",
+        "decades": r"(?:aastakümmet|aastakümne|aastakümmend)",
+        "centuries": r"(?:aastasada|aastasaja|sajand(?:it|i)?)",
+        "millenniums": r"(?:aastatuhat|aastatuhande|aastatuhat)",
+    }))

--- a/ovos_date_parser/res/et/date_time.json
+++ b/ovos_date_parser/res/et/date_time.json
@@ -1,0 +1,112 @@
+{
+  "decade_format": {
+    "default": "{number}"
+  },
+  "hundreds_format": {
+    "default": "{number}"
+  },
+  "thousand_format": {
+    "default": "{number}"
+  },
+  "year_format": {
+    "default": "{year} {bc}",
+    "bc": "enne Kristust"
+  },
+  "date_format": {
+    "date_full": "{weekday} {day} {month} {formatted_year}",
+    "date_full_no_year": "{weekday} {day} {month}",
+    "date_full_no_year_month": "{weekday} {day}",
+    "today": "täna",
+    "tomorrow": "homme",
+    "yesterday": "eile"
+  },
+  "date_time_format": {
+    "date_time": "{formatted_date} {formatted_time}"
+  },
+  "weekday": {
+    "0": "esmaspäev",
+    "1": "teisipäev",
+    "2": "kolmapäev",
+    "3": "neljapäev",
+    "4": "reede",
+    "5": "laupäev",
+    "6": "pühapäev"
+  },
+  "date": {
+    "1": "esimene",
+    "2": "teine",
+    "3": "kolmas",
+    "4": "neljas",
+    "5": "viies",
+    "6": "kuues",
+    "7": "seitsmes",
+    "8": "kaheksas",
+    "9": "üheksas",
+    "10": "kümnes",
+    "11": "üheteistkümnes",
+    "12": "kaheteistkümnes",
+    "13": "kolmeteistkümnes",
+    "14": "neljateistkümnes",
+    "15": "viieteistkümnes",
+    "16": "kuueteistkümnes",
+    "17": "seitsmeteistkümnes",
+    "18": "kaheksateistkümnes",
+    "19": "üheksateistkümnes",
+    "20": "kahekümnes",
+    "21": "kahekümne esimene",
+    "22": "kahekümne teine",
+    "23": "kahekümne kolmas",
+    "24": "kahekümne neljas",
+    "25": "kahekümne viies",
+    "26": "kahekümne kuues",
+    "27": "kahekümne seitsmes",
+    "28": "kahekümne kaheksas",
+    "29": "kahekümne üheksas",
+    "30": "kolmekümnes",
+    "31": "kolmekümne esimene"
+  },
+  "month": {
+    "1": "jaanuar",
+    "2": "veebruar",
+    "3": "märts",
+    "4": "aprill",
+    "5": "mai",
+    "6": "juuni",
+    "7": "juuli",
+    "8": "august",
+    "9": "september",
+    "10": "oktoober",
+    "11": "november",
+    "12": "detsember"
+  },
+  "number": {
+    "0": "null",
+    "1": "üks",
+    "2": "kaks",
+    "3": "kolm",
+    "4": "neli",
+    "5": "viis",
+    "6": "kuus",
+    "7": "seitse",
+    "8": "kaheksa",
+    "9": "üheksa",
+    "10": "kümme",
+    "20": "kakskümmend",
+    "30": "kolmkümmend",
+    "40": "nelikümmend",
+    "50": "viiskümmend",
+    "60": "kuuskümmend",
+    "70": "seitsekümmend",
+    "80": "kaheksakümmend",
+    "90": "üheksakümmend",
+    "11": "üksteist",
+    "12": "kaksteist",
+    "13": "kolmteist",
+    "14": "neliteist",
+    "15": "viisteist",
+    "16": "kuusteist",
+    "17": "seitseteist",
+    "18": "kaheksateist",
+    "19": "üheksateist"
+  }
+}

--- a/ovos_date_parser/res/et/date_words.json
+++ b/ovos_date_parser/res/et/date_words.json
@@ -1,0 +1,11 @@
+{
+  "second": "sekund",
+  "seconds": "sekundit",
+  "minute": "minut",
+  "minutes": "minutit",
+  "hour": "tund",
+  "hours": "tundi",
+  "day": "päev",
+  "days": "päeva",
+  "now": "nüüd"
+}

--- a/test/test_dates_et.py
+++ b/test/test_dates_et.py
@@ -1,0 +1,297 @@
+"""Estonian date/time tests: behaviour, adversarial input, round-trip sweep."""
+import unittest
+from datetime import datetime, timedelta
+
+from ovos_date_parser import (extract_datetime, extract_duration, nice_time,
+                              nice_duration, nice_weekday, nice_month,
+                              nice_year, nice_date)
+from ovos_date_parser.dates_et import extract_duration_et
+
+# Wednesday 10 January 2024, 12:00
+ANCHOR = datetime(2024, 1, 10, 12, 0)
+
+
+class TestNiceTimeEt(unittest.TestCase):
+    def test_24hour(self):
+        self.assertEqual(nice_time(datetime(2024, 1, 1, 15, 30), "et",
+                                   use_24hour=True),
+                         "kell viisteist kolmkümmend")
+        self.assertEqual(nice_time(datetime(2024, 1, 1, 9, 5), "et",
+                                   use_24hour=True),
+                         "kell üheksa null viis")
+        self.assertEqual(nice_time(datetime(2024, 1, 1, 14, 0), "et",
+                                   use_24hour=True),
+                         "kell neliteist")
+
+    def test_12hour(self):
+        self.assertEqual(nice_time(datetime(2024, 1, 1, 15, 30), "et"),
+                         "kell kolm kolmkümmend")
+
+    def test_special(self):
+        self.assertEqual(nice_time(datetime(2024, 1, 1, 0, 0), "et"),
+                         "kesköö")
+        self.assertEqual(nice_time(datetime(2024, 1, 1, 12, 0), "et"),
+                         "keskpäev")
+
+    def test_ampm_part_of_day(self):
+        self.assertTrue(nice_time(datetime(2024, 1, 1, 20, 0), "et",
+                                  use_ampm=True).endswith("õhtul"))
+        self.assertTrue(nice_time(datetime(2024, 1, 1, 8, 0), "et",
+                                  use_ampm=True).endswith("hommikul"))
+
+    def test_display(self):
+        self.assertEqual(nice_time(datetime(2024, 1, 1, 13, 4), "et",
+                                   speech=False, use_24hour=True), "13:04")
+
+
+class TestNiceDateFamilyEt(unittest.TestCase):
+    def test_weekday(self):
+        self.assertEqual(nice_weekday(ANCHOR, "et"), "Kolmapäev")
+
+    def test_month(self):
+        self.assertEqual(nice_month(ANCHOR, "et"), "Jaanuar")
+
+    def test_year_is_cardinal(self):
+        self.assertEqual(nice_year(datetime(1984, 1, 1), "et"),
+                         "tuhat üheksasada kaheksakümmend neli")
+
+    def test_year_bc(self):
+        self.assertTrue(nice_year(datetime(44, 1, 1), "et", bc=True)
+                        .endswith("enne Kristust"))
+
+    def test_nice_date_non_empty(self):
+        self.assertTrue(nice_date(ANCHOR, "et").strip())
+
+
+class TestExtractDatetimeEt(unittest.TestCase):
+    def test_relative_days(self):
+        self.assertEqual(extract_datetime("homme", "et", ANCHOR)[0].date(),
+                         datetime(2024, 1, 11).date())
+        self.assertEqual(extract_datetime("eile", "et", ANCHOR)[0].date(),
+                         datetime(2024, 1, 9).date())
+        self.assertEqual(extract_datetime("ülehomme", "et", ANCHOR)[0].date(),
+                         datetime(2024, 1, 12).date())
+
+    def test_weekday_adessive_and_next(self):
+        self.assertEqual(
+            extract_datetime("teisipäeval", "et", ANCHOR)[0].date(),
+            datetime(2024, 1, 16).date())
+        self.assertEqual(
+            extract_datetime("järgmine esmaspäev", "et", ANCHOR)[0].date(),
+            datetime(2024, 1, 15).date())
+        self.assertEqual(
+            extract_datetime("eelmine reede", "et", ANCHOR)[0].date(),
+            datetime(2024, 1, 5).date())
+
+    def test_clock(self):
+        dt, _ = extract_datetime("kell 15:30", "et", ANCHOR)
+        self.assertEqual((dt.hour, dt.minute), (15, 30))
+        dt, _ = extract_datetime("kell 9", "et", ANCHOR)
+        self.assertEqual((dt.hour, dt.minute), (9, 0))
+
+    def test_month_date(self):
+        self.assertEqual(
+            extract_datetime("15. jaanuar", "et", ANCHOR)[0].date(),
+            datetime(2024, 1, 15).date())
+
+    def test_relative_offset(self):
+        self.assertEqual(
+            extract_datetime("kolm päeva pärast", "et", ANCHOR)[0].date(),
+            datetime(2024, 1, 13).date())
+
+    def test_leftover(self):
+        dt, leftover = extract_datetime("kohtumine kell 9", "et", ANCHOR)
+        self.assertEqual(leftover, "kohtumine")
+
+
+class TestClockIdiomsEt(unittest.TestCase):
+    def _hm(self, text):
+        res = extract_datetime(text, "et", ANCHOR)
+        self.assertIsNotNone(res, text)
+        return res[0].hour, res[0].minute
+
+    def test_half_hour_is_before_named_hour(self):
+        # the classic trap: "pool kaks" is 1:30, NOT 2:30
+        self.assertEqual(self._hm("pool kaks"), (1, 30))
+        self.assertEqual(self._hm("pool kolm"), (2, 30))
+
+    def test_half_hour_wraps_at_one(self):
+        self.assertEqual(self._hm("pool üks"), (12, 30))
+
+    def test_quarter_into_hour(self):
+        # traditional Estonian counting toward the coming hour
+        self.assertEqual(self._hm("veerand kaks"), (1, 15))
+
+    def test_three_quarters_into_hour(self):
+        self.assertEqual(self._hm("kolmveerand kaks"), (1, 45))
+
+    def test_with_kell(self):
+        self.assertEqual(self._hm("kell pool kaks"), (1, 30))
+
+    def test_duration_pool_not_read_as_clock(self):
+        # "pool tundi" is a duration, not a half-clock -> no datetime
+        self.assertIsNone(extract_datetime("pool tundi", "et", ANCHOR))
+
+
+class TestFractionalDurationEt(unittest.TestCase):
+    def test_half_hour(self):
+        self.assertEqual(extract_duration("pool tundi", "et")[0],
+                         timedelta(minutes=30))
+
+    def test_one_and_a_half_hours(self):
+        self.assertEqual(extract_duration("poolteist tundi", "et")[0],
+                         timedelta(hours=1, minutes=30))
+
+    def test_n_and_a_half_hours(self):
+        self.assertEqual(extract_duration("kolm ja pool tundi", "et")[0],
+                         timedelta(hours=3, minutes=30))
+
+
+class TestExtractDatetimeAdversarialEt(unittest.TestCase):
+    def test_empty(self):
+        self.assertIsNone(extract_datetime("", "et", ANCHOR))
+
+    def test_none(self):
+        self.assertIsNone(extract_datetime(None, "et", ANCHOR))
+
+    def test_no_date(self):
+        self.assertIsNone(extract_datetime("tere kuidas läheb", "et", ANCHOR))
+
+    def test_punctuation_only(self):
+        self.assertIsNone(extract_datetime("?!.,", "et", ANCHOR))
+
+    def test_invalid_clock_not_time(self):
+        self.assertIsNone(extract_datetime("kell 25:99", "et", ANCHOR))
+
+    def test_out_of_range_ordinal_day_ignored(self):
+        res = extract_datetime("45. jaanuar", "et", ANCHOR)
+        self.assertIsNotNone(res)
+        self.assertEqual(res[0].month, 1)
+
+    def test_garbage_tokens(self):
+        self.assertIsNone(extract_datetime("xyzzy qwerty 12345abc", "et",
+                                           ANCHOR))
+
+
+class TestExtractDurationAdversarialEt(unittest.TestCase):
+    def test_empty(self):
+        self.assertIsNone(extract_duration("", "et"))
+
+    def test_no_duration(self):
+        dur, _ = extract_duration("siin pole midagi", "et")
+        self.assertIsNone(dur)
+
+    def test_unit_without_number(self):
+        dur, _ = extract_duration("tundi", "et")
+        self.assertIsNone(dur)
+
+    def test_number_without_unit(self):
+        dur, _ = extract_duration("viis", "et")
+        self.assertIsNone(dur)
+
+    def test_direct_function_matches_dispatch(self):
+        self.assertEqual(extract_duration_et("kaks tundi")[0],
+                         timedelta(hours=2))
+
+
+class TestRealSentencesEt(unittest.TestCase):
+    """Full natural sentences, not word<->value anchors.
+
+    Every expected value is derived by hand from the anchor (Wednesday
+    10 January 2024, 12:00) and Estonian reference usage, never copied from
+    parser output. Each case also checks the surrounding words survive as
+    leftover text.
+    """
+
+    # (sentence, expected (Y, M, D, h, m), expected leftover)
+    CASES = [
+        # idiomatic clock (traditional counting toward the coming hour)
+        ("Ärata mind veerand kaheksa", (2024, 1, 10, 7, 15), "ärata mind"),
+        ("kohtume pool kolm", (2024, 1, 10, 2, 30), "kohtume"),
+        ("näeme homme pool kaks", (2024, 1, 11, 1, 30), "näeme"),
+        ("äratus kolmveerand kaheksa", (2024, 1, 10, 7, 45), "äratus"),
+        # relative time offsets with the genitive numeral
+        ("tuleta mulle meelde kolme tunni pärast",
+         (2024, 1, 10, 15, 0), "tuleta mulle meelde"),
+        ("meeldetuletus viie minuti pärast",
+         (2024, 1, 10, 12, 5), "meeldetuletus"),
+        ("ärka poole tunni pärast", (2024, 1, 10, 12, 30), "ärka"),
+        ("helista pooleteist tunni pärast",
+         (2024, 1, 10, 13, 30), "helista"),
+        # relative day/week offsets
+        ("helista mulle kolme päeva pärast",
+         (2024, 1, 13, 0, 0), "helista mulle"),
+        ("kohtumine kahe nädala pärast", (2024, 1, 24, 0, 0), "kohtumine"),
+        # weekdays, nominative and adessive, with järgmine/eelmine
+        ("kohtumine on järgmisel esmaspäeval kell 15:30",
+         (2024, 1, 15, 15, 30), "kohtumine on"),
+        ("broneeri aeg reedel", (2024, 1, 12, 0, 0), "broneeri aeg"),
+        ("käisin eelmisel reedel", (2024, 1, 5, 0, 0), "käisin"),
+        # relative days
+        ("näeme homme", (2024, 1, 11, 0, 0), "näeme"),
+        ("tulin eile koju", (2024, 1, 9, 0, 0), "tulin koju"),
+        # calendar date with month name
+        ("lähen 15. jaanuaril", (2024, 1, 15, 0, 0), "lähen"),
+        # plain clock in a sentence, with trailing punctuation
+        ("äratus kell 7.", (2024, 1, 10, 7, 0), "äratus"),
+        ("rong väljub 15:30", (2024, 1, 10, 15, 30), "rong väljub"),
+    ]
+
+    def test_sentences(self):
+        for text, exp, leftover in self.CASES:
+            res = extract_datetime(text, "et", ANCHOR)
+            self.assertIsNotNone(res, text)
+            got = (res[0].year, res[0].month, res[0].day,
+                   res[0].hour, res[0].minute)
+            self.assertEqual(got, exp, text)
+            self.assertEqual(res[1], leftover, text)
+
+
+class TestRealSentenceDurationsEt(unittest.TestCase):
+    """Durations inside natural sentences, expectations derived by hand."""
+
+    CASES = [
+        ("sea taimer kaks tundi", 2 * 3600),
+        ("puhka pool tundi", 30 * 60),
+        ("kestus on poolteist tundi", 90 * 60),
+        ("jookse kolm ja pool tundi", int(3.5 * 3600)),
+        ("oota viisteist minutit", 15 * 60),
+        ("maga kaheksa tundi", 8 * 3600),
+        ("kolmkümmend minutit", 30 * 60),
+    ]
+
+    def test_sentences(self):
+        for text, secs in self.CASES:
+            dur, rem = extract_duration(text, "et")
+            self.assertIsNotNone(dur, text)
+            self.assertEqual(int(dur.total_seconds()), secs, text)
+
+
+class TestDurationRoundTripEt(unittest.TestCase):
+    """Sweep: nice_duration(seconds) -> extract_duration -> identity."""
+
+    def _values(self):
+        vals = set()
+        vals.update(range(1, 141))
+        vals.update(m * 60 for m in range(1, 61))
+        for h in range(1, 13):
+            vals.add(h * 3600)
+            vals.add(h * 3600 + 30 * 60)
+            vals.add(h * 3600 + 90)
+        for d in range(1, 15):
+            vals.add(d * 86400 + 3600 + 60 + 1)
+        return sorted(vals)
+
+    def test_round_trip(self):
+        values = self._values()
+        self.assertGreaterEqual(len(values), 200)
+        for secs in values:
+            spoken = nice_duration(secs, "et")
+            dur, _ = extract_duration(spoken, "et")
+            self.assertIsNotNone(dur, f"{secs}: {spoken!r}")
+            self.assertEqual(int(dur.total_seconds()), secs,
+                             f"{secs}: {spoken!r} -> {dur}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds date and time support for Estonian (`et`), wired into every relevant public dispatch entry point in `ovos_date_parser`. One language per PR (Finnish is a separate PR).

## Approach
Estonian is agglutinative and case-rich: numerals below a hundred that are not round agglutinate (`kakskümmend` = 20) and the noun after a numeral greater than one takes the partitive singular (`kaks tundi`). Number pronunciation/extraction reuse the already-verified `ovos-number-parser` engine. Estonian is implemented explicitly with its own forms, never aliased to Finnish.

## Provided
- `nice_time` — spoken clock with the `kell` marker, `kesköö`/`keskpäev`, part-of-day adverbs.
- Idiomatic spoken clock in `extract_datetime`, traditional EKI counting toward the coming hour: `pool kaks` = 1:30 (not 2:30), `veerand kaks` = 1:15, `kolmveerand kaks` = 1:45.
- `nice_year` read as a whole cardinal (Estonian reads years as cardinals).
- `nice_weekday`, `nice_month`, `nice_date`, `nice_date_time`, `nice_relative_time` via the shared resource engine (`res/et`).
- `extract_duration` on the shared unit-lexicon engine, tolerating nominative/partitive unit forms and fractional numerals: `pool tundi` = 30 min, `poolteist tundi` = 90 min, `kolm ja pool tundi` = 3.5 h.
- `extract_datetime` for relative days, weekday names (adessive) with `järgmine`/`eelmine`, `N <unit> pärast`, clock times and month-name dates.

## Scope
The competing modern `veerand üle`/`üle`-past forms use a genitive hour the verified number parser does not resolve, and contradict the traditional `veerand kaks` = 1:15 reading; omitted to avoid ambiguity (null beats wrong). A duration (`pool tundi`) is never misread as a half-clock.

## Tests
`test/test_dates_et.py`: per-function behaviour, adversarial cases (empty/`None`/garbage/punctuation/invalid clock `25:99`/out-of-range ordinal day), the half-clock trap, fractional durations, and a 200+ value duration round-trip sweep. `et` added to the `test_lang_parity.py` guard.

Full suite: 467 passed, 2 skipped (the single `test_packaging` failure is a pre-existing environment version-metadata mismatch, unrelated to this change).

## Sources
Eesti Keele Instituut (EKI), Eesti keele käsiraamat — arvsõnad, kellaaja/kuupäeva usage.