### PR TITLE
feat: Turkish date formatting and parsing

### DIFF
--- a/ovos_date_parser/__init__.py
+++ b/ovos_date_parser/__init__.py
@@ -102,6 +102,7 @@ from ovos_date_parser.dates_sv import (
 from ovos_date_parser.dates_uk import (
     extract_datetime_uk, extract_duration_uk, nice_time_uk, nice_duration_uk
 )
+from ovos_date_parser.dates_tr import nice_time_tr, extract_datetime_tr
 
 
 def nice_time(
@@ -176,6 +177,8 @@ def nice_time(
         return nice_time_sl(dt, speech, use_24hour, use_ampm)
     if lang.startswith("uk"):
         return nice_time_uk(dt, speech, use_24hour, use_ampm)
+    if lang.startswith("tr"):
+        return nice_time_tr(dt, speech, use_24hour, use_ampm)
     raise NotImplementedError(f"Unsupported language: {lang}")
 
 
@@ -336,6 +339,8 @@ def extract_datetime(
         return extract_datetime_sv(text, anchorDate=anchorDate, default_time=default_time)
     if lang.startswith("uk"):
         return extract_datetime_uk(text, anchor_date=anchorDate, default_time=default_time)
+    if lang.startswith("tr"):
+        return extract_datetime_tr(text, anchorDate=anchorDate, default_time=default_time)
 
     # fallback parser
     LOG.warning(f"{lang} is not implemented! attempting to use fallback date parser")

--- a/ovos_date_parser/dates_tr.py
+++ b/ovos_date_parser/dates_tr.py
@@ -1,0 +1,305 @@
+# Copyright OpenVoiceOS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Turkish (``tr``) date and time tools.
+
+Turkish reads clock times as "saat <hour> <minute>" (literally "hour
+<h> <m>"), the form used in broadcast and announcement speech. The
+idiomatic case-marked forms ("üçü on geçiyor" = "ten past three")
+require the accusative/ablative declension of the numeral and are left
+out rather than approximated.
+
+Weekday and month names use standard orthography. Turkish nouns stay
+singular after a numeral (iki saat = "two hour"), so the duration units
+are the bare stems; "decade" is the phrase "on yıl" ("ten years"), not
+a single word, and is omitted.
+"""
+import re
+from datetime import datetime, timedelta
+
+from dateutil.relativedelta import relativedelta
+from ovos_number_parser import pronounce_number, numbers_to_digits
+
+from ovos_date_parser.duration import DurationLexicon, register_duration_lexicon
+
+register_duration_lexicon(DurationLexicon(
+    lang="tr",
+    units={
+        "microseconds": r"mikrosaniye",
+        "milliseconds": r"milisaniye",
+        "seconds": r"saniye",
+        "minutes": r"dakika",
+        "hours": r"saat",
+        "days": r"gün",
+        "weeks": r"hafta",
+        "months": r"ay",
+        "years": r"yıl|sene",
+        "centuries": r"yüzyıl|asır",
+        "millenniums": r"binyıl|milenyum",
+    }))
+
+WEEKDAYS_TR = {"pazartesi": 0, "salı": 1, "çarşamba": 2, "perşembe": 3,
+               "cuma": 4, "cumartesi": 5, "pazar": 6}
+MONTHS_TR = {"ocak": 1, "şubat": 2, "mart": 3, "nisan": 4, "mayıs": 5,
+             "haziran": 6, "temmuz": 7, "ağustos": 8, "eylül": 9,
+             "ekim": 10, "kasım": 11, "aralık": 12}
+
+_RELATIVE_DAYS_TR = {"bugün": 0, "yarın": 1, "dün": -1, "öbür gün": 2,
+                     "evvelki gün": -2, "önceki gün": -2}
+_OFFSET_UNITS_TR = {"saniye": "seconds", "dakika": "minutes", "saat": "hours",
+                    "gün": "days", "hafta": "weeks", "ay": "months",
+                    "yıl": "years", "sene": "years"}
+_PERIOD_NOUNS_TR = {"hafta": "week", "ay": "month", "yıl": "year",
+                    "sene": "year"}
+_NEXT_TR = {"gelecek", "önümüzdeki"}
+_LAST_TR = {"geçen", "geçtiğimiz"}
+_AGO_TR = {"önce"}
+_FUTURE_TR = {"sonra"}
+_CLOCK_PREFIX_TR = {"saat"}
+
+_TIME_UNIT_SECONDS = {"seconds": 1, "minutes": 60, "hours": 3600}
+
+
+def _apply_offset(result, unit, value, backward):
+    """Shift ``result`` by ``value`` of ``unit``; return (dt, is_time)."""
+    sign = -1 if backward else 1
+    if unit in _TIME_UNIT_SECONDS:
+        return result + timedelta(
+            seconds=sign * value * _TIME_UNIT_SECONDS[unit]), True
+    if unit == "days":
+        return result + timedelta(days=sign * value), False
+    if unit == "weeks":
+        return result + timedelta(weeks=sign * value), False
+    if unit == "months":
+        return result + relativedelta(months=sign * value), False
+    return result + relativedelta(years=sign * value), False
+
+
+def _weekday_delta(cur, target, backward):
+    if backward:
+        return -((cur - target) % 7 or 7)
+    return (target - cur) % 7 or 7
+
+
+def extract_datetime_tr(text, anchorDate=None, default_time=None):
+    """Extract a datetime from Turkish text.
+
+    Understands the relative day words (bugün, yarın, dün, öbür gün),
+    weekday and month names with optional gelecek/geçen (next/last),
+    "<n> <birim> önce/sonra" offsets and clock times ("saat 3", "15:30").
+    Returns the resolved datetime and the leftover text, or ``None`` when
+    nothing date/time related is found.
+    """
+    if not text:
+        return None
+    anchor = anchorDate or datetime.now()
+    # Turkish dotted/dotless casing: I->ı and İ->i before lowercasing
+    text = text.replace("İ", "i").replace("I", "ı").lower()
+    # fold spelled numbers to digits; drop surrounding punctuation, a
+    # number's apostrophe suffix (locative "saat 3'te") and the trailing
+    # ".0" the number parser can leave on an integer fused with a stop
+    tokens = [re.sub(r"^(\d+)\.0$", r"\1",
+                     re.sub(r"(?<=\d)'\w*$", "", t.strip(".,!?;:")))
+              for t in numbers_to_digits(text, "tr").split()]
+    n = len(tokens)
+    result = anchor
+    consumed = set()
+    date_found = False
+    time_found = False
+
+    def free(i):
+        return 0 <= i < n and i not in consumed
+
+    # 1. "<n> <unit> önce/sonra"
+    for i in range(n):
+        if not (free(i) and re.fullmatch(r"\d+", tokens[i]) and free(i + 1)):
+            continue
+        unit = _OFFSET_UNITS_TR.get(tokens[i + 1])
+        if not unit:
+            continue
+        backward, dir_idx = None, None
+        for j in (i + 2, i + 3):
+            if free(j) and tokens[j] in _AGO_TR:
+                backward, dir_idx = True, j
+                break
+            if free(j) and tokens[j] in _FUTURE_TR:
+                backward, dir_idx = False, j
+                break
+        if backward is None:
+            continue
+        result, is_time = _apply_offset(result, unit, int(tokens[i]), backward)
+        date_found = True
+        time_found = time_found or is_time
+        consumed.update({i, i + 1, dir_idx})
+
+    # 2. next/last <weekday|period>
+    for i in range(n):
+        if i in consumed or tokens[i] not in (_NEXT_TR | _LAST_TR):
+            continue
+        backward = tokens[i] in _LAST_TR
+        for j in (i + 1, i - 1):
+            if not free(j):
+                continue
+            if tokens[j] in _PERIOD_NOUNS_TR:
+                unit = {"week": "weeks", "month": "months",
+                        "year": "years"}[_PERIOD_NOUNS_TR[tokens[j]]]
+                result, _ = _apply_offset(result, unit, 1, backward)
+                date_found = True
+                consumed.update({i, j})
+                break
+            if tokens[j] in WEEKDAYS_TR:
+                result += timedelta(days=_weekday_delta(
+                    anchor.weekday(), WEEKDAYS_TR[tokens[j]], backward))
+                date_found = True
+                consumed.update({i, j})
+                break
+
+    # 3. relative day words (longest phrase first)
+    for phrase in sorted(_RELATIVE_DAYS_TR, key=lambda p: -len(p.split())):
+        parts = phrase.split()
+        w = len(parts)
+        for i in range(n - w + 1):
+            if any((i + k) in consumed for k in range(w)):
+                continue
+            if tokens[i:i + w] == parts:
+                result = anchor + timedelta(days=_RELATIVE_DAYS_TR[phrase])
+                date_found = True
+                consumed.update(range(i, i + w))
+
+    # 4. bare weekday -> next occurrence
+    for i in range(n):
+        if free(i) and tokens[i] in WEEKDAYS_TR:
+            result += timedelta(days=_weekday_delta(
+                anchor.weekday(), WEEKDAYS_TR[tokens[i]], False))
+            date_found = True
+            consumed.add(i)
+
+    # 5. month-name date: <day>? <month> <year>?
+    for i in range(n):
+        if i in consumed or tokens[i] not in MONTHS_TR:
+            continue
+        month = MONTHS_TR[tokens[i]]
+        day = year = None
+        for j in (i - 1, i + 1):
+            if day is None and free(j) and re.fullmatch(r"\d{1,2}", tokens[j]) \
+                    and 1 <= int(tokens[j]) <= 31:
+                day = int(tokens[j])
+                consumed.add(j)
+        for j in (i + 1, i + 2):
+            if free(j) and re.fullmatch(r"\d{4}", tokens[j]):
+                year = int(tokens[j])
+                consumed.add(j)
+                break
+        if year is None:
+            year = anchor.year
+            if datetime(year, month, day or 1).date() < anchor.date():
+                year += 1
+        result = result.replace(year=year, month=month, day=day or 1)
+        date_found = True
+        consumed.add(i)
+
+    # 6. clock times: HH:MM, or "saat <hour>"
+    for i in range(n):
+        if i in consumed:
+            continue
+        m = re.fullmatch(r"(\d{1,2}):(\d{2})", tokens[i])
+        if m and int(m.group(1)) < 24 and int(m.group(2)) < 60:
+            result = result.replace(hour=int(m.group(1)),
+                                    minute=int(m.group(2)), second=0,
+                                    microsecond=0)
+            time_found = True
+            consumed.add(i)
+            continue
+        if tokens[i] in _CLOCK_PREFIX_TR and free(i + 1):
+            hm = re.fullmatch(r"(\d{1,2})(?::(\d{2}))?", tokens[i + 1])
+            if hm and int(hm.group(1)) < 24:
+                minute = int(hm.group(2)) if hm.group(2) else 0
+                if minute < 60:
+                    result = result.replace(hour=int(hm.group(1)),
+                                            minute=minute, second=0,
+                                            microsecond=0)
+                    time_found = True
+                    consumed.update({i, i + 1})
+
+    if not date_found and not time_found:
+        return None
+    if not time_found:
+        if default_time:
+            result = result.replace(hour=default_time.hour,
+                                    minute=default_time.minute,
+                                    second=default_time.second, microsecond=0)
+        else:
+            result = result.replace(hour=0, minute=0, second=0, microsecond=0)
+    remainder = " ".join(t for idx, t in enumerate(tokens)
+                         if idx not in consumed)
+    return result, remainder.strip()
+
+
+def _period_tr(hour):
+    if hour < 6:
+        return "gece"
+    if hour < 12:
+        return "sabah"
+    if hour < 18:
+        return "öğleden sonra"
+    if hour < 22:
+        return "akşam"
+    return "gece"
+
+
+def nice_time_tr(dt, speech=True, use_24hour=False, use_ampm=False):
+    """Format a time to a comfortable Turkish human format.
+
+    Args:
+        dt (datetime): date to format (assumes already in local timezone)
+        speech (bool): format for speech (True) or display (False)
+        use_24hour (bool): output in 24-hour or 12-hour format
+        use_ampm (bool): append the part of day for 12-hour format
+    Returns:
+        (str): The formatted time string
+    """
+    if use_24hour:
+        string = dt.strftime("%H:%M")
+    else:
+        if use_ampm:
+            string = dt.strftime("%I:%M %p")
+        else:
+            string = dt.strftime("%I:%M")
+
+    if not speech:
+        return string
+
+    if use_24hour:
+        speak = "saat " + pronounce_number(dt.hour, lang="tr")
+        if dt.minute:
+            if dt.minute < 10:
+                speak += " sıfır"
+            speak += " " + pronounce_number(dt.minute, lang="tr")
+        return speak
+
+    if dt.hour == 0 and dt.minute == 0:
+        return "gece yarısı"
+    if dt.hour == 12 and dt.minute == 0:
+        return "öğle"
+
+    hour = dt.hour % 12
+    if hour == 0:
+        hour = 12
+    speak = "saat " + pronounce_number(hour, lang="tr")
+    if dt.minute:
+        if dt.minute < 10:
+            speak += " sıfır"
+        speak += " " + pronounce_number(dt.minute, lang="tr")
+    if use_ampm:
+        speak += " " + _period_tr(dt.hour)
+    return speak

--- a/ovos_date_parser/res/tr/date_words.json
+++ b/ovos_date_parser/res/tr/date_words.json
@@ -1,10 +1,11 @@
 {
-  "seconds": "saniyeler",
-  "hour": "saat",
+  "now": "şimdi",
+  "second": "saniye",
+  "seconds": "saniye",
   "minute": "dakika",
-  "days": "günler",
+  "minutes": "dakika",
+  "hour": "saat",
+  "hours": "saat",
   "day": "gün",
-  "minutes": "dakikalar",
-  "hours": "saatler",
-  "second": "saniye"
+  "days": "gün"
 }

--- a/test/test_dates_tr.py
+++ b/test/test_dates_tr.py
@@ -1,0 +1,301 @@
+import unittest
+from datetime import datetime, time, timedelta
+
+from dateutil.relativedelta import relativedelta
+
+from ovos_date_parser import (nice_time, nice_duration, extract_duration,
+                              nice_relative_time, extract_datetime)
+from ovos_date_parser.duration import DurationResolution
+
+# a fixed Wednesday noon anchor
+ANCHOR = datetime(2026, 7, 15, 12, 0)
+
+
+class TestNiceTimeTr(unittest.TestCase):
+    def test_display(self):
+        dt = datetime(2026, 7, 17, 13, 4)
+        self.assertEqual(nice_time(dt, "tr", speech=False, use_24hour=True),
+                         "13:04")
+        self.assertEqual(nice_time(dt, "tr", speech=False), "01:04")
+
+    def test_24hour(self):
+        self.assertEqual(
+            nice_time(datetime(2026, 7, 17, 14, 0), "tr", use_24hour=True),
+            "saat on dört")
+        # sub-ten minute gets the explicit zero to stay unambiguous
+        self.assertEqual(
+            nice_time(datetime(2026, 7, 17, 14, 5), "tr", use_24hour=True),
+            "saat on dört sıfır beş")
+        self.assertEqual(
+            nice_time(datetime(2026, 7, 17, 9, 30), "tr", use_24hour=True),
+            "saat dokuz otuz")
+
+    def test_12hour(self):
+        self.assertEqual(nice_time(datetime(2026, 7, 17, 15, 0), "tr"),
+                         "saat üç")
+        self.assertEqual(nice_time(datetime(2026, 7, 17, 15, 15), "tr"),
+                         "saat üç on beş")
+
+    def test_midnight_noon(self):
+        self.assertEqual(nice_time(datetime(2026, 7, 17, 0, 0), "tr"),
+                         "gece yarısı")
+        self.assertEqual(nice_time(datetime(2026, 7, 17, 12, 0), "tr"),
+                         "öğle")
+
+    def test_ampm_period(self):
+        self.assertTrue(
+            nice_time(datetime(2026, 7, 17, 15, 0), "tr",
+                      use_ampm=True).endswith("öğleden sonra"))
+        self.assertTrue(
+            nice_time(datetime(2026, 7, 17, 8, 0), "tr",
+                      use_ampm=True).endswith("sabah"))
+
+
+class TestDurationTr(unittest.TestCase):
+    def test_nice_duration(self):
+        self.assertEqual(nice_duration(3720, "tr"), "bir saat iki dakika")
+        self.assertEqual(nice_duration(1, "tr"), "bir saniye")
+        self.assertEqual(nice_duration(90061, "tr"),
+                         "bir gün  bir saat bir dakika bir saniye")
+
+    def test_extract_units(self):
+        self.assertEqual(
+            extract_duration("iki saat otuz dakika sonra", "tr"),
+            (timedelta(hours=2, minutes=30), "sonra"))
+        self.assertEqual(
+            extract_duration("on beş dakika", "tr"),
+            (timedelta(minutes=15), ""))
+        self.assertEqual(
+            extract_duration("üç yıl iki ay", "tr",
+                             resolution=DurationResolution.RELATIVEDELTA),
+            (relativedelta(years=3, months=2), ""))
+        # "sene" is an accepted synonym for "yıl" (year)
+        self.assertEqual(
+            extract_duration("bir sene", "tr",
+                             resolution=DurationResolution.RELATIVEDELTA),
+            (relativedelta(years=1), ""))
+
+    def test_relative_time(self):
+        anchor = datetime(2026, 7, 17, 14, 0, 0)
+        self.assertEqual(
+            nice_relative_time(anchor + timedelta(seconds=45), anchor, "tr"),
+            "kırk beş saniye")
+
+    def test_roundtrip_sweep(self):
+        vals = list(range(1, 240)) + [3599, 3600, 3661, 86399, 86400, 90061]
+        for s in vals:
+            spoken = nice_duration(s, "tr")
+            dur, _ = extract_duration(spoken, "tr")
+            self.assertEqual(int(dur.total_seconds()), s,
+                             f"roundtrip {s} via {spoken!r}")
+
+
+class TestAdversarialTr(unittest.TestCase):
+    def test_empty(self):
+        self.assertIsNone(extract_duration("", "tr"))
+
+    def test_no_duration(self):
+        self.assertEqual(extract_duration("merhaba dünya", "tr"),
+                         (None, "merhaba dünya"))
+
+    def test_bare_unit_without_number(self):
+        # a unit word with no numeral must not be consumed
+        self.assertEqual(extract_duration("saat", "tr"), (None, "saat"))
+
+    def test_number_without_unit(self):
+        self.assertEqual(extract_duration("beş", "tr"), (None, "5"))
+
+    def test_weekday_not_month(self):
+        # "ay" is month; without a preceding numeral nothing matches
+        self.assertEqual(extract_duration("bu ay", "tr"), (None, "bu ay"))
+
+    def test_zero(self):
+        dur, _ = extract_duration("sıfır dakika", "tr")
+        self.assertEqual(dur, timedelta(0))
+
+
+class TestExtractDatetimeTr(unittest.TestCase):
+    def _dt(self, text, **kw):
+        return extract_datetime(text, "tr", anchorDate=ANCHOR, **kw)
+
+    def test_relative_days(self):
+        self.assertEqual(self._dt("yarın")[0], datetime(2026, 7, 16, 0, 0))
+        self.assertEqual(self._dt("dün")[0], datetime(2026, 7, 14, 0, 0))
+        self.assertEqual(self._dt("bugün")[0], datetime(2026, 7, 15, 0, 0))
+        self.assertEqual(self._dt("öbür gün")[0], datetime(2026, 7, 17, 0, 0))
+
+    def test_weekday_next_last(self):
+        self.assertEqual(self._dt("gelecek salı")[0],
+                         datetime(2026, 7, 21, 0, 0))
+        self.assertEqual(self._dt("geçen cuma")[0],
+                         datetime(2026, 7, 10, 0, 0))
+        # bare weekday resolves to the next occurrence
+        self.assertEqual(self._dt("pazartesi")[0],
+                         datetime(2026, 7, 20, 0, 0))
+
+    def test_offsets(self):
+        self.assertEqual(self._dt("üç gün önce")[0],
+                         datetime(2026, 7, 12, 0, 0))
+        self.assertEqual(self._dt("iki saat sonra")[0],
+                         datetime(2026, 7, 15, 14, 0))
+        self.assertEqual(self._dt("gelecek hafta")[0],
+                         datetime(2026, 7, 22, 0, 0))
+
+    def test_clock(self):
+        self.assertEqual(self._dt("saat 3")[0], datetime(2026, 7, 15, 3, 0))
+        self.assertEqual(self._dt("saat üç")[0], datetime(2026, 7, 15, 3, 0))
+        self.assertEqual(self._dt("15:30")[0], datetime(2026, 7, 15, 15, 30))
+
+    def test_month_date(self):
+        self.assertEqual(self._dt("26 temmuz 2026")[0],
+                         datetime(2026, 7, 26, 0, 0))
+
+    def test_combined_and_remainder(self):
+        dt, rem = self._dt("bana üç saat sonra hatırlat")
+        self.assertEqual(dt, datetime(2026, 7, 15, 15, 0))
+        self.assertEqual(rem, "bana hatırlat")
+        self.assertEqual(self._dt("yarın saat 3")[0],
+                         datetime(2026, 7, 16, 3, 0))
+
+    def test_default_time(self):
+        self.assertEqual(self._dt("yarın", default_time=time(8, 30))[0],
+                         datetime(2026, 7, 16, 8, 30))
+
+
+class TestExtractDatetimeAdversarialTr(unittest.TestCase):
+    def test_empty(self):
+        self.assertIsNone(extract_datetime("", "tr", anchorDate=ANCHOR))
+
+    def test_no_datetime(self):
+        self.assertIsNone(
+            extract_datetime("merhaba dünya", "tr", anchorDate=ANCHOR))
+
+    def test_number_without_unit(self):
+        self.assertIsNone(extract_datetime("beş", "tr", anchorDate=ANCHOR))
+
+    def test_offset_without_direction(self):
+        # "üç gün" alone is a bare span, not a datetime; needs önce/sonra
+        self.assertIsNone(extract_datetime("üç gün", "tr", anchorDate=ANCHOR))
+
+    def test_impossible_clock(self):
+        # 25:00 is not a valid clock time and must be ignored
+        self.assertIsNone(extract_datetime("25:00", "tr", anchorDate=ANCHOR))
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestRealSentencesTr(unittest.TestCase):
+    """Natural Turkish sentences a user actually speaks/writes."""
+
+    def _dt(self, text, **kw):
+        return extract_datetime(text, "tr", anchorDate=ANCHOR, **kw)
+
+    def test_relative_day_sentences(self):
+        self.assertEqual(self._dt("Toplantı yarın."),
+                         (datetime(2026, 7, 16, 0, 0), "toplantı"))
+        self.assertEqual(self._dt("Dün akşam geldim.")[0],
+                         datetime(2026, 7, 14, 0, 0))
+        self.assertEqual(self._dt("Öbür gün tatil.")[0],
+                         datetime(2026, 7, 17, 0, 0))
+        self.assertEqual(self._dt("Önceki gün aramıştı.")[0],
+                         datetime(2026, 7, 13, 0, 0))
+        self.assertEqual(self._dt("Bugün işe gitmedim.")[0],
+                         datetime(2026, 7, 15, 0, 0))
+
+    def test_offset_sentences(self):
+        self.assertEqual(self._dt("Beni iki saat sonra uyandır."),
+                         (datetime(2026, 7, 15, 14, 0), "beni uyandır"))
+        self.assertEqual(self._dt("Üç gün önce geldi."),
+                         (datetime(2026, 7, 12, 0, 0), "geldi"))
+        self.assertEqual(self._dt("On beş dakika sonra çıkıyoruz.")[0],
+                         datetime(2026, 7, 15, 12, 15))
+        # a whole-day-or-larger offset resolves to midnight of that day
+        self.assertEqual(self._dt("Bir hafta sonra sınav var.")[0],
+                         datetime(2026, 7, 22, 0, 0))
+
+    def test_weekday_sentences(self):
+        self.assertEqual(self._dt("Gelecek salı görüşürüz."),
+                         (datetime(2026, 7, 21, 0, 0), "görüşürüz"))
+        self.assertEqual(self._dt("Geçen cuma oradaydım."),
+                         (datetime(2026, 7, 10, 0, 0), "oradaydım"))
+        self.assertEqual(self._dt("Geçen pazartesi başladı.")[0],
+                         datetime(2026, 7, 13, 0, 0))
+        self.assertEqual(self._dt("Pazartesi spora gidiyorum."),
+                         (datetime(2026, 7, 20, 0, 0), "spora gidiyorum"))
+
+    def test_period_sentences(self):
+        self.assertEqual(self._dt("Gelecek hafta tatildeyim."),
+                         (datetime(2026, 7, 22, 0, 0), "tatildeyim"))
+        self.assertEqual(self._dt("Geçen ay taşındık.")[0],
+                         datetime(2026, 6, 15, 0, 0))
+        self.assertEqual(self._dt("Gelecek yıl mezun oluyorum.")[0],
+                         datetime(2027, 7, 15, 0, 0))
+
+    def test_clock_sentences(self):
+        # Turkish written locative suffix on the hour
+        self.assertEqual(self._dt("Alarmı saat 7'ye kur."),
+                         (datetime(2026, 7, 15, 7, 0), "alarmı kur"))
+        self.assertEqual(self._dt("Randevu 15:30'da."),
+                         (datetime(2026, 7, 15, 15, 30), "randevu"))
+        self.assertEqual(self._dt("Bugün saat 23:59")[0],
+                         datetime(2026, 7, 15, 23, 59))
+        # spelled-out clock hour
+        self.assertEqual(self._dt("Saat üç buluşalım.")[0],
+                         datetime(2026, 7, 15, 3, 0))
+
+    def test_month_date_sentences(self):
+        self.assertEqual(self._dt("Doğum günüm 26 Temmuz 2026."),
+                         (datetime(2026, 7, 26, 0, 0), "doğum günüm"))
+        # a past month rolls to next year
+        self.assertEqual(self._dt("5 Nisan")[0], datetime(2027, 4, 5, 0, 0))
+
+    def test_combined_date_and_time(self):
+        self.assertEqual(self._dt("Yarın saat 9'da toplantı var.")[0],
+                         datetime(2026, 7, 16, 9, 0))
+
+
+class TestRealSentenceEdgesTr(unittest.TestCase):
+    def test_none_input(self):
+        self.assertIsNone(extract_datetime(None, "tr", anchorDate=ANCHOR))
+
+    def test_whitespace_only(self):
+        self.assertIsNone(extract_datetime("   ", "tr", anchorDate=ANCHOR))
+
+    def test_leading_trailing_junk(self):
+        self.assertEqual(
+            extract_datetime("!!! yarın !!!", "tr", anchorDate=ANCHOR)[0],
+            datetime(2026, 7, 16, 0, 0))
+
+    def test_mixed_case_with_dotless_i(self):
+        # "YARIN" must lowercase to "yarın" (dotless), not "yarin"
+        self.assertEqual(
+            extract_datetime("YARIN Saat 3", "tr", anchorDate=ANCHOR)[0],
+            datetime(2026, 7, 16, 3, 0))
+
+    def test_language_code_variant(self):
+        self.assertEqual(
+            extract_datetime("yarın", "tr-TR", anchorDate=ANCHOR)[0],
+            datetime(2026, 7, 16, 0, 0))
+
+    def test_leap_day(self):
+        self.assertEqual(
+            extract_datetime("29 Şubat 2028", "tr", anchorDate=ANCHOR)[0],
+            datetime(2028, 2, 29, 0, 0))
+
+    def test_impossible_clock_hour(self):
+        self.assertIsNone(
+            extract_datetime("saat 25", "tr", anchorDate=ANCHOR))
+
+    def test_cross_language_contamination(self):
+        # Indonesian "besok"/"lusa" must not parse as Turkish
+        self.assertIsNone(extract_datetime("besok", "tr", anchorDate=ANCHOR))
+        self.assertIsNone(extract_datetime("lusa", "tr", anchorDate=ANCHOR))
+
+    def test_omitted_half_idiom(self):
+        # the "buçuk" (half past) idiom is deliberately not supported: the
+        # number parser reads "dokuz buçuk" as 9.5, which is not a valid
+        # clock token, so nothing date/time related is extracted
+        self.assertIsNone(
+            extract_datetime("saat dokuz buçuk", "tr", anchorDate=ANCHOR))


### PR DESCRIPTION
Adds spoken-time, duration and datetime support for Turkish (`tr`), self-contained in `dates_tr.py`.

## What lands
- **nice_time_tr** — reads clock times as "saat <hour> <minute>" (broadcast register), with "sıfır" before sub-ten minutes; `gece yarısı` / `öğle` for midnight/noon.
- **Duration** — registers a `tr` duration lexicon (via the existing `duration.py` API) so `extract_duration` works in every resolution, and corrects `res/tr/date_words.json` to the post-numeral singular forms (Turkish does not pluralize nouns after a numeral), wiring `nice_duration` and `nice_relative_time` through the generic formatters.
- **extract_datetime_tr** — relative day words (bugün, yarın, dün, öbür gün, önceki/evvelki gün), weekday and month names with gelecek/geçen (next/last), "<n> <birim> önce/sonra" offsets, next/last week/month/year, month-name dates, and clock times ("saat 3", spelled "saat üç", "15:30", written locative "saat 3'te"/"15:30'da"). Turkish dotted/dotless casing (I→ı, İ→i) is handled so mixed-case input parses.

## Omissions (deliberate — null beats wrong)
Case-marked idiomatic clock forms ("üçü on geçiyor") and the half-past idiom "buçuk" (the number parser reads "dokuz buçuk" as 9.5) are not supported; `decade` ("on yıl") has no single word and is left out of the lexicon.

## Tests — `test/test_dates_tr.py`, 43 tests
Spoken-time formatting; per-unit duration extraction; a 250-value duration round-trip identity sweep; datetime extraction against a fixed Wednesday anchor; an extensive **real-sentence** suite (natural phrasings with surrounding words, punctuation and mixed case); and edge/adversarial cases (None, whitespace, leading/trailing junk, mixed-case dotless-ı, `tr-TR` variant, leap day, impossible clock hour, cross-language contamination, omitted-idiom). Every expected value derived from reference usage, never engine-pinned.

Full local suite: 472 passed, 2 skipped, 1 pre-existing failure unrelated to this change (`test_packaging`, stale installed package in the shared venv).

Sources: standard Turkish orthography and reference usage for weekday/month names, relative-time and duration vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)