### PR TITLE
fix: harden Basque datetime extraction against crashes and wrong hours

### DIFF
--- a/ovos_date_parser/dates_eu.py
+++ b/ovos_date_parser/dates_eu.py
@@ -235,6 +235,16 @@ def extract_datetime_eu(input_str, anchorDate=None, default_time=None):
     if anchorDate is None:
         anchorDate = datetime.now()
 
+    def is_numeric_day(tok):
+        # a bare day number ("25"), not a clock ("15:00") or a
+        # case-inflected number ("3etan")
+        return bool(tok) and tok.isdigit()
+
+    def is_numeric_year(tok):
+        # only a 4 digit token is treated as a year, so a trailing
+        # clock time or inflected number is never swallowed as one
+        return bool(tok) and tok.isdigit() and len(tok) == 4
+
     found = False
     daySpecified = False
     dayOffset = False
@@ -443,47 +453,47 @@ def extract_datetime_eu(input_str, anchorDate=None, default_time=None):
                 m = monthsShort.index(word)
             used += 1
             datestr = months[m]
-            if wordPrev and wordPrev[0].isdigit():
+            if is_numeric_day(wordPrev):
                 # 13 mayo
                 datestr += " " + wordPrev
                 start -= 1
                 used += 1
-                if wordNext and wordNext[0].isdigit():
+                if is_numeric_year(wordNext):
                     datestr += " " + wordNext
                     used += 1
                     hasYear = True
                 else:
                     hasYear = False
 
-            elif wordNext and wordNext[0].isdigit():
+            elif is_numeric_day(wordNext):
                 # mayo 13
                 datestr += " " + wordNext
                 used += 1
-                if wordNextNext and wordNextNext[0].isdigit():
+                if is_numeric_year(wordNextNext):
                     datestr += " " + wordNextNext
                     used += 1
                     hasYear = True
                 else:
                     hasYear = False
 
-            elif wordPrevPrev and wordPrevPrev[0].isdigit():
+            elif is_numeric_day(wordPrevPrev):
                 # 13 dia mayo
                 datestr += " " + wordPrevPrev
 
                 start -= 2
                 used += 2
-                if wordNext and word[0].isdigit():
+                if is_numeric_year(wordNext):
                     datestr += " " + wordNext
                     used += 1
                     hasYear = True
                 else:
                     hasYear = False
 
-            elif wordNextNext and wordNextNext[0].isdigit():
+            elif is_numeric_day(wordNextNext):
                 # mayo dia 13
                 datestr += " " + wordNextNext
                 used += 2
-                if wordNextNextNext and wordNextNextNext[0].isdigit():
+                if is_numeric_year(wordNextNextNext):
                     datestr += " " + wordNextNextNext
                     used += 1
                     hasYear = True
@@ -690,7 +700,7 @@ def extract_datetime_eu(input_str, anchorDate=None, default_time=None):
                         remainder = "pm"
                         used += 1
                     elif wordNext == "gaua" or wordNext == "gauean" or wordNext == "gaueko":
-                        if 0 < int(word[0]) < 6:
+                        if 0 < int(strHH) < 6:
                             remainder = "am"
                         else:
                             remainder = "pm"
@@ -709,11 +719,9 @@ def extract_datetime_eu(input_str, anchorDate=None, default_time=None):
                         remainder = "pm"
                         used = 2
                     else:
-                        if timeQualifier != "":
-                            if strHH <= 12 and \
-                                    (timeQualifier == "goiza" or
-                                     timeQualifier == "arratsaldea"):
-                                strHH += 12
+                        if timeQualifier == "arratsaldea" and \
+                                strHH and int(strHH) < 12:
+                            strHH = int(strHH) + 12
 
             else:
                 # try to parse # s without colons
@@ -759,27 +767,27 @@ def extract_datetime_eu(input_str, anchorDate=None, default_time=None):
                         strHH = strNum
                         remainder = "am"
                         used = 0
-                    elif (int(word) > 100 and
+                    elif (int(strNum) > 100 and
                           (
                                   # wordPrev == "o" or
                                   # wordPrev == "oh" or
                                   wordPrev == "zero"
                           )):
                         # 0800 hours (pronounced oh-eight-hundred)
-                        strHH = int(word) / 100
-                        strMM = int(word) - strHH * 100
+                        strHH = int(strNum) / 100
+                        strMM = int(strNum) - strHH * 100
                         if wordNext == "orduak":
                             used += 1
                     elif (
                             wordNext == "orduak" and
                             word[0] != '0' and
                             (
-                                    int(word) < 100 and
-                                    int(word) > 2400
+                                    int(strNum) < 100 and
+                                    int(strNum) > 2400
                             )):
                         # ignores military time
                         # "in 3 hours"
-                        hrOffset = int(word)
+                        hrOffset = int(strNum)
                         used = 2
                         isTime = False
                         hrAbs = -1
@@ -787,27 +795,27 @@ def extract_datetime_eu(input_str, anchorDate=None, default_time=None):
 
                     elif wordNext == "minutu":
                         # "in 10 minutes"
-                        minOffset = int(word)
+                        minOffset = int(strNum)
                         used = 2
                         isTime = False
                         hrAbs = -1
                         minAbs = -1
                     elif wordNext == "segundu":
                         # in 5 seconds
-                        secOffset = int(word)
+                        secOffset = int(strNum)
                         used = 2
                         isTime = False
                         hrAbs = -1
                         minAbs = -1
-                    elif int(word) > 100:
-                        strHH = int(word) / 100
-                        strMM = int(word) - strHH * 100
+                    elif int(strNum) > 100:
+                        strHH = int(strNum) / 100
+                        strMM = int(strNum) - strHH * 100
                         if wordNext == "ordu":
                             used += 1
 
                     elif wordNext == "" or (
                             wordNext == "puntuan"):
-                        strHH = word
+                        strHH = strNum
                         strMM = 00
                         if wordNext == "puntuan":
                             used += 2
@@ -825,7 +833,7 @@ def extract_datetime_eu(input_str, anchorDate=None, default_time=None):
                                 used += 1
 
                     elif wordNext[0].isdigit():
-                        strHH = word
+                        strHH = strNum
                         strMM = wordNext
                         used += 1
                         if wordNextNext == "orduak":
@@ -889,30 +897,33 @@ def extract_datetime_eu(input_str, anchorDate=None, default_time=None):
         for idx, en_month in enumerate(en_monthsShort):
             datestr = re.sub(r"\b" + re.escape(monthsShort[idx]) + r"\b", en_month, datestr)
 
-        if hasYear:
-            temp = datetime.strptime(datestr, "%B %d %Y")
-        else:
-            temp = datetime.strptime(datestr, "%B %d")
-        temp = temp.replace(tzinfo=None)
-        if not hasYear:
-            temp = temp.replace(year=extractedDate.year, tzinfo=extractedDate.tzinfo)
-            if extractedDate < temp:
-                extractedDate = extractedDate.replace(year=int(currentYear),
-                                                      month=int(
-                                                          temp.strftime(
-                                                              "%m")),
-                                                      day=int(temp.strftime(
-                                                          "%d")))
+        try:
+            if hasYear:
+                temp = datetime.strptime(datestr, "%B %d %Y")
             else:
+                # 2000 is a leap year, so Feb 29 parses; the year is
+                # replaced below anyway
+                temp = datetime.strptime(datestr + " 2000", "%B %d %Y")
+            temp = temp.replace(tzinfo=None)
+            if not hasYear:
+                if extractedDate.replace(year=extractedDate.year) < \
+                        temp.replace(year=extractedDate.year):
+                    chosen_year = int(currentYear)
+                else:
+                    chosen_year = int(currentYear) + 1
                 extractedDate = extractedDate.replace(
-                    year=int(currentYear) + 1,
+                    year=chosen_year,
                     month=int(temp.strftime("%m")),
                     day=int(temp.strftime("%d")))
-        else:
-            extractedDate = extractedDate.replace(
-                year=int(temp.strftime("%Y")),
-                month=int(temp.strftime("%m")),
-                day=int(temp.strftime("%d")))
+            else:
+                extractedDate = extractedDate.replace(
+                    year=int(temp.strftime("%Y")),
+                    month=int(temp.strftime("%m")),
+                    day=int(temp.strftime("%d")))
+        except ValueError:
+            # impossible date (e.g. an out-of-range day, or Feb 29 in a
+            # non-leap target year): treat it as no valid date found
+            return None
 
     if yearOffset != 0:
         extractedDate = extractedDate + relativedelta(years=yearOffset)

--- a/test/parse_tests/test_parse_eu.py
+++ b/test/parse_tests/test_parse_eu.py
@@ -142,6 +142,77 @@ class TestDatetime_eu(unittest.TestCase):
         self.assertEqual(extract_datetime("bart", anchorDate=datetime(1998, 1, 1),
                                           lang='eu')[0], datetime(1997, 12, 31, 21, tzinfo=default_timezone()))
 
+    def test_part_of_day_applies_pm(self):
+        anchor = datetime(1998, 1, 1)
+        # arratsaldeko = "in the afternoon" -> the hour is PM
+        self.assertEqual(extract_datetime_eu("arratsaldeko 3etan", anchorDate=anchor)[0],
+                         datetime(1998, 1, 1, 15, 0))
+        self.assertEqual(extract_datetime_eu("arratsaldea 5:00", anchorDate=anchor)[0],
+                         datetime(1998, 1, 1, 17, 0))
+        # goizeko = "in the morning" -> the hour stays AM
+        self.assertEqual(extract_datetime_eu("goizeko 8etan", anchorDate=anchor)[0],
+                         datetime(1998, 1, 1, 8, 0))
+        self.assertEqual(extract_datetime_eu("goiza 11:00", anchorDate=anchor)[0],
+                         datetime(1998, 1, 1, 11, 0))
+
+    def test_night_clock_does_not_wrap_to_am(self):
+        anchor = datetime(1998, 1, 1)
+        # "23:00 at night" must stay 23:00, not fold to 11:00
+        self.assertEqual(extract_datetime_eu("23:00 gauean", anchorDate=anchor)[0],
+                         datetime(1998, 1, 1, 23, 0))
+        # an early hour "at night" reads as AM
+        self.assertEqual(extract_datetime_eu("3:00 gauean", anchorDate=anchor)[0],
+                         datetime(1998, 1, 1, 3, 0))
+
+    def test_inflected_bare_hour_does_not_crash(self):
+        anchor = datetime(1998, 1, 1)
+        # "3etan" = "at 3 o'clock" (locative), a case-inflected number
+        self.assertEqual(extract_datetime_eu("3etan", anchorDate=anchor)[0],
+                         datetime(1998, 1, 1, 3, 0))
+
+    def test_trailing_clock_not_taken_as_year(self):
+        anchor = datetime(2020, 1, 1)
+        # the clock time after the date must not be swallowed as a year
+        self.assertEqual(extract_datetime_eu("abendua 25 15:00", anchorDate=anchor)[0],
+                         datetime(2020, 12, 25, 15, 0))
+        # explicit four digit year still works
+        self.assertEqual(extract_datetime_eu("maiatza 13 1998",
+                                             anchorDate=datetime(1998, 1, 1))[0],
+                         datetime(1998, 5, 13, 0, 0))
+
+    def test_leap_day(self):
+        # Feb 29 resolves in a leap year
+        self.assertEqual(extract_datetime_eu("otsaila 29", anchorDate=datetime(2020, 1, 1))[0],
+                         datetime(2020, 2, 29, 0, 0))
+        self.assertEqual(extract_datetime_eu("otsaila 29 2020",
+                                             anchorDate=datetime(2020, 1, 1))[0],
+                         datetime(2020, 2, 29, 0, 0))
+        # Feb 29 is impossible in a non-leap year -> no date, not a crash
+        self.assertEqual(extract_datetime_eu("otsaila 29", anchorDate=datetime(2021, 1, 1)),
+                         None)
+
+    def test_out_of_range_day_is_no_date(self):
+        # day 32 does not exist -> no date, not a crash
+        self.assertEqual(extract_datetime_eu("maiatza 32", anchorDate=datetime(2020, 1, 1)),
+                         None)
+
+    def test_remainder_text_is_returned(self):
+        anchor = datetime(1998, 1, 1)
+        res = extract_datetime_eu("bihar 15:00 mesedez", anchorDate=anchor)
+        self.assertEqual(res[0], datetime(1998, 1, 2, 15, 0))
+        self.assertEqual(res[1], "mesedez")
+
+    def test_mixed_case_and_lang_variants(self):
+        anchor = datetime(1998, 1, 1)
+        self.assertEqual(extract_datetime_eu("BIHAR 15:00", anchorDate=anchor)[0],
+                         datetime(1998, 1, 2, 15, 0))
+        # eu and eu-es route to the same extractor
+        self.assertEqual(extract_datetime("bihar 15:00", lang="eu-es", anchorDate=anchor)[0],
+                         datetime(1998, 1, 2, 15, 0, tzinfo=default_timezone()))
+
+    def test_empty_input_is_none(self):
+        self.assertEqual(extract_datetime_eu(""), None)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The Basque `extract_datetime_eu` raised exceptions on several natural and
adversarial inputs, and mis-assigned one hour. All are covered by new tests.

## Bugs fixed
- **Inflected bare hour / trailing clock crash** — `"3etan"` ("at 3", locative) and a colon clock time were run through `int()` on the raw token, raising `ValueError`. Now the extracted digits are used; `"3etan"` resolves to 03:00.
- **Part-of-day + colon time crash** — a standalone qualifier before a colon time (`"goiza 11:00"`, `"arratsaldea 5:00"`) compared a `str` hour to an `int`, raising `TypeError`. The hour is converted first, and only afternoon times shift to PM (`arratsaldea 5:00` -> 17:00, `goiza 11:00` stays 11:00).
- **Night hour folded to AM** — the night qualifier keyed AM/PM off the first digit character, so `"23:00 gauean"` became 11:00. It now keys off the parsed hour and stays 23:00.
- **Trailing token swallowed as year** — a clock time or inflected number after a date (`"abendua 25 15:00"`) was appended as a year and fed to `strptime`, crashing. Only a four-digit token is treated as a year now.
- **Impossible dates crashed** — out-of-range day (`"maiatza 32"`) and Feb 29 in a non-leap year raised from `strptime`; they now yield no date. Feb 29 resolves correctly in leap years.

## Tests
Added 10 adversarial/behavioral tests to `test/parse_tests/test_parse_eu.py` covering part-of-day PM application, night clocks, inflected hours, trailing-clock-as-year, leap day, out-of-range days, remainder retention, mixed case, `eu`/`eu-es` variants, and empty input. Full suite green (pre-existing unrelated packaging-metadata failure aside).