### PR TITLE
fix: correct Portuguese month names and clock-time parsing

### DIFF
--- a/ovos_date_parser/dates_pt.py
+++ b/ovos_date_parser/dates_pt.py
@@ -321,11 +321,11 @@ def extract_datetime_pt(text, anchorDate=None, default_time=None):
                        "no", "dia", "hora"]
     days = ['segunda', 'terca', 'quarta',
             'quinta', 'sexta', 'sabado', 'domingo']
-    months = ['janeiro', 'febreiro', 'marco', 'abril', 'maio', 'junho',
+    months = ['janeiro', 'fevereiro', 'marco', 'abril', 'maio', 'junho',
               'julho', 'agosto', 'setembro', 'outubro', 'novembro',
               'dezembro']
-    monthsShort = ['jan', 'feb', 'mar', 'abr', 'mai', 'jun', 'jul', 'ag',
-                   'set', 'out', 'nov', 'dec']
+    monthsShort = ['jan', 'fev', 'mar', 'abr', 'mai', 'jun', 'jul', 'ago',
+                   'set', 'out', 'nov', 'dez']
     nexts = ["proximo", "proxima"]
     suffix_nexts = ["seguinte", "subsequente", "seguir"]
     lasts = ["ultimo", "ultima"]
@@ -526,7 +526,7 @@ def extract_datetime_pt(text, anchorDate=None, default_time=None):
                 datestr += " " + wordPrev
                 start -= 1
                 used += 1
-                if wordNext and wordNext[0].isdigit():
+                if wordNext.isdigit() and len(wordNext) == 4:
                     datestr += " " + wordNext
                     used += 1
                     hasYear = True
@@ -537,7 +537,7 @@ def extract_datetime_pt(text, anchorDate=None, default_time=None):
                 # maio 13
                 datestr += " " + wordNext
                 used += 1
-                if wordNextNext and wordNextNext[0].isdigit():
+                if wordNextNext.isdigit() and len(wordNextNext) == 4:
                     datestr += " " + wordNextNext
                     used += 1
                     hasYear = True
@@ -550,7 +550,7 @@ def extract_datetime_pt(text, anchorDate=None, default_time=None):
 
                 start -= 2
                 used += 2
-                if wordNext and word[0].isdigit():
+                if wordNext.isdigit() and len(wordNext) == 4:
                     datestr += " " + wordNext
                     used += 1
                     hasYear = True
@@ -561,7 +561,7 @@ def extract_datetime_pt(text, anchorDate=None, default_time=None):
                 # maio dia 13
                 datestr += " " + wordNextNext
                 used += 2
-                if wordNextNextNext and wordNextNextNext[0].isdigit():
+                if wordNextNextNext.isdigit() and len(wordNextNextNext) == 4:
                     datestr += " " + wordNextNextNext
                     used += 1
                     hasYear = True
@@ -853,6 +853,19 @@ def extract_datetime_pt(text, anchorDate=None, default_time=None):
                         if wordNext == "hora":
                             used += 1
                     elif (
+                            wordNext == "hora" and strNum and
+                            wordPrev in ["as", "nas", "pelas", "volta"] and
+                            0 <= int(strNum) <= 24):
+                        # "às 14 horas" / "pelas 9 horas" -> absolute clock
+                        # time, unlike "em 14 horas" which is an offset
+                        strHH = strNum
+                        strMM = 0
+                        used += 1
+                        if timeQualifier in ["tarde", "noite"]:
+                            remainder = "pm"
+                        elif timeQualifier == "manha":
+                            remainder = "am"
+                    elif (
                             wordNext == "hora" and
                             word[0] != '0' and strNum and
                             (
@@ -977,32 +990,39 @@ def extract_datetime_pt(text, anchorDate=None, default_time=None):
         for idx, en_month in enumerate(en_monthsShort):
             datestr = re.sub(r"\b" + re.escape(monthsShort[idx]) + r"\b", en_month, datestr)
 
-        if hasYear:
-            temp = datetime.strptime(datestr, "%B %d %Y")
+        try:
+            if hasYear:
+                temp = datetime.strptime(datestr, "%B %d %Y")
+            else:
+                temp = datetime.strptime(datestr, "%B %d")
+        except ValueError:
+            # impossible dates ("31 de abril") should not crash the parser
+            temp = None
+        if temp is None:
+            datestr = ""
         else:
-            temp = datetime.strptime(datestr, "%B %d")
-        if extractedDate.tzinfo:
-            temp = temp.replace(tzinfo=extractedDate.tzinfo)
+            if extractedDate.tzinfo:
+                temp = temp.replace(tzinfo=extractedDate.tzinfo)
 
-        if not hasYear:
-            temp = temp.replace(year=extractedDate.year)
-            if extractedDate < temp:
-                extractedDate = extractedDate.replace(year=int(currentYear),
-                                                      month=int(
-                                                          temp.strftime(
-                                                              "%m")),
-                                                      day=int(temp.strftime(
-                                                          "%d")))
+            if not hasYear:
+                temp = temp.replace(year=extractedDate.year)
+                if extractedDate < temp:
+                    extractedDate = extractedDate.replace(year=int(currentYear),
+                                                          month=int(
+                                                              temp.strftime(
+                                                                  "%m")),
+                                                          day=int(temp.strftime(
+                                                              "%d")))
+                else:
+                    extractedDate = extractedDate.replace(
+                        year=int(currentYear) + 1,
+                        month=int(temp.strftime("%m")),
+                        day=int(temp.strftime("%d")))
             else:
                 extractedDate = extractedDate.replace(
-                    year=int(currentYear) + 1,
+                    year=int(temp.strftime("%Y")),
                     month=int(temp.strftime("%m")),
                     day=int(temp.strftime("%d")))
-        else:
-            extractedDate = extractedDate.replace(
-                year=int(temp.strftime("%Y")),
-                month=int(temp.strftime("%m")),
-                day=int(temp.strftime("%d")))
 
     if timeStr != "":
         temp = datetime(timeStr)

--- a/test/test_dates_pt.py
+++ b/test/test_dates_pt.py
@@ -765,5 +765,169 @@ class TestComplexDateTimeExtractionScenarios(unittest.TestCase):
                         self.assertAlmostEqual(duration.total_seconds(), expected, places=1)
 
 
+class TestExtractDatetimeAbsoluteHours(unittest.TestCase):
+    """'às N horas' should be an absolute clock time, not an offset."""
+
+    def setUp(self):
+        # a Friday at noon
+        self.anchor = datetime(2026, 7, 17, 12, 0, 0)
+
+    def _time(self, text):
+        result = extract_datetime_pt(text, anchorDate=self.anchor)
+        self.assertIsNotNone(result, f"no datetime found in {text!r}")
+        return result[0]
+
+    def test_as_14_horas_is_two_pm(self):
+        # "às 14 horas" is 14:00, never "in 14 hours"
+        self.assertEqual(self._time("às 14 horas").hour, 14)
+
+    def test_pelas_14_horas_is_two_pm(self):
+        self.assertEqual(self._time("pelas 14 horas").hour, 14)
+
+    def test_as_nine_horas_is_nine(self):
+        self.assertEqual(self._time("às 9 horas").hour, 9)
+
+    def test_as_nine_horas_manha_applies_am(self):
+        # part of day must not be dropped
+        self.assertEqual(self._time("às 9 horas da manhã").hour, 9)
+
+    def test_as_three_horas_tarde_applies_pm(self):
+        self.assertEqual(self._time("às 3 horas da tarde").hour, 15)
+
+    def test_as_midnight_hour(self):
+        self.assertEqual(self._time("às 0 horas").hour, 0)
+
+    def test_em_n_horas_still_offset(self):
+        # "em 3 horas" stays a relative offset from the anchor
+        self.assertEqual(self._time("em 3 horas").hour, 15)
+
+    def test_em_14_horas_still_offset(self):
+        dt = self._time("em 14 horas")
+        # 12:00 + 14h wraps to the next day at 02:00
+        self.assertEqual((dt.day, dt.hour), (18, 2))
+
+    def test_date_with_absolute_hour(self):
+        dt = self._time("2 de maio às 20 horas")
+        self.assertEqual((dt.month, dt.day, dt.hour), (5, 2, 20))
+
+
+class TestExtractDatetimeMonthSpelling(unittest.TestCase):
+    """Correctly spelled Portuguese months and their abbreviations."""
+
+    def setUp(self):
+        self.anchor = datetime(2026, 7, 17, 12, 0, 0)
+
+    def _date(self, text):
+        result = extract_datetime_pt(text, anchorDate=self.anchor)
+        self.assertIsNotNone(result, f"no datetime found in {text!r}")
+        return result[0]
+
+    def test_fevereiro_full(self):
+        dt = self._date("3 de fevereiro")
+        self.assertEqual((dt.month, dt.day), (2, 3))
+
+    def test_fevereiro_short(self):
+        dt = self._date("15 de fev")
+        self.assertEqual((dt.month, dt.day), (2, 15))
+
+    def test_agosto_short(self):
+        dt = self._date("1 de ago às 14 horas")
+        self.assertEqual((dt.month, dt.day, dt.hour), (8, 1, 14))
+
+    def test_dezembro_short(self):
+        dt = self._date("3 de dez às 9 horas")
+        self.assertEqual((dt.month, dt.day, dt.hour), (12, 3, 9))
+
+    def test_all_full_months_recognized(self):
+        months = {
+            "janeiro": 1, "fevereiro": 2, "abril": 4, "maio": 5,
+            "junho": 6, "julho": 7, "agosto": 8, "setembro": 9,
+            "outubro": 10, "novembro": 11, "dezembro": 12,
+        }
+        for name, num in months.items():
+            dt = self._date(f"10 de {name}")
+            self.assertEqual(dt.month, num, f"{name} -> month {dt.month}")
+
+
+class TestExtractDatetimeRobustness(unittest.TestCase):
+    """Adversarial / malformed inputs must never raise."""
+
+    def setUp(self):
+        self.anchor = datetime(2026, 7, 17, 12, 0, 0)
+
+    def _no_crash(self, text):
+        try:
+            return extract_datetime_pt(text, anchorDate=self.anchor)
+        except Exception as e:  # noqa
+            self.fail(f"{text!r} raised {type(e).__name__}: {e}")
+
+    def test_trailing_number_not_year(self):
+        # a bare non-four-digit trailing number must not be fed to strptime
+        for text in ["15 de junho 10", "20 de dezembro 45", "3 de março 99",
+                     "dia 15 de junho 30", "15 janeiro 14:30",
+                     "consulta 15 de junho 3"]:
+            self._no_crash(text)
+
+    def test_impossible_dates_do_not_crash(self):
+        for text in ["31 de abril", "30 de fevereiro", "29 de fevereiro"]:
+            self._no_crash(text)
+
+    def test_four_digit_year_still_parsed(self):
+        result = extract_datetime_pt("15 de junho de 2030", anchorDate=self.anchor)
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0].year, 2030)
+
+    def test_trailing_number_used_as_time(self):
+        # without an explicit year, a following number is the clock time
+        result = extract_datetime_pt("15 de junho às 10", anchorDate=self.anchor)
+        self.assertIsNotNone(result)
+        self.assertEqual((result[0].month, result[0].day, result[0].hour),
+                         (6, 15, 10))
+
+    def test_junk_and_none_like_inputs(self):
+        for text in ["", "isto não tem data nenhuma", "   ",
+                     "xyz 999999", "de de de", "à à à"]:
+            # must not raise; empty/junk should yield None
+            self._no_crash(text)
+
+    def test_mixed_case_preserved(self):
+        result = extract_datetime_pt("AMANHÃ", anchorDate=self.anchor)
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0].date(),
+                         (self.anchor + timedelta(days=1)).date())
+
+
+class TestExtractDatetimeRealSentences(unittest.TestCase):
+    """End to end sentences a user would actually say."""
+
+    def setUp(self):
+        self.anchor = datetime(2026, 7, 17, 12, 0, 0)
+
+    def _dt(self, text):
+        result = extract_datetime_pt(text, anchorDate=self.anchor)
+        self.assertIsNotNone(result, f"no datetime found in {text!r}")
+        return result[0]
+
+    def test_appointment_date(self):
+        dt = self._dt("consulta a 15 de junho às 15:30")
+        self.assertEqual((dt.month, dt.day, dt.hour, dt.minute), (6, 15, 15, 30))
+
+    def test_reminder_full_date(self):
+        dt = self._dt("reunião a 20 de dezembro de 2027")
+        self.assertEqual((dt.year, dt.month, dt.day), (2027, 12, 20))
+
+    def test_christmas(self):
+        dt = self._dt("no dia 25 de dezembro")
+        self.assertEqual((dt.month, dt.day), (12, 25))
+
+    def test_relative_offset_minutes(self):
+        dt = self._dt("em 10 minutos")
+        self.assertEqual((dt - self.anchor), timedelta(minutes=10))
+
+    def test_day_after_tomorrow(self):
+        dt = self._dt("depois de amanhã")
+        self.assertEqual(dt.date(), (self.anchor + timedelta(days=2)).date())
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes several Portuguese `extract_datetime_pt` defects, each covered by new tests.

## Month names
The internal month table listed the misspelled `febreiro` and non-standard abbreviations (`feb`, `ag`, `dec`), so correctly written dates like `3 de fevereiro` and short forms like `fev`, `ago`, `dez` were never recognised. These now use the standard spellings.

## Absolute clock times
`às N horas` was interpreted as a relative offset ("in N hours"), so `às 14 horas` resolved to the next day at 02:00 and `às 9 horas da manhã` silently dropped the part-of-day. It is now read as an absolute clock time, keeping any following qualifier, while `em N horas` remains a relative offset.

## Robust date construction
A bare trailing number after a day/month was appended as a year and fed to `strptime`, which raised `ValueError` for anything that was not four digits (`15 de junho 10`, `20 de dezembro 45`). Only a four-digit token is now taken as a year; other numbers fall through to time parsing. Date construction is additionally guarded so impossible dates such as `31 de abril` no longer raise.