### PR TITLE
fix: build Hungarian explicit dates without crashing on invalid days

### DIFF
--- a/ovos_date_parser/dates_hu.py
+++ b/ovos_date_parser/dates_hu.py
@@ -400,13 +400,34 @@ def extract_datetime_hu(text, anchorDate=None, default_time=None):
     extractedDate = dateNow.replace(microsecond=0, second=0, minute=0, hour=0)
 
     if datestrMonth is not None:
-        temp = extractedDate.replace(month=datestrMonth,
-                                     day=datestrDay or 1)
+        day = datestrDay or 1
         if datestrYear:
-            temp = temp.replace(year=datestrYear)
-        elif temp < extractedDate:
-            temp = temp.replace(year=extractedDate.year + 1)
-        extractedDate = temp
+            candidate_years = [datestrYear]
+        else:
+            # walk forward to the soonest year where the date exists and is
+            # not already past (handles "február 29" -> next leap year)
+            candidate_years = range(extractedDate.year,
+                                    extractedDate.year + 9)
+        temp = None
+        for y in candidate_years:
+            try:
+                cand = extractedDate.replace(year=y, month=datestrMonth,
+                                             day=day)
+            except ValueError:
+                continue  # e.g. Feb 29 in a common year
+            if datestrYear or cand >= extractedDate:
+                temp = cand
+                break
+        if temp is None:
+            # a date that never exists ("április 31") or an invalid
+            # explicit year ("február 29 2019"): drop the bad date rather
+            # than raising, and give up entirely if nothing else was found
+            datestrMonth = None
+            if not (hrAbs is not None or hrOffset or minOffset or secOffset
+                    or dayOffset or monthOffset or yearOffset):
+                return None
+        else:
+            extractedDate = temp
 
     if yearOffset != 0:
         extractedDate = extractedDate + relativedelta(years=yearOffset)

--- a/test/parse_tests/test_parse_hu.py
+++ b/test/parse_tests/test_parse_hu.py
@@ -97,6 +97,31 @@ class TestExtractDatetimeHu(unittest.TestCase):
         self.assertIsNone(self.extract("helló világ"))
         self.assertIsNone(self.extract(""))
 
+    def test_leap_day_explicit_year(self):
+        # the explicit year must be honoured when building the date; the
+        # anchor year (2017, a common year) must not reject Feb 29 first
+        self.assertDate("február 29 2020", "2020-02-29 00:00:00")
+        self.assertDate("február 29-én 2024", "2024-02-29 00:00:00")
+
+    def test_leap_day_without_year_finds_next_leap_year(self):
+        # anchor is 2017; the next February 29 is in 2020
+        self.assertDate("február 29", "2020-02-29 00:00:00")
+
+    def test_leap_day_with_time(self):
+        self.assertDate("február 29-én 8 órakor", "2020-02-29 08:00:00")
+
+    def test_invalid_calendar_date_is_not_a_date(self):
+        # dates that never exist must fail cleanly, not raise
+        self.assertIsNone(self.extract("április 31"))
+        self.assertIsNone(self.extract("február 30"))
+        self.assertIsNone(self.extract("november 31-én"))
+        # Feb 29 of a common year is likewise impossible
+        self.assertIsNone(self.extract("február 29 2019"))
+
+    def test_invalid_date_keeps_a_valid_time(self):
+        # an impossible day drops the date but a stated time still stands
+        self.assertDate("április 31 8 órakor", "2017-06-27 08:00:00")
+
     def test_default_time(self):
         result = self.extract("holnap", default_time=time(9, 30))
         self.assertEqual(result[0].strftime("%Y-%m-%d %H:%M:%S"),


### PR DESCRIPTION
`extract_datetime_hu` constructed an explicit date by applying the month and day to the anchor year *before* applying the stated year. When the anchor year was a common year, a valid leap date crashed:

```
extract_datetime("február 29 2024", lang="hu", anchorDate=datetime(2017,6,27))
# ValueError: day is out of range for month
```

The same path raised `ValueError` for dates that never exist (`április 31`, `február 30`, `november 31-én`).

The date is now built at the intended year directly. With no year given it walks forward to the soonest year where the date is valid and not already past — so `február 29` resolves to the next leap year (2020 from a 2017 anchor). An impossible date is dropped rather than raised, and yields `None` when nothing else was found while still preserving a stated time (`április 31 8 órakor` → today at 08:00).

New tests cover explicit-year leap dates, the no-year next-leap-year walk, leap date with a time, impossible calendar dates, and an invalid date that keeps its time.