### PR TITLE
fix(sl): leap-day dates and night-hour qualifiers in Slovene

### DIFF
--- a/ovos_date_parser/dates_sl.py
+++ b/ovos_date_parser/dates_sl.py
@@ -386,6 +386,17 @@ def extract_datetime_sl(text, anchorDate=None, default_time=None):
     hrAbs = None
     minAbs = None
 
+    def _apply_time_qualifier(hour):
+        # "ponoči" (in the night) keeps the small hours in the AM: "ob enih
+        # ponoči" is 1:00, while "ob enajstih ponoči" is 23:00.
+        if timeQualifier == "ponoči":
+            return hour + 12 if 5 < hour < 12 else hour
+        if timeQualifier in timeQualifiersPM and 0 < hour < 12:
+            return hour + 12
+        if timeQualifier in timeQualifiersAM and hour >= 12:
+            return hour - 12
+        return hour
+
     for idx, word in enumerate(words):
         if word == "":
             continue
@@ -445,10 +456,7 @@ def extract_datetime_sl(text, anchorDate=None, default_time=None):
                 minAbs = 30
                 start -= 1
                 used += 1
-            if timeQualifier in timeQualifiersPM and 0 < hrAbs < 12:
-                hrAbs += 12
-            elif timeQualifier in timeQualifiersAM and hrAbs >= 12:
-                hrAbs -= 12
+            hrAbs = _apply_time_qualifier(hrAbs)
         elif word[0].isdigit():
             strHH = ""
             strMM = ""
@@ -484,10 +492,7 @@ def extract_datetime_sl(text, anchorDate=None, default_time=None):
                 HH = int(strHH)
                 MM = int(strMM) if strMM else 0
                 if HH <= 24 and MM <= 59:
-                    if timeQualifier in timeQualifiersPM and 0 < HH < 12:
-                        HH += 12
-                    elif timeQualifier in timeQualifiersAM and HH >= 12:
-                        HH -= 12
+                    HH = _apply_time_qualifier(HH)
                     hrAbs = HH % 24
                     minAbs = MM
                 else:
@@ -511,35 +516,40 @@ def extract_datetime_sl(text, anchorDate=None, default_time=None):
     # perform date manipulation
     extractedDate = anchorDate.replace(microsecond=0)
     if datestr != "":
-        try:
-            temp = datetime.strptime(datestr, "%B %d")
-        except ValueError:
+        temp = None
+        for fmt in ("%B %d %Y", "%B %d", "%B %Y", "%B"):
             try:
-                temp = datetime.strptime(datestr, "%B %d %Y")
+                temp = datetime.strptime(datestr, fmt)
+                break
             except ValueError:
-                temp = datetime.strptime(datestr + " 1", "%B %d")
+                continue
+        if temp is None:
+            # a leap day like "29. februarja" has no valid date in the
+            # default year 1900; parse it against a known leap year
+            temp = datetime.strptime(datestr + " 2000", "%B %d %Y")
+        month = temp.month
+        day = temp.day
         extractedDate = extractedDate.replace(hour=0, minute=0, second=0)
+
+        def _on_or_after(year):
+            # roll forward to the next year the day exists in, so that
+            # "29. februarja" lands on the next actual 29 February
+            while True:
+                try:
+                    return extractedDate.replace(year=year, month=month,
+                                                 day=day,
+                                                 tzinfo=extractedDate.tzinfo)
+                except ValueError:
+                    year += 1
+
         if not hasYear:
-            temp = temp.replace(year=extractedDate.year,
-                                tzinfo=extractedDate.tzinfo)
-            if extractedDate < temp:
-                extractedDate = extractedDate.replace(
-                    year=int(currentYear),
-                    month=int(temp.strftime("%m")),
-                    day=int(temp.strftime("%d")),
-                    tzinfo=extractedDate.tzinfo)
+            thisYear = _on_or_after(int(currentYear))
+            if extractedDate < thisYear:
+                extractedDate = thisYear
             else:
-                extractedDate = extractedDate.replace(
-                    year=int(currentYear) + 1,
-                    month=int(temp.strftime("%m")),
-                    day=int(temp.strftime("%d")),
-                    tzinfo=extractedDate.tzinfo)
+                extractedDate = _on_or_after(int(currentYear) + 1)
         else:
-            extractedDate = extractedDate.replace(
-                year=int(temp.strftime("%Y")),
-                month=int(temp.strftime("%m")),
-                day=int(temp.strftime("%d")),
-                tzinfo=extractedDate.tzinfo)
+            extractedDate = _on_or_after(temp.year)
     else:
         # ignore the current HH:MM:SS if relative using days or greater
         if hrOffset == 0 and minOffset == 0 and secOffset == 0:

--- a/test/parse_tests/test_parse_sl.py
+++ b/test/parse_tests/test_parse_sl.py
@@ -94,6 +94,38 @@ class TestExtractDateTimeSL(unittest.TestCase):
                                   default_time=time(9, 30))
         self.assertEqual(result[0], datetime(2023, 6, 7, 9, 30))
 
+    def test_leap_day_rolls_to_next_leap_year(self):
+        # 29 February does not exist in 2023 or 2024 is the next leap year;
+        # the reference must not raise and must land on a real 29 February
+        self.extract("29. februarja", datetime(2024, 2, 29, 0, 0))
+        self.extract("nastavi opomnik za 29. februarja",
+                     datetime(2024, 2, 29, 0, 0), "nastavi opomnik")
+
+    def test_night_keeps_small_hours_in_am(self):
+        # "ponoči" (in the night): 1 at night is 01:00, not 13:00
+        self.extract("ob enih ponoči", datetime(2023, 6, 7, 1, 0))
+        self.extract("ob dveh ponoči", datetime(2023, 6, 7, 2, 0))
+        self.extract("ob 3 ponoči", datetime(2023, 6, 7, 3, 0))
+
+    def test_night_shifts_late_hours_to_pm(self):
+        # the late evening hours still move into the PM half
+        self.extract("ob enajstih ponoči", datetime(2023, 6, 6, 23, 0))
+
+    def test_evening_spoken_hour_is_pm(self):
+        self.extract("ob osmih zvečer", datetime(2023, 6, 6, 20, 0))
+        self.extract("ob 8 zvečer", datetime(2023, 6, 6, 20, 0))
+
+    def test_afternoon_spoken_hour_is_pm(self):
+        self.extract("ob treh popoldne", datetime(2023, 6, 6, 15, 0))
+
+    def test_explicit_year_with_time(self):
+        self.extract("1. januarja 2025 ob 20:00",
+                     datetime(2025, 1, 1, 20, 0))
+
+    def test_bare_month_defaults_to_first(self):
+        # "junij" alone; 1 June already passed -> next year
+        self.extract("junij", datetime(2024, 6, 1, 0, 0))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Two real defects in the Slovene date module.

## Leap day crashed
`extract_datetime("29. februarja")` raised `ValueError` because 29 February has no place in the default parse year and the month-only fallback re-appended a day. Parsing now uses a fallback ladder plus a leap-safe parse, and the resolved date rolls forward to the next year in which the day actually exists (e.g. 2024-02-29).

## Night hours forced to PM
`ponoči` (in the night) was applied as a blanket PM shift, so `ob enih ponoči` (1 at night) became 13:00. The small hours now stay in the morning while the late evening hours still move into the PM half, and the spoken-hour and digit-hour paths share one qualifier helper.

## Verification
- `29. februarja` -> 2024-02-29 with no exception; night hours 1-3 stay AM, 11 -> 23:00.
- Full suite green (pre-existing unrelated `test_packaging` metadata failure aside).

🤖 Generated with [Claude Code](https://claude.com/claude-code)