### PR TITLE
fix: parse spoken Italian clock hours and guard malformed dates

### DIFF
--- a/ovos_date_parser/dates_it.py
+++ b/ovos_date_parser/dates_it.py
@@ -359,8 +359,11 @@ def extract_datetime_it(text, anchorDate=None, default_time=None):
                 datestr += ' ' + str(int(extract_number_it(word_prev)))
                 start -= 1
                 used += 1
-                if word_next and extract_number_it(word_next):
-                    datestr += ' ' + str(int(extract_number_it(word_next)))
+                # only a value large enough to be a year (never a clock
+                # hour or a day-of-month) may follow the day as the year
+                _yr = extract_number_it(word_next) if word_next else False
+                if _yr and int(_yr) >= 100:
+                    datestr += ' ' + str(int(_yr))
                     used += 1
                     has_year = True
                 else:
@@ -368,7 +371,8 @@ def extract_datetime_it(text, anchorDate=None, default_time=None):
             elif word_next and word_next[0].isdigit():
                 datestr += ' ' + word_next
                 used += 1
-                if word_next_next and word_next_next[0].isdigit():
+                if word_next_next and word_next_next[0].isdigit() \
+                        and int(word_next_next) >= 100:
                     datestr += ' ' + word_next_next
                     used += 1
                     has_year = True
@@ -426,6 +430,20 @@ def extract_datetime_it(text, anchorDate=None, default_time=None):
                 words[start - 1] = ''
             found = True
             day_specified = True
+
+    # spoken clock hours ("alle tre", "domani alle otto") must reach the
+    # digit-based time parser just like "alle 3" does; the indefinite
+    # article and the fraction words keep their own meaning and are left
+    # untouched
+    _keep_words = {'un', 'uno', 'una', "un'", 'mezzo', 'mezza', 'mezzora',
+                   'quarto', 'quarti', 'paio'}
+    for _i, _w in enumerate(words):
+        if not _w or _w[0].isdigit() or _w in _keep_words:
+            continue
+        _n = extract_number_it(_w)
+        if _n is not False and _n is not None and float(_n) == int(_n) \
+                and 1 <= int(_n) <= 24:
+            words[_i] = str(int(_n))
 
     # parse time
     time_str = ''
@@ -732,13 +750,20 @@ def extract_datetime_it(text, anchorDate=None, default_time=None):
         for idx, en_month in enumerate(en_months_short):
             datestr = datestr.replace(months_short[idx], en_month)
 
-        try:
-            temp = datetime.strptime(datestr, '%B %d')
-        except ValueError:
-            # Try again, allowing the year
-            temp = datetime.strptime(datestr, '%B %d %Y')
+        temp = None
+        for _fmt in ('%B %d', '%B %d %Y', '%B'):
+            try:
+                temp = datetime.strptime(datestr, _fmt)
+                # a bare month with no day ("a giugno"): first of the month
+                has_year = has_year and _fmt == '%B %d %Y'
+                break
+            except ValueError:
+                continue
         extracted_date = extracted_date.replace(hour=0, minute=0, second=0)
-        if not has_year:
+        if temp is None:
+            # unparseable day/month ("il 99 dicembre"): leave the date alone
+            pass
+        elif not has_year:
             temp = temp.replace(year=extracted_date.year,
                                 tzinfo=extracted_date.tzinfo)
             if extracted_date < temp:

--- a/test/parse_tests/test_parse_it.py
+++ b/test/parse_tests/test_parse_it.py
@@ -1,0 +1,98 @@
+import unittest
+from datetime import datetime, timedelta
+
+from ovos_date_parser.dates_it import extract_datetime_it, extract_duration_it
+
+# Tuesday, June 27, 2017, 13:04
+ANCHOR = datetime(2017, 6, 27, 13, 4)
+
+
+class TestExtractDatetimeIT(unittest.TestCase):
+    def _dt(self, text):
+        result = extract_datetime_it(text, anchorDate=ANCHOR)
+        self.assertIsNotNone(result, text)
+        return result[0]
+
+    def test_day_words(self):
+        self.assertEqual(self._dt("oggi").date(), ANCHOR.date())
+        self.assertEqual(self._dt("domani").date(),
+                         (ANCHOR + timedelta(days=1)).date())
+        self.assertEqual(self._dt("ieri").date(),
+                         (ANCHOR - timedelta(days=1)).date())
+        self.assertEqual(self._dt("dopodomani").date(),
+                         (ANCHOR + timedelta(days=2)).date())
+
+    def test_weekday_next(self):
+        # anchor is a Tuesday
+        self.assertEqual(self._dt("lunedì prossimo").date(),
+                         datetime(2017, 7, 10).date())
+
+    def test_relative_weeks(self):
+        self.assertEqual(self._dt("tra tre settimane").date(),
+                         (ANCHOR + timedelta(days=21)).date())
+
+    def test_explicit_date_with_year(self):
+        dt = self._dt("15 giugno 2020")
+        self.assertEqual((dt.year, dt.month, dt.day), (2020, 6, 15))
+
+    def test_explicit_date_no_year(self):
+        dt = self._dt("il 25 dicembre")
+        self.assertEqual((dt.month, dt.day), (12, 25))
+
+    def test_spoken_hour(self):
+        # spoken clock hours must parse like their digit form
+        self.assertEqual(extract_datetime_it("alle tre", anchorDate=ANCHOR),
+                         extract_datetime_it("alle 3", anchorDate=ANCHOR))
+        self.assertEqual(extract_datetime_it("alle ventuno", anchorDate=ANCHOR),
+                         extract_datetime_it("alle 21", anchorDate=ANCHOR))
+
+    def test_spoken_hour_with_day(self):
+        # day fixed by "domani" so the hour is unambiguous
+        dt = self._dt("domani alle otto")
+        self.assertEqual(dt.date(), (ANCHOR + timedelta(days=1)).date())
+        self.assertEqual((dt.hour, dt.minute), (8, 0))
+
+    def test_part_of_day_applies_pm(self):
+        dt = self._dt("alle quattro del pomeriggio")
+        self.assertEqual((dt.hour, dt.minute), (16, 0))
+
+    def test_half_past_spoken(self):
+        dt = self._dt("metti una sveglia alle quattro e mezza")
+        self.assertEqual(dt.minute, 30)
+        self.assertIn(dt.hour, (4, 16))
+
+    def test_date_and_spoken_hour_together(self):
+        # trailing clock hour must not be swallowed as a year (no crash)
+        dt = self._dt("appuntamento il 15 giugno alle tre")
+        self.assertEqual((dt.month, dt.day), (6, 15))
+        self.assertEqual(dt.hour, 15)
+
+    def test_no_date(self):
+        for junk in ["", "ciao come stai", "gattopardo", "!!!"]:
+            with self.subTest(junk=junk):
+                self.assertIsNone(
+                    extract_datetime_it(junk, anchorDate=ANCHOR))
+
+    def test_malformed_does_not_raise(self):
+        for junk in ["alle giugno", "il 99 dicembre", "tre giugno tre",
+                     "giugno alle otto", "quindici sedici diciassette"]:
+            with self.subTest(junk=junk):
+                # must return a value or None, never raise
+                extract_datetime_it(junk, anchorDate=ANCHOR)
+
+
+class TestExtractDurationIT(unittest.TestCase):
+    def test_days(self):
+        self.assertEqual(extract_duration_it("tre giorni")[0],
+                         timedelta(days=3))
+
+    def test_minutes(self):
+        self.assertEqual(extract_duration_it("dieci minuti")[0],
+                         timedelta(minutes=10))
+
+    def test_no_duration(self):
+        self.assertEqual(extract_duration_it("ciao")[0], None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Italian datetime extraction dropped spoken clock hours and raised on a few date shapes.

## Fixes
- Spoken clock hours now parse like their digit form: `alle tre`, `svegliami alle sette`, `domani alle otto`, `alle quattro del pomeriggio` (part-of-day applied). Previously these returned `None`. The indefinite article (`una`) and fraction words (`mezza`, `quarto`) are left untouched.
- A trailing spoken hour after a date is no longer swallowed as the year (`appuntamento il 15 giugno alle tre` previously raised a `ValueError` in `strptime`).
- A bare month with no day resolves to the first of the month instead of raising (`giugno alle otto`, `a giugno`).
- An out-of-range day (`il 99 dicembre`) no longer raises.

## Tests
- New `test/parse_tests/test_parse_it.py` covering day words, weekday/relative offsets, explicit dates with/without year, spoken hours, part-of-day PM, date+hour together, and adversarial/malformed input that must not raise.