### PR TITLE
fix: Czech accusative weekdays and February genitive in extract_datetime

### DIFF
--- a/ovos_date_parser/dates_cs.py
+++ b/ovos_date_parser/dates_cs.py
@@ -278,7 +278,7 @@ def extract_datetime_cs(text, anchorDate=None, default_time=None):
     timeQualifiersAM = ['ráno', 'dopoledne']
     timeQualifiersPM = ['odpoledne', 'večer', 'noc', 'noci']
     timeQualifiersList = set(timeQualifiersAM + timeQualifiersPM)
-    markers = ['na', 'v', 'do', 'na', 'tento',
+    markers = ['na', 'v', 've', 'do', 'na', 'tento',
                'okolo', 'toto', 'během', 'za', 'této']
     days = ['pondělí', 'úterý', 'středa',
             'čtvrtek', 'pátek', 'sobota', 'neděle']
@@ -1121,6 +1121,14 @@ def _text_cs_inflection_normalize(word, arg):
             word = "večer"
         if word == "noční":
             word = "noc"
+        # Accusative weekday forms ("v neděli", "v sobotu", "ve středu")
+        if word == "neděli":
+            word = "neděle"
+        if word == "sobotu":
+            word = "sobota"
+        if word == "středu":
+            word = "středa"
+
         if word == "víkendech":
             word = "víkend"
         if word == "víkendu":
@@ -1132,6 +1140,8 @@ def _text_cs_inflection_normalize(word, arg):
 
         # Months
         if word == "únoru":
+            word = "únor"
+        elif word == "února":
             word = "únor"
         elif word == "červenci":
             word = "červenec"

--- a/test/parse_tests/test_parse_cs.py
+++ b/test/parse_tests/test_parse_cs.py
@@ -1,0 +1,82 @@
+import unittest
+from datetime import datetime
+
+from ovos_date_parser import extract_datetime
+
+
+class TestExtractDateTimeCS(unittest.TestCase):
+    # Tuesday, 27 June 2017, 10:00
+    ANCHOR = datetime(2017, 6, 27, 10, 0)
+
+    def extract(self, text, expected_dt, expected_leftover=""):
+        result = extract_datetime(text, "cs", anchorDate=self.ANCHOR)
+        self.assertIsNotNone(result, text)
+        self.assertEqual(result[0], expected_dt, text)
+        self.assertEqual(result[1], expected_leftover, text)
+
+    def test_today(self):
+        self.extract("dnes", datetime(2017, 6, 27, 0, 0))
+
+    def test_tomorrow(self):
+        self.extract("zítra", datetime(2017, 6, 28, 0, 0))
+
+    def test_yesterday(self):
+        self.extract("včera", datetime(2017, 6, 26, 0, 0))
+
+    def test_weekday_nominative(self):
+        # anchor is Tuesday; forthcoming Friday and Monday
+        self.extract("v pátek", datetime(2017, 6, 30, 0, 0))
+        self.extract("v pondělí", datetime(2017, 7, 3, 0, 0))
+
+    def test_weekday_accusative(self):
+        # the natural spoken forms decline the weekday noun
+        self.extract("ve středu", datetime(2017, 6, 28, 0, 0))
+        self.extract("v sobotu", datetime(2017, 7, 1, 0, 0))
+        self.extract("v neděli", datetime(2017, 7, 2, 0, 0))
+
+    def test_next_weekday(self):
+        self.extract("příští neděli", datetime(2017, 7, 2, 0, 0))
+
+    def test_weekday_in_sentence(self):
+        self.extract("schůzka v sobotu", datetime(2017, 7, 1, 0, 0),
+                     "schůzka")
+
+    def test_month_genitive_day(self):
+        self.extract("27 ledna", datetime(2018, 1, 27, 0, 0))
+        self.extract("3 července", datetime(2017, 7, 3, 0, 0))
+
+    def test_february_genitive(self):
+        # genitive of únor is irregular ("února", not "únoen")
+        self.extract("15 února", datetime(2018, 2, 15, 0, 0))
+        self.extract("1 února", datetime(2018, 2, 1, 0, 0))
+        self.extract("28 února", datetime(2018, 2, 28, 0, 0))
+
+    def test_february_leap_day(self):
+        self.extract("29 února 2020", datetime(2020, 2, 29, 0, 0))
+
+    def test_ordinal_day_month(self):
+        self.extract("prvního května", datetime(2018, 5, 1, 0, 0))
+        self.extract("druhého února", datetime(2018, 2, 2, 0, 0))
+        self.extract("patnáctého února", datetime(2018, 2, 15, 0, 0))
+
+    def test_noon(self):
+        self.extract("v poledne", datetime(2017, 6, 27, 12, 0))
+
+    def test_next_week(self):
+        self.extract("příští týden", datetime(2017, 7, 4, 0, 0))
+
+    def test_no_date(self):
+        self.assertIsNone(extract_datetime("ahoj jak se máš", "cs",
+                                           anchorDate=self.ANCHOR))
+
+    def test_empty(self):
+        self.assertIsNone(extract_datetime("", "cs", anchorDate=self.ANCHOR))
+
+    def test_lang_code_variant(self):
+        result = extract_datetime("zítra", "cs-cz", anchorDate=self.ANCHOR)
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], datetime(2017, 6, 28, 0, 0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Bug fixes to the existing Czech date module, each covered by new tests in a new `test/parse_tests/test_parse_cs.py`.

## Accusative weekdays yielded no date
The weekday list holds nominative forms, but natural speech declines the weekday noun. `ve středu`, `v sobotu`, and `v neděli` matched nothing and returned `None`. These accusative forms now normalize to their nominative, and the vocalized preposition `ve` is consumed like `v`, leaving clean remainder text.

## Every February date failed
The genitive of únor is irregular (`února`). The generic month de-inflection turned `února` into `únoen`, which matches no month, so `15 února`, `prvního února`, and the leap day `29 února 2020` all returned `None`. An explicit mapping restores February parsing.

## Tests
Added Czech datetime extraction tests covering today/tomorrow/yesterday, nominative and accusative weekdays, next-weekday, weekday-in-sentence, month-and-day (including February genitive and the leap day), ordinal day+month, noon, next week, and empty/no-date/lang-code-variant cases. Full suite green (pre-existing unrelated packaging metadata test excluded).