### PR TITLE
fix: robust English datetime extraction for impossible dates

### DIFF
--- a/ovos_date_parser/dates_en.py
+++ b/ovos_date_parser/dates_en.py
@@ -1051,21 +1051,22 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
 
     extractedDate = anchorDate.replace(microsecond=0)
 
+    temp = None
     if datestr != "":
         # date included an explicit date, e.g. "june 5" or "june 2, 2017"
-        try:
-            temp = datetime.strptime(datestr, "%B %d")
-        except ValueError:
-            # Try again, allowing the year
+        for fmt in ("%B %d", "%B %d %Y", "%B %Y", "%B"):
             try:
-                temp = datetime.strptime(datestr, "%B %d %Y")
+                temp = datetime.strptime(datestr, fmt)
+                break
             except ValueError:
-                # Try again, without day
-                try:
-                    temp = datetime.strptime(datestr, "%B %Y")
-                except ValueError:
-                    # Try again, with only month
-                    temp = datetime.strptime(datestr, "%B")
+                # e.g. an impossible calendar date like "february 29 2019"
+                # falls through every format and leaves temp as None
+                continue
+    if datestr != "" and temp is None:
+        # an explicit date was spoken but it does not exist on the calendar
+        # (e.g. "february 29 2019"); report nothing rather than a wrong guess
+        return None
+    if temp is not None:
         extractedDate = extractedDate.replace(hour=0, minute=0, second=0)
         if not hasYear:
             temp = temp.replace(year=extractedDate.year,

--- a/test/parse_tests/test_parse_en.py
+++ b/test/parse_tests/test_parse_en.py
@@ -1,0 +1,90 @@
+import unittest
+from datetime import datetime, timedelta
+
+from ovos_date_parser import extract_datetime, extract_duration
+
+
+class TestExtractDatetimeEN(unittest.TestCase):
+    anchor = datetime(2017, 6, 27, 13, 4, 0)
+
+    def _extract(self, text, lang="en-us"):
+        return extract_datetime(text, lang=lang, anchorDate=self.anchor)
+
+    def _assert_dt(self, text, expected, leftover=None, lang="en-us"):
+        res = self._extract(text, lang=lang)
+        self.assertIsNotNone(res, f"no datetime extracted from {text!r}")
+        got = res[0].strftime("%Y-%m-%d %H:%M:%S")
+        self.assertEqual(got, expected, f"{text!r} -> {got}")
+        if leftover is not None:
+            self.assertEqual(res[1], leftover)
+
+    def test_natural_time_of_day(self):
+        # an explicit hour plus a part-of-day must resolve to PM
+        self._assert_dt("seven in the evening", "2017-06-27 19:00:00")
+        self._assert_dt("eight tonight", "2017-06-27 20:00:00")
+        self._assert_dt("nine in the morning", "2017-06-28 09:00:00")
+        self._assert_dt("meeting on June 15 at three in the afternoon",
+                        "2018-06-15 15:00:00")
+
+    def test_meeting_with_month_day_and_clock(self):
+        # a trailing clock number must not be swallowed as the year
+        self._assert_dt("meeting on June 15 at three", "2018-06-15 15:00:00")
+        self._assert_dt("dinner on December 24 at eight", "2017-12-24 20:00:00")
+
+    def test_relative_offsets(self):
+        self._assert_dt("remind me in two hours", "2017-06-27 15:04:00")
+        self._assert_dt("wake me in half an hour", "2017-06-27 13:34:00")
+        self._assert_dt("in ten minutes", "2017-06-27 13:14:00")
+
+    def test_explicit_leap_day(self):
+        self._assert_dt("february 29 2020 at noon", "2020-02-29 12:00:00")
+
+    def test_lang_code_variants(self):
+        for lang in ("en", "en-us", "en-gb"):
+            res = extract_datetime("in ten minutes", lang=lang,
+                                   anchorDate=self.anchor)
+            self.assertIsNotNone(res)
+            self.assertEqual(res[0].strftime("%H:%M"), "13:14")
+
+    def test_impossible_dates_return_none(self):
+        # dates that do not exist on the calendar must not crash and must
+        # report nothing rather than a plausible-looking wrong date
+        for text in ("february 29 2019", "february 30", "april 31 2020",
+                     "june 31", "november 31 2021"):
+            self.assertIsNone(self._extract(text),
+                              f"expected None for {text!r}")
+
+    def test_empty_and_junk_input(self):
+        self.assertIsNone(self._extract(""))
+        self.assertIsNone(self._extract("the quick brown fox"))
+
+    def test_now(self):
+        res = self._extract("what time is it now")
+        self.assertIsNotNone(res)
+        self.assertEqual(res[0].strftime("%Y-%m-%d %H:%M:%S"),
+                         "2017-06-27 13:04:00")
+
+
+class TestExtractDurationEN(unittest.TestCase):
+    def _assert_dur(self, text, seconds, lang="en-us"):
+        res = extract_duration(text, lang=lang)
+        self.assertIsNotNone(res)
+        self.assertEqual(res[0], timedelta(seconds=seconds), f"{text!r} -> {res}")
+
+    def test_spoken_durations(self):
+        self._assert_dur("two hours", 7200)
+        self._assert_dur("half an hour", 1800)
+        self._assert_dur("two and a half hours", 9000)
+        self._assert_dur("in two hours and thirty minutes", 9000)
+        self._assert_dur("ninety minutes", 5400)
+
+    def test_empty_duration(self):
+        # empty input yields nothing at all
+        self.assertIsNone(extract_duration("", lang="en-us"))
+        # no duration present -> None delta, text returned untouched
+        self.assertEqual(extract_duration("hello there", lang="en-us"),
+                         (None, "hello there"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`extract_datetime_en` fed an assembled date string through a `strptime` cascade whose final format was not wrapped in a `try`. An impossible calendar date raised an uncaught `ValueError`:

- `"february 29 2019"` -> `ValueError` (2019 is not a leap year)
- `"february 30"`, `"april 31 2020"`, `"june 31"`, ... likewise crashed

## Fix

Iterate the candidate formats and fall through cleanly when none match. When an explicit spoken date does not exist on the calendar, return `None` (nothing found) rather than a misleading anchor-based guess. Valid dates, including real leap days like `"february 29 2020"`, are unchanged.

## Tests

New `test/parse_tests/test_parse_en.py` covering natural time-of-day phrasing, month/day plus trailing clock, relative offsets, a valid leap day, `en`/`en-us`/`en-gb` lang codes, impossible-date rejection, empty/junk input, and spoken durations.

Full suite green apart from the pre-existing unrelated packaging metadata check.