### PR TITLE
fix: robust German date extraction for clock hours and invalid dates

### DIFF
--- a/ovos_date_parser/dates_de.py
+++ b/ovos_date_parser/dates_de.py
@@ -291,7 +291,7 @@ def extract_datetime_de(text, anchorDate=None, default_time=None):
                     datestr += " " + wordPrev
                 start -= 1
                 used += 1
-                if wordNext and wordNext[0].isdigit():
+                if wordNext and wordNext.isdigit() and len(wordNext) == 4:
                     datestr += " " + wordNext
                     used += 1
                     hasYear = True
@@ -301,7 +301,8 @@ def extract_datetime_de(text, anchorDate=None, default_time=None):
             elif wordNext and wordNext[0].isdigit():
                 datestr += " " + wordNext
                 used += 1
-                if wordNextNext and wordNextNext[0].isdigit():
+                if wordNextNext and wordNextNext.isdigit() and \
+                        len(wordNextNext) == 4:
                     datestr += " " + wordNextNext
                     used += 1
                     hasYear = True
@@ -715,28 +716,45 @@ def extract_datetime_de(text, anchorDate=None, default_time=None):
         for idx, en_month in enumerate(en_monthsShort):
             datestr = re.sub(r"\b" + re.escape(monthsShort[idx]) + r"\b", en_month, datestr)
 
-        if hasYear:
-            temp = datetime.strptime(datestr, "%B %d %Y")
-        else:
-            temp = datetime.strptime(datestr, "%B %d")
+        try:
+            if hasYear:
+                temp = datetime.strptime(datestr, "%B %d %Y")
+            else:
+                # parse against a leap year so "29. februar" is a valid reference
+                temp = datetime.strptime(datestr + " 2000", "%B %d %Y")
+        except ValueError:
+            # impossible calendar date (e.g. "31. juni", "0. januar",
+            # "29. februar 2021") - null beats a wrong guess
+            return None
 
         if extractedDate.tzinfo:
             temp = temp.replace(tzinfo=extractedDate.tzinfo)
 
         if not hasYear:
-            temp = temp.replace(year=extractedDate.year)
-            if extractedDate < temp:
-                extractedDate = extractedDate.replace(year=int(currentYear),
-                                                      month=int(
-                                                          temp.strftime(
-                                                              "%m")),
-                                                      day=int(temp.strftime(
-                                                          "%d")))
+            month = temp.month
+            day = temp.day
+
+            def _valid_date(year):
+                # a calendar day may be missing in a given year (e.g. 29 Feb)
+                try:
+                    return extractedDate.replace(year=year, month=month, day=day)
+                except ValueError:
+                    return None
+
+            candidate = _valid_date(extractedDate.year)
+            if candidate is not None and extractedDate < candidate:
+                extractedDate = candidate
             else:
-                extractedDate = extractedDate.replace(
-                    year=int(currentYear) + 1,
-                    month=int(temp.strftime("%m")),
-                    day=int(temp.strftime("%d")))
+                # search a bounded span of years for the next valid occurrence
+                candidate = None
+                for year in range(extractedDate.year + 1,
+                                  extractedDate.year + 9):
+                    candidate = _valid_date(year)
+                    if candidate is not None:
+                        break
+                if candidate is None:
+                    return None
+                extractedDate = candidate
         else:
             extractedDate = extractedDate.replace(
                 year=int(temp.strftime("%Y")),

--- a/test/parse_tests/test_parse_de.py
+++ b/test/parse_tests/test_parse_de.py
@@ -214,6 +214,83 @@ class TestExtractDatetime(unittest.TestCase):
         self.assertEqual(default, res[0].time())
 
 
+class TestExtractDatetimeGerman(unittest.TestCase):
+    """Natural and adversarial German date/time utterances."""
+
+    anchor = datetime(2017, 6, 27, 0, 0)
+
+    def _extract(self, text):
+        res = extract_datetime(text, lang="de-de", anchorDate=self.anchor)
+        if res is None:
+            return None
+        return [res[0].strftime("%Y-%m-%d %H:%M:%S"), res[1]]
+
+    def test_part_of_day_makes_hour_pm(self):
+        # explicit hour + part-of-day must convert to the evening hour
+        self.assertEqual(self._extract("sieben uhr abends"),
+                         ["2017-06-27 19:00:00", ""])
+        self.assertEqual(self._extract("acht uhr abends"),
+                         ["2017-06-27 20:00:00", ""])
+        self.assertEqual(self._extract("elf uhr abends"),
+                         ["2017-06-27 23:00:00", ""])
+        self.assertEqual(self._extract("drei uhr nachmittags"),
+                         ["2017-06-27 15:00:00", ""])
+        self.assertEqual(self._extract("neun uhr morgens"),
+                         ["2017-06-27 09:00:00", ""])
+
+    def test_halb_is_half_to_next_hour(self):
+        # "halb vier" is 03:30 (half to four), not 04:30
+        self.assertEqual(self._extract("weck mich um halb vier")[0],
+                         "2017-06-27 03:30:00")
+
+    def test_trailing_clock_number_is_not_a_year(self):
+        # a single clock digit after "15. Juni" must not be grabbed as the year
+        self.assertEqual(self._extract("Treffen am 15. Juni um drei uhr"),
+                         ["2018-06-15 03:00:00", "treffen"])
+        self.assertEqual(self._extract("15. Juni um sieben uhr"),
+                         ["2018-06-15 07:00:00", ""])
+
+    def test_explicit_four_digit_year_still_parses(self):
+        self.assertEqual(self._extract("Treffen am 15. Juni 2019"),
+                         ["2019-06-15 00:00:00", "treffen"])
+        self.assertEqual(self._extract("kaufe feuerwerk am 21. juli 2020"),
+                         ["2020-07-21 00:00:00", "kaufe feuerwerk"])
+
+    def test_leap_day_without_year_rolls_to_next_leap_year(self):
+        # 2017 is not a leap year, the next 29 Feb is in 2020
+        self.assertEqual(self._extract("am 29. februar"),
+                         ["2020-02-29 00:00:00", ""])
+        self.assertEqual(self._extract("am 29. februar 2020"),
+                         ["2020-02-29 00:00:00", ""])
+
+    def test_impossible_calendar_dates_return_none(self):
+        # invalid days must not raise, they yield no datetime
+        for text in ["am 31. juni", "am 31. april", "am 0. januar",
+                     "am 32. märz", "am 29. februar 2021"]:
+            with self.subTest(text=text):
+                self.assertEqual(
+                    extract_datetime(text, lang="de-de", anchorDate=self.anchor),
+                    None)
+
+    def test_wraparound_midnight(self):
+        self.assertEqual(self._extract("setze den timer auf zwölf uhr nachts"),
+                         ["2017-06-28 00:00:00", "setze timer"])
+
+    def test_empty_and_junk_return_none(self):
+        for text in ["", "   ", "?", "kein zeit", "hallo wie geht es dir"]:
+            with self.subTest(text=text):
+                self.assertEqual(
+                    extract_datetime(text, lang="de-de", anchorDate=self.anchor),
+                    None)
+
+    def test_lang_code_variants(self):
+        for lang in ("de", "de-de", "de-DE"):
+            with self.subTest(lang=lang):
+                res = extract_datetime("sieben uhr abends", lang=lang,
+                                       anchorDate=self.anchor)
+                self.assertEqual(res[0].strftime("%H:%M"), "19:00")
+
+
 class TestExtractDuration(unittest.TestCase):
     def test_extract_duration_de(self):
         self.assertEqual(extract_duration("10 sekunden", lang="de-de"),


### PR DESCRIPTION
German `extract_datetime` crashed on several natural and adversarial utterances. This makes it robust:

- A trailing clock digit after a day/month ("15. Juni um drei uhr") was consumed as the year, producing an unparseable date string and a `strptime` `ValueError`. A year is now only taken from a four-digit token.
- A leap day without a year ("29. februar") raised because the fallback parse year was not a leap year; it now resolves to the next year that actually has that calendar day.
- Impossible calendar dates ("31. juni", "0. januar", "29. februar 2021") raised `ValueError`; they now yield no datetime.

Adds tests covering these plus part-of-day to PM conversion ("sieben uhr abends" -> 19:00), "halb" half-to-next-hour semantics ("halb vier" -> 03:30), four-digit years, midnight wrap-around, empty/junk input and language-code variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)