### PR TITLE
fix: understand spoken Danish clock times and evening hours

### DIFF
--- a/ovos_date_parser/dates_da.py
+++ b/ovos_date_parser/dates_da.py
@@ -133,6 +133,7 @@ def extract_datetime_da(text, anchorDate=None, default_time=None):
             for 12 hour date format
         """
 
+        s = numbers_to_digits_da(s)
         s = s.lower().replace('?', '').replace('.', '').replace(',', '') \
             .replace(' den ', ' ').replace(' det ', ' ').replace(' om ',
                                                                  ' ').replace(
@@ -641,11 +642,11 @@ def extract_datetime_da(text, anchorDate=None, default_time=None):
                         strHH = word
                         strMM = 00
                         isTime = True
-                        if wordNext[:10] == "eftermidag":
+                        if wordNext[:11] == "eftermiddag":
                             used += 1
                             remainder = "pm"
                         elif wordNext == "om" and \
-                                wordNextNext == "eftermiddanen":
+                                wordNextNext == "eftermiddagen":
                             used += 2
                             remainder = "pm"
                         elif wordNext[:7] == "aftenen":

--- a/test/format_tests/test_parse_da.py
+++ b/test/format_tests/test_parse_da.py
@@ -1,7 +1,11 @@
 import unittest
-from datetime import timedelta
-from ovos_date_parser.dates_da import extract_duration_da
+from datetime import datetime, timedelta
+from ovos_date_parser.dates_da import extract_duration_da, extract_datetime_da
 from ovos_utils.time import now_local, DAYS_IN_1_YEAR, DAYS_IN_1_MONTH
+
+
+# a Tuesday, early afternoon, used as a stable anchor for relative phrases
+_ANCHOR = datetime(2017, 6, 27, 13, 0, 0)
 
 
 class TestExtractDurationDA(unittest.TestCase):
@@ -33,6 +37,67 @@ class TestExtractDurationDA(unittest.TestCase):
     def test_no_duration_found(self):
         self.assertEqual(extract_duration_da("der er ikke nogen tid"), (None, "der er ikke nogen tid"))
         self.assertEqual(extract_duration_da(""), None)
+
+
+class TestExtractDatetimeDA(unittest.TestCase):
+    def _dt(self, text):
+        res = extract_datetime_da(text, anchorDate=_ANCHOR)
+        self.assertIsNotNone(res, f"no datetime extracted from {text!r}")
+        return res[0]
+
+    def test_spoken_clock_hour(self):
+        # spelled-out cardinal hours must be understood, not just digits
+        self.assertEqual(self._dt("klokken tre").hour, 3)
+        self.assertEqual(self._dt("klokken syv").hour, 7)
+        self.assertEqual(self._dt("klokken ti").hour, 10)
+        self.assertEqual(self._dt("klokken 19").hour, 19)
+
+    def test_part_of_day_sets_pm(self):
+        # an explicit evening hour must land in the evening, not default to 19
+        self.assertEqual(self._dt("syv om aftenen").hour, 19)
+        self.assertEqual(self._dt("otte om aftenen").hour, 20)
+        self.assertEqual(self._dt("ni om aftenen").hour, 21)
+        # morning keeps the stated hour
+        self.assertEqual(self._dt("fem om morgenen").hour, 5)
+        # afternoon promotes the stated hour into the afternoon
+        self.assertEqual(self._dt("klokken tre om eftermiddagen").hour, 15)
+
+    def test_date_with_spoken_time(self):
+        dt = self._dt("møde den 15. juni klokken tre")
+        self.assertEqual((dt.month, dt.day, dt.hour), (6, 15, 3))
+        dt = self._dt("møde den 15. juni klokken tre om eftermiddagen")
+        self.assertEqual((dt.month, dt.day, dt.hour), (6, 15, 15))
+
+    def test_remainder_preserved(self):
+        # non-time words survive as the returned remainder
+        res = extract_datetime_da("møde den 15. juni klokken tre",
+                                  anchorDate=_ANCHOR)
+        self.assertEqual(res[1], "møde")
+
+    def test_relative_offsets_spoken(self):
+        self.assertEqual(self._dt("om tre timer"),
+                         datetime(2017, 6, 27, 16, 0))
+        self.assertEqual(self._dt("om ti minutter"),
+                         datetime(2017, 6, 27, 13, 10))
+
+    def test_tomorrow(self):
+        self.assertEqual(self._dt("i morgen").date(),
+                         (_ANCHOR + timedelta(days=1)).date())
+        self.assertEqual(self._dt("i overmorgen").date(),
+                         (_ANCHOR + timedelta(days=2)).date())
+
+    def test_weekday(self):
+        # "næste mandag" must resolve to a Monday
+        self.assertEqual(self._dt("næste mandag klokken ni").weekday(), 0)
+        self.assertEqual(self._dt("næste mandag klokken ni").hour, 9)
+
+    def test_no_datetime(self):
+        self.assertIsNone(extract_datetime_da("hej med dig", anchorDate=_ANCHOR))
+        self.assertIsNone(extract_datetime_da("", anchorDate=_ANCHOR))
+
+    def test_none_input(self):
+        # empty string is defined to yield None
+        self.assertIsNone(extract_datetime_da("", anchorDate=_ANCHOR))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The Danish datetime extractor imported the spelled-number normaliser but never applied it. As a result spoken clock times were mishandled:

- 'klokken tre' / 'klokken syv' returned no time at all (cardinal hour dropped)
- 'otte om aftenen' resolved to 19:00 instead of 20:00 — the explicit evening hour was discarded in favour of a fixed evening default
- 'om tre timer' and similar spoken relative offsets were not understood

Applying the normaliser inside clean_string lets spoken hours combine with part-of-day markers and relative offsets. A separate typo in the afternoon branch that failed to promote an explicit hour into the afternoon ('klokken tre om eftermiddagen') is also fixed.

Adds extract_datetime tests covering spoken hours, part-of-day promotion, date-plus-time, relative offsets, weekday resolution and empty/garbage input. Full suite green (pre-existing packaging version-block failure aside).

🤖 Generated with [Claude Code](https://claude.com/claude-code)