### PR TITLE
fix: Polish spoken ordinal dates and leap-day crash in extract_datetime

### DIFF
--- a/ovos_date_parser/dates_pl.py
+++ b/ovos_date_parser/dates_pl.py
@@ -1,3 +1,4 @@
+import calendar
 import re
 from datetime import datetime, timedelta
 
@@ -397,6 +398,36 @@ def extract_duration_pl(text, resolution=DurationResolution.TIMEDELTA,
                                     resolution, replace_token)
 
 
+# Ordinal day-of-month words in the genitive case Polish uses for dates,
+# e.g. "piętnastego stycznia" -> 15 January. Mapped to the day number so the
+# date parser can treat them like a numeric day.
+_ORDINAL_DAY_UNITS_PL = {
+    1: 'pierwszego', 2: 'drugiego', 3: 'trzeciego', 4: 'czwartego',
+    5: 'piątego', 6: 'szóstego', 7: 'siódmego', 8: 'ósmego',
+    9: 'dziewiątego', 10: 'dziesiątego', 11: 'jedenastego', 12: 'dwunastego',
+    13: 'trzynastego', 14: 'czternastego', 15: 'piętnastego',
+    16: 'szesnastego', 17: 'siedemnastego', 18: 'osiemnastego',
+    19: 'dziewiętnastego', 20: 'dwudziestego', 30: 'trzydziestego',
+}
+
+
+def _build_ordinal_days_pl():
+    phrases = {}
+    for day in range(1, 32):
+        if day in _ORDINAL_DAY_UNITS_PL:
+            phrase = _ORDINAL_DAY_UNITS_PL[day]
+        elif 21 <= day <= 29:
+            phrase = _ORDINAL_DAY_UNITS_PL[20] + ' ' \
+                + _ORDINAL_DAY_UNITS_PL[day - 20]
+        else:  # 31
+            phrase = _ORDINAL_DAY_UNITS_PL[30] + ' ' + _ORDINAL_DAY_UNITS_PL[1]
+        phrases[phrase] = day
+    return phrases
+
+
+_ORDINAL_DAYS_PL = _build_ordinal_days_pl()
+
+
 def extract_datetime_pl(string, anchorDate=None, default_time=None):
     """ Convert a human date reference into an exact datetime
 
@@ -432,6 +463,12 @@ def extract_datetime_pl(string, anchorDate=None, default_time=None):
         # clean unneeded punctuation and capitalization among other things.
         s = s.lower().replace('?', '').replace('.', '').replace(',', '') \
             .replace("para", "2")
+
+        # spoken ordinal day-of-month ("piętnastego stycznia") -> "15 stycznia"
+        # longest phrase first so "dwudziestego pierwszego" wins over "dwudziestego"
+        for phrase in sorted(_ORDINAL_DAYS_PL, key=len, reverse=True):
+            s = re.sub(r'\b' + phrase + r'\b',
+                       str(_ORDINAL_DAYS_PL[phrase]), s)
 
         wordList = s.split()
         for idx, word in enumerate(wordList):
@@ -994,30 +1031,39 @@ def extract_datetime_pl(string, anchorDate=None, default_time=None):
         try:
             temp = datetime.strptime(datestr, "%B %d")
         except ValueError:
-            # Try again, allowing the year
-            temp = datetime.strptime(datestr, "%B %d %Y")
+            # Try again, allowing the year, then a leap-safe day, then a
+            # bare month. "February 29" has no valid date in the default
+            # year 1900, so parse the day against a known leap year.
+            try:
+                temp = datetime.strptime(datestr, "%B %d %Y")
+            except ValueError:
+                try:
+                    temp = datetime.strptime(datestr + " 2000", "%B %d %Y")
+                except ValueError:
+                    try:
+                        temp = datetime.strptime(datestr, "%B %Y")
+                    except ValueError:
+                        temp = datetime.strptime(datestr, "%B")
         extractedDate = extractedDate.replace(hour=0, minute=0, second=0)
-        if not hasYear:
-            temp = temp.replace(year=extractedDate.year,
-                                tzinfo=extractedDate.tzinfo)
-            if extractedDate < temp:
-                extractedDate = extractedDate.replace(
-                    year=int(currentYear),
-                    month=int(temp.strftime("%m")),
-                    day=int(temp.strftime("%d")),
-                    tzinfo=extractedDate.tzinfo)
-            else:
-                extractedDate = extractedDate.replace(
-                    year=int(currentYear) + 1,
-                    month=int(temp.strftime("%m")),
-                    day=int(temp.strftime("%d")),
-                    tzinfo=extractedDate.tzinfo)
+        month = temp.month
+        day = temp.day
+        if hasYear:
+            year = temp.year
+        elif month == 2 and day == 29:
+            # 29 February only exists in leap years: pick the next leap
+            # year on or after the reference date
+            year = int(currentYear)
+            while not (calendar.isleap(year) and
+                       datetime(year, 2, 29, tzinfo=extractedDate.tzinfo)
+                       >= extractedDate):
+                year += 1
         else:
-            extractedDate = extractedDate.replace(
-                year=int(temp.strftime("%Y")),
-                month=int(temp.strftime("%m")),
-                day=int(temp.strftime("%d")),
-                tzinfo=extractedDate.tzinfo)
+            year = int(currentYear)
+            candidate = extractedDate.replace(year=year, month=month, day=day)
+            if not extractedDate < candidate:
+                year += 1
+        extractedDate = extractedDate.replace(
+            year=year, month=month, day=day, tzinfo=extractedDate.tzinfo)
     else:
         # ignore the current HH:MM:SS if relative using days or greater
         if hrOffset == 0 and minOffset == 0 and secOffset == 0:

--- a/test/parse_tests/test_parse_pl.py
+++ b/test/parse_tests/test_parse_pl.py
@@ -1,0 +1,125 @@
+import datetime
+import unittest
+
+from ovos_config.locale import get_default_tz as default_timezone
+
+from ovos_date_parser import extract_datetime, extract_duration
+
+
+def _anchor():
+    # Tuesday, 27 June 2017, 13:04 local
+    return datetime.datetime(2017, 6, 27, 13, 4, tzinfo=default_timezone())
+
+
+class TestExtractDatetimePolishMonths(unittest.TestCase):
+    """Genitive month names with spoken ordinal days.
+
+    "piętnastego stycznia" means the 15th of January and must not raise.
+    """
+
+    def _extract(self, text):
+        return extract_datetime(text, anchorDate=_anchor(), lang="pl")
+
+    def test_spoken_ordinal_day_with_month(self):
+        cases = {
+            'piętnastego stycznia': (2018, 1, 15),
+            'dwudziestego lutego': (2018, 2, 20),
+            'trzeciego sierpnia': (2017, 8, 3),
+            'pierwszego stycznia': (2018, 1, 1),
+            'dwudziestego pierwszego marca': (2018, 3, 21),
+            'trzydziestego kwietnia': (2018, 4, 30),
+            'trzydziestego pierwszego grudnia': (2017, 12, 31),
+        }
+        for text, (y, m, d) in cases.items():
+            with self.subTest(text=text):
+                res = self._extract(text)
+                self.assertIsNotNone(res)
+                self.assertEqual((res[0].year, res[0].month, res[0].day),
+                                 (y, m, d))
+
+    def test_numeric_day_with_month(self):
+        res = self._extract('15 stycznia 2020')
+        self.assertEqual((res[0].year, res[0].month, res[0].day),
+                         (2020, 1, 15))
+
+    def test_bare_month_does_not_crash(self):
+        # a month with no parseable day must degrade, not raise
+        res = self._extract('stycznia')
+        self.assertIsNotNone(res)
+        self.assertEqual(res[0].month, 1)
+
+
+class TestExtractDatetimePolishLeapDay(unittest.TestCase):
+    """29 February must resolve to a leap year, not raise."""
+
+    def _extract(self, text):
+        return extract_datetime(text, anchorDate=_anchor(), lang="pl")
+
+    def test_leap_day_no_year(self):
+        for text in ['29 lutego', 'dwudziestego dziewiątego lutego']:
+            with self.subTest(text=text):
+                res = self._extract(text)
+                self.assertEqual((res[0].year, res[0].month, res[0].day),
+                                 (2020, 2, 29))
+
+    def test_leap_day_with_valid_year(self):
+        res = self._extract('29 lutego 2020')
+        self.assertEqual((res[0].year, res[0].month, res[0].day),
+                         (2020, 2, 29))
+
+
+class TestExtractDatetimePolishRelative(unittest.TestCase):
+    def _extract(self, text):
+        return extract_datetime(text, anchorDate=_anchor(), lang="pl")
+
+    def test_weekdays_accusative(self):
+        cases = {
+            'we wtorek': (2017, 6, 27),
+            'w środę': (2017, 6, 28),
+            'w piątek': (2017, 6, 30),
+        }
+        for text, (y, m, d) in cases.items():
+            with self.subTest(text=text):
+                res = self._extract(text)
+                self.assertEqual((res[0].year, res[0].month, res[0].day),
+                                 (y, m, d))
+
+    def test_relative_days(self):
+        self.assertEqual(self._extract('pojutrze')[0].day, 29)
+        self.assertEqual(self._extract('przedwczoraj')[0].day, 25)
+
+    def test_part_of_day_applies_hour(self):
+        self.assertEqual(self._extract('jutro rano')[0].hour, 8)
+        self.assertEqual(self._extract('jutro wieczorem')[0].hour, 19)
+        self.assertEqual(self._extract('dzisiaj po południu')[0].hour, 15)
+
+    def test_digit_offsets(self):
+        self.assertEqual(self._extract('za 5 minut')[0].strftime("%H:%M"),
+                         "13:09")
+        self.assertEqual(self._extract('za 2 godziny')[0].strftime("%H:%M"),
+                         "15:04")
+
+
+class TestExtractDatetimePolishAdversarial(unittest.TestCase):
+    def test_empty_and_no_date(self):
+        for text in ['', 'cześć jak się masz', '   ']:
+            with self.subTest(text=text):
+                self.assertIsNone(
+                    extract_datetime(text, anchorDate=_anchor(), lang="pl"))
+
+
+class TestExtractDurationPolish(unittest.TestCase):
+    def test_durations(self):
+        self.assertEqual(
+            extract_duration('ustaw minutnik na pięć minut', lang="pl")[0],
+            datetime.timedelta(minutes=5))
+        self.assertEqual(
+            extract_duration('trzy dni', lang="pl")[0],
+            datetime.timedelta(days=3))
+        self.assertEqual(
+            extract_duration('za dwie godziny', lang="pl")[0],
+            datetime.timedelta(hours=2))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Polish `extract_datetime` raised `ValueError` on several everyday date phrases.

## Bugs

| input | before |
|-------|--------|
| `piętnastego stycznia` | `ValueError: time data 'January' does not match format '%B %d %Y'` |
| `stycznia` (bare month) | same `ValueError` |
| `29 lutego` (no year) | `ValueError: day is out of range for month` |

Polish expresses the day of the month with a genitive ordinal word (`piętnastego stycznia` = 15 January). These words were never converted to a day, so only the month name reached `strptime`, which then raised. A bare month name and a yearless 29 February hit the same unguarded path.

## Fix

- Map the genitive ordinal day words (`pierwszego` .. `trzydziestego pierwszego`) to day numbers in `clean_string`, so `piętnastego stycznia` becomes `15 stycznia`.
- Extend the `strptime` fallback ladder to a bare month (`%B`), matching the English parser, so a lone month degrades to the first of that month instead of crashing.
- Resolve a yearless `29 lutego` to the next leap year on or after the reference date.

## Tests

Added `test/parse_tests/test_parse_pl.py` covering spoken ordinal days with genitive months, numeric days, bare month, leap day (word and numeric), accusative weekdays, part-of-day hour mapping, digit relative offsets, durations, and empty/junk input. Full suite green (pre-existing unrelated `test_packaging` metadata failure aside).