### PR TITLE
fix: Dutch date parsing of month names, part-of-day and clock hours

### DIFF
--- a/ovos_date_parser/dates_nl.py
+++ b/ovos_date_parser/dates_nl.py
@@ -127,6 +127,7 @@ def extract_datetime_nl(text, anchorDate=None, default_time=None):
                     'sep', 'okt', 'nov', 'dec']
     year_multiples = ["decennium", "eeuw", "millennium"]
     day_multiples = ["dagen", "weken", "maanden", "jaren"]
+    time_units = ["uur", "uren", "minuut", "minuten", "seconde", "seconden"]
 
     words = clean_string(text)
 
@@ -281,7 +282,10 @@ def extract_datetime_nl(text, anchorDate=None, default_time=None):
                     datestr += " " + wordPrev
                 start -= 1
                 used += 1
-                if wordNext and wordNext[0].isdigit():
+                if wordNext and wordNext[0].isdigit() and \
+                        wordNextNext not in time_units:
+                    # a bare clock hour following the date ("15 juni 3 uur")
+                    # must not be swallowed as the year
                     datestr += " " + wordNext
                     used += 1
                     hasYear = True
@@ -568,7 +572,16 @@ def extract_datetime_nl(text, anchorDate=None, default_time=None):
                     strHH = strNum
                     used = 1
                 else:
+                    # "3 uur 's middags" is a clock time, not "in 3 hours";
+                    # a part-of-day right after the hour disambiguates it
+                    _after_uur = words[idx + 2] if idx + 2 < len(words) else ""
+                    _after_uur2 = words[idx + 3] if idx + 3 < len(words) else ""
+                    pod_follows = (
+                        (_after_uur == "'s" and _after_uur2 in
+                         ("ochtends", "middags", "avonds", "nachts")) or
+                        _after_uur in timeQualifiersList)
                     if (
+                            not pod_follows and
                             (wordNext == "uren" or wordNext == "uur" or
                              remainder == "uren" or remainder == "uur") and
                             word[0] != '0' and
@@ -631,6 +644,18 @@ def extract_datetime_nl(text, anchorDate=None, default_time=None):
                         strMM = "00"
                         if wordNext == "uur":
                             used += 1
+
+                        # part of day expressed genitively after the hour:
+                        # "3 uur 's middags" -> pm, "8 uur 's avonds" -> pm
+                        genitive_pod = {"ochtends": "am", "middags": "pm",
+                                        "avonds": "pm", "nachts": "am"}
+                        _pod_i = idx + used + 1
+                        _pod_next = words[_pod_i + 1] \
+                            if _pod_i + 1 < len(words) else ""
+                        if _pod_i < len(words) and words[_pod_i] == "'s" \
+                                and _pod_next in genitive_pod:
+                            remainder = genitive_pod[_pod_next]
+                            used += 2
 
                         if wordNext == "in" or wordNextNext == "in":
                             used += (1 if wordNext == "in" else 2)
@@ -733,12 +758,15 @@ def extract_datetime_nl(text, anchorDate=None, default_time=None):
     extractedDate = anchorDate.replace(microsecond=0)
 
     if datestr != "":
-        # date included an explicit date, e.g. "june 5" or "june 2, 2017"
-        try:
-            temp = datetime.strptime(datestr, "%B %d")
-        except ValueError:
-            # Try again, allowing the year
-            temp = datetime.strptime(datestr, "%B %d %Y")
+        # date included an explicit date, e.g. "juni 5" or "juni 2 2017".
+        # parse against the Dutch month names directly; strptime's "%B"
+        # only knows C-locale English names and would reject "juni",
+        # "maart", "augustus", etc.
+        date_parts = datestr.split()
+        month_num = months.index(date_parts[0]) + 1
+        day_num = int(date_parts[1]) if len(date_parts) > 1 else 1
+        year_num = int(date_parts[2]) if len(date_parts) > 2 else 1900
+        temp = datetime(year_num, month_num, day_num)
         extractedDate = extractedDate.replace(hour=0, minute=0, second=0)
         if not hasYear:
             temp = temp.replace(year=extractedDate.year,

--- a/test/format_tests/test_format_nl.py
+++ b/test/format_tests/test_format_nl.py
@@ -200,6 +200,32 @@ class TestNiceDateFormat_nl(unittest.TestCase):
         self.assertEqual(nice_time(dt, lang="nl-nl", use_ampm=True),
                          "half zes 's nachts")
 
+    def test_half_uur_nl(self):
+        # Dutch "half vier" counts down to the coming hour: 3:30, not 4:30
+        dt = datetime.datetime(2017, 1, 31, 3, 30, 0,
+                               tzinfo=default_timezone())
+        self.assertEqual(nice_time(dt, lang="nl-nl"), "half vier")
+        self.assertEqual(nice_time(dt, lang="nl-nl", speech=False), "3:30")
+
+        dt = datetime.datetime(2017, 1, 31, 15, 30, 0,
+                               tzinfo=default_timezone())
+        self.assertEqual(nice_time(dt, lang="nl-nl"), "half vier")
+        self.assertEqual(nice_time(dt, lang="nl-nl", use_ampm=True),
+                         "half vier 's middags")
+
+    def test_quarter_forms_nl(self):
+        dt = datetime.datetime(2017, 1, 31, 7, 15, 0,
+                               tzinfo=default_timezone())
+        self.assertEqual(nice_time(dt, lang="nl-nl"), "kwart over zeven")
+        dt = datetime.datetime(2017, 1, 31, 16, 45, 0,
+                               tzinfo=default_timezone())
+        self.assertEqual(nice_time(dt, lang="nl-nl"), "kwart voor vijf")
+
+    def test_midnight_nl(self):
+        dt = datetime.datetime(2017, 1, 31, 0, 0, 0,
+                               tzinfo=default_timezone())
+        self.assertEqual(nice_time(dt, lang="nl-nl"), "Middernacht")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/parse_tests/test_parse_nl.py
+++ b/test/parse_tests/test_parse_nl.py
@@ -157,5 +157,83 @@ class TestParsing(unittest.TestCase):
                          (timedelta(seconds=3600), ""))
 
 
+class TestParsingNatural(unittest.TestCase):
+    """Natural spoken Dutch and adversarial inputs for extract_datetime."""
+
+    def setUp(self):
+        self.anchor = datetime(2017, 6, 27, 0, 0,
+                               tzinfo=default_timezone())
+
+    def _extract(self, text):
+        return extract_datetime(text, anchorDate=self.anchor, lang=LANG)
+
+    def _fmt(self, text):
+        res = self._extract(text)
+        self.assertIsNotNone(res, text)
+        return res[0].strftime("%Y-%m-%d %H:%M:%S"), res[1]
+
+    def test_dutch_month_names(self):
+        # months whose Dutch spelling differs from the English one must not
+        # crash the parser (strptime "%B" only knows C-locale month names)
+        self.assertEqual(self._fmt("afspraak op 3 mei")[0],
+                         "2018-05-03 00:00:00")
+        self.assertEqual(self._fmt("afspraak op 5 juli")[0],
+                         "2017-07-05 00:00:00")
+        self.assertEqual(self._fmt("afspraak op 20 oktober")[0],
+                         "2017-10-20 00:00:00")
+        self.assertEqual(self._fmt("afspraak op 10 augustus")[0],
+                         "2017-08-10 00:00:00")
+        self.assertEqual(self._fmt("15 maart 2019")[0],
+                         "2019-03-15 00:00:00")
+        self.assertEqual(self._fmt("29 februari 2020")[0],
+                         "2020-02-29 00:00:00")
+
+    def test_all_month_names_do_not_crash(self):
+        for m in ['januari', 'februari', 'maart', 'april', 'mei', 'juni',
+                  'juli', 'augustus', 'september', 'oktober', 'november',
+                  'december']:
+            with self.subTest(month=m):
+                res = self._extract("afspraak op 12 " + m)
+                self.assertIsNotNone(res)
+                self.assertEqual(res[0].day, 12)
+
+    def test_part_of_day_makes_hour_pm(self):
+        # a genitive part-of-day after an explicit hour marks it as pm
+        self.assertEqual(self._fmt("3 uur 's middags")[0],
+                         "2017-06-27 15:00:00")
+        self.assertEqual(self._fmt("8 uur 's avonds")[0],
+                         "2017-06-27 20:00:00")
+        self.assertEqual(self._fmt("om 2 uur 's middags")[0],
+                         "2017-06-27 14:00:00")
+        date, leftover = self._fmt("plan een afspraak om 2 uur 's middags")
+        self.assertEqual(date, "2017-06-27 14:00:00")
+        self.assertEqual(leftover, "plan een afspraak")
+
+    def test_part_of_day_morning_stays_am(self):
+        self.assertEqual(self._fmt("3 uur 's ochtends")[0],
+                         "2017-06-27 03:00:00")
+
+    def test_hour_after_date_not_swallowed_as_year(self):
+        # "3 uur" following a date must be a clock time, not a bogus year
+        self.assertEqual(self._fmt("15 december 3 uur")[0],
+                         "2017-12-15 03:00:00")
+        self.assertEqual(self._fmt("afspraak op 15 juni om 3 uur")[0],
+                         "2018-06-15 03:00:00")
+
+    def test_relative_hour_offset_preserved(self):
+        # "over 3 uur" stays a duration offset from the anchor
+        self.assertEqual(self._fmt("over 3 uur")[0],
+                         "2017-06-27 03:00:00")
+
+    def test_mixed_case(self):
+        self.assertEqual(self._fmt("AFSPRAAK OP 3 MEI")[0],
+                         "2018-05-03 00:00:00")
+
+    def test_no_date_returns_none(self):
+        for junk in ["", "   ", "geen tijd hier", "hallo wereld", "!!!"]:
+            with self.subTest(junk=junk):
+                self.assertIsNone(self._extract(junk))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes three defects in `extract_datetime_nl`:

1. **Month-name crash** — Dutch months that differ from English (maart, mei, juni, juli, augustus, oktober, februari) raised `ValueError` from `strptime('%B')`, which only knows C-locale English names. Now parsed against the Dutch month table. e.g. `afspraak op 3 mei` no longer crashes.
2. **Part-of-day PM** — an explicit hour with a genitive part-of-day (`3 uur 's middags` -> 15:00, `8 uur 's avonds` -> 20:00) was read as a duration and stayed in the morning; now resolved to pm.
3. **Clock hour grabbed as year** — `15 december 3 uur` swallowed the `3` as the year; it is now kept as the time (12-15 03:00).

Relative durations like `over 3 uur` are unchanged.

Tests: natural + adversarial parse cases (all twelve months, mixed case, empty/junk), plus `half vier`=3:30, quarter forms and midnight format tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)