### PR TITLE
fix: handle 29 of february and None input in Asturian datetime extraction

### DIFF
--- a/ovos_date_parser/dates_ast.py
+++ b/ovos_date_parser/dates_ast.py
@@ -298,7 +298,7 @@ def extract_datetime_ast(text, anchorDate=None, default_time=None):
                     minAbs or secOffset != 0
             )
 
-    if text == "":
+    if not text:
         return None
     if anchorDate is None:
         anchorDate = now_local()
@@ -917,30 +917,33 @@ def extract_datetime_ast(text, anchorDate=None, default_time=None):
                              en_month, datestr)
 
         if hasYear:
-            temp = datetime.strptime(datestr, "%B %d %Y")
-        else:
-            temp = datetime.strptime(datestr, "%B %d")
-        if extractedDate.tzinfo:
-            temp = temp.replace(tzinfo=extractedDate.tzinfo)
-
-        if not hasYear:
-            temp = temp.replace(year=extractedDate.year)
-
-            if extractedDate < temp:
-                extractedDate = extractedDate.replace(
-                    year=int(currentYear),
-                    month=int(temp.strftime("%m")),
-                    day=int(temp.strftime("%d")))
-            else:
-                extractedDate = extractedDate.replace(
-                    year=int(currentYear) + 1,
-                    month=int(temp.strftime("%m")),
-                    day=int(temp.strftime("%d")))
-        else:
+            try:
+                temp = datetime.strptime(datestr, "%B %d %Y")
+            except ValueError:
+                # impossible date for the given year (e.g. 29 of february
+                # in a non-leap year) -> no date to extract
+                return None
             extractedDate = extractedDate.replace(
-                year=int(temp.strftime("%Y")),
-                month=int(temp.strftime("%m")),
-                day=int(temp.strftime("%d")))
+                year=temp.year, month=temp.month, day=temp.day)
+        else:
+            # parse against a leap year so 29 of february never raises here,
+            # then resolve the actual year below
+            temp = datetime.strptime(datestr + " 2000", "%B %d %Y")
+            month, day = temp.month, temp.day
+            year = int(currentYear)
+            # advance to the next year where this day exists and is in the
+            # future relative to the anchor (skips non-leap years for feb 29)
+            while True:
+                try:
+                    candidate = extractedDate.replace(
+                        year=year, month=month, day=day)
+                except ValueError:
+                    year += 1
+                    continue
+                if extractedDate < candidate:
+                    break
+                year += 1
+            extractedDate = candidate
 
     if yearOffset != 0:
         extractedDate = extractedDate + relativedelta(years=yearOffset)

--- a/test/parse_tests/test_parse_ast.py
+++ b/test/parse_tests/test_parse_ast.py
@@ -161,6 +161,60 @@ class TestDatetimeAst(unittest.TestCase):
             datetime(1998, 1, 6, 9, 30, tzinfo=default_timezone()))
 
 
+class TestDatetimeEdgeCasesAst(unittest.TestCase):
+    # anchor: 1998-01-01 was a thursday (non-leap year)
+    ANCHOR = datetime(1998, 1, 1)
+    LEAP_ANCHOR = datetime(2020, 1, 1)
+
+    def test_leap_day_non_leap_anchor(self):
+        # "29 de febreru" with no year on a non-leap anchor must not crash;
+        # it resolves to the next february that has a 29th (year 2000)
+        self.assertEqual(
+            extract_datetime("29 de febreru", anchorDate=self.ANCHOR)[0],
+            datetime(2000, 2, 29, tzinfo=default_timezone()))
+
+    def test_leap_day_leap_anchor(self):
+        self.assertEqual(
+            extract_datetime("29 de febreru", anchorDate=self.LEAP_ANCHOR)[0],
+            datetime(2020, 2, 29, tzinfo=default_timezone()))
+
+    def test_leap_day_explicit_leap_year(self):
+        self.assertEqual(
+            extract_datetime("29 de febreru de 2020",
+                             anchorDate=self.ANCHOR)[0],
+            datetime(2020, 2, 29, tzinfo=default_timezone()))
+
+    def test_leap_day_explicit_non_leap_year(self):
+        # 29 february 2019 does not exist -> no date, not a crash
+        self.assertIsNone(
+            extract_datetime("29 de febreru de 2019", anchorDate=self.ANCHOR))
+
+    def test_date_then_clock_not_taken_as_year(self):
+        # the trailing clock must not be swallowed as the year
+        self.assertEqual(
+            extract_datetime("3 de xunu a les 5", anchorDate=self.ANCHOR)[0],
+            datetime(1998, 6, 3, 5, 0, tzinfo=default_timezone()))
+
+    def test_date_with_year_and_clock(self):
+        self.assertEqual(
+            extract_datetime("3 de xunu 2020 a les 5",
+                             anchorDate=self.ANCHOR)[0],
+            datetime(2020, 6, 3, 5, 0, tzinfo=default_timezone()))
+
+    def test_none_input(self):
+        self.assertIsNone(extract_datetime(None, anchorDate=self.ANCHOR))
+
+    def test_afternoon_pm_applied(self):
+        self.assertEqual(
+            extract_datetime("a les 3 de la tarde", anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 1, 15, 0, tzinfo=default_timezone()))
+
+    def test_night_pm_applied(self):
+        self.assertEqual(
+            extract_datetime("a les 8 de la nueche", anchorDate=self.ANCHOR)[0],
+            datetime(1998, 1, 1, 20, 0, tzinfo=default_timezone()))
+
+
 class TestExtractDurationAst(unittest.TestCase):
     def test_extract_duration(self):
         self.assertEqual(extract_duration("10 segundos"),
@@ -179,6 +233,18 @@ class TestExtractDurationAst(unittest.TestCase):
                          (timedelta(days=1), ""))
         self.assertEqual(extract_duration("1 selmana"),
                          (timedelta(weeks=1), ""))
+
+    def test_duration_none_and_empty(self):
+        self.assertEqual(extract_duration(None), (None, None))
+        self.assertEqual(extract_duration(""), (None, ""))
+
+    def test_duration_no_units(self):
+        self.assertEqual(extract_duration("nun hai duración"),
+                         (None, "nun hai duración"))
+
+    def test_duration_combined(self):
+        dur, _ = extract_duration("3 díes 8 hores 10 minutos y 49 segundos")
+        self.assertEqual(dur, timedelta(days=3, hours=8, minutes=10, seconds=49))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Bugs
1. **Leap-day crash.** `extract_datetime("29 de febreru")` with no explicit year raised `ValueError: day is out of range for month`. The date string was parsed with `strptime(datestr, "%B %d")`, which defaults to year 1900 — a non-leap year — so 29 february crashed before the real year was ever applied. This happened even when the anchor year was itself a leap year.
2. **None input crash.** `extract_datetime(None)` raised `AttributeError` because the empty-input guard only tested `text == ""`.

## Fix
- Parse the day/month against a leap year, then resolve the target year by advancing to the next year in which the day actually exists. For `29 de febreru` with no year this lands on the next leap February; normal dates are unchanged.
- An explicit impossible date (`29 de febreru de 2019`) now returns no date rather than crashing.
- Guard `None`/empty input up front.

## Tests
Added leap-day coverage (non-leap anchor, leap anchor, explicit leap and non-leap years), a date-plus-clock case ensuring the trailing time is not swallowed as a year, PM part-of-day checks, `None` input, and duration edge cases (None/empty/no-units/combined).