### PR TITLE
docs: polish docs and examples for beginners, advanced users and standalone use

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,139 +1,240 @@
 # ovos-date-parser
 
-`ovos-date-parser` is a comprehensive library for multilingual date and time parsing, extraction, and formatting,
-designed to handle a range of human-readable date, time, and duration expressions.
+Multilingual parsing, extraction and formatting of human date, time and duration
+expressions — a two-way bridge between machine timestamps and the way people
+actually speak and write about time.
 
-## Features
+- **Text → datetime**: pull a `datetime` out of "next friday at 3pm" or
+  "amanhã às 15h30", and keep the leftover words.
+- **Text → duration**: turn "two hours and thirty minutes" into a `timedelta`.
+- **datetime → speech**: render `2024-01-05 15:30` as "January fifth twenty
+  twenty four at half past three".
+- **Dozens of languages**, resolved by BCP-47 code, with an automatic
+  [dateparser](https://dateparser.readthedocs.io) fallback for the rest.
 
-- **Date and Time Extraction**: Extract specific dates and times from natural language phrases in various languages.
-- **Duration Parsing**: Parse phrases that indicate a span of time, such as "two hours and fifteen minutes."
-- **Friendly Time Formatting**: Format time for human-friendly output, supporting both 12-hour and 24-hour formats.
-- **Relative Time Descriptions**: Generate relative descriptions (e.g., "tomorrow," "in three days") for given dates.
-- **Multilingual Support**: Includes extraction and formatting methods for multiple languages, such as English, Spanish,
-  French, German, and more.
+It powers date/time understanding in [OpenVoiceOS](https://openvoiceos.org), but
+it is a **plain Python library with no voice-assistant dependency at runtime** —
+equally useful in an NER pipeline, a TTS front-end, an ASR post-processor, or a
+scheduling/calendar/logging tool.
 
 ## Installation
 
 ```bash
 pip install ovos-date-parser
+# or
+uv pip install ovos-date-parser
 ```
 
-### Languages Supported
-
-`ovos-date-parser` supports a wide array of languages, each with its own set of methods for handling natural language
-time expressions.
-
-- ✅ - supported
-- ❌ - not supported
-- 🚧 - imperfect placeholder, usually a language agnostic implementation or external library
-
-**Parse**
-
-| Language | `extract_duration` | `extract_datetime` |
-|----------|--------------------|--------------------|
-| az       | ✅                  | ✅                  |
-| ca       | ✅                  | ✅                  |
-| cs       | ✅                  | ✅                  |
-| da       | ✅                  | ✅                  |
-| de       | ✅                  | ✅                  |
-| en       | ✅                  | ✅                  |
-| es       | ✅                  | ✅                  |
-| gl       | ✅                  | 🚧                 |
-| eu       | ❌                  | ✅                  |
-| fa       | ✅                  | ✅                  |
-| fr       | ❌                  | ✅                  |
-| hu       | ❌                  | 🚧                 |
-| it       | ❌                  | ✅                  |
-| nl       | ✅                  | ✅                  |
-| oc       | ✅                  | ✅                  |
-| pl       | ✅                  | ✅                  |
-| pt       | ✅                  | ✅                  |
-| ro       | ✅                  | ✅                  |
-| ru       | ✅                  | ✅                  |
-| sv       | ✅                  | ✅                  |
-| uk       | ✅                  | ✅                  |
-
-
-> 💡 If a language is not implemented for `extract_datetime` then [dateparser](https://dateparser.readthedocs.io/en/latest/) will be used as a fallback
-
-**Format**
-
-| Language | `nice_date`<br>`nice_date_time`<br>`nice_day` <br>`nice_weekday` <br>`nice_month` <br>`nice_year` <br>`get_date_strings` | `nice_time` | `nice_relative_time` | `nice_duration` |
-|----------|--------------------------------------------------------------------------------------------------------------------------|-------------|----------------------|-----------------|
-| az       | ✅                                                                                                                        | ✅           | 🚧                   | ✅               | 
-| ca       | ✅                                                                                                                        | ✅           | 🚧                   | ✅               | 
-| cs       | ✅                                                                                                                        | ✅           | 🚧                   | ✅               | 
-| da       | ✅                                                                                                                        | ✅           | 🚧                   | ✅               | 
-| de       | ✅                                                                                                                        | ✅           | 🚧                   | ✅               | 
-| en       | ✅                                                                                                                        | ✅           | 🚧                   | ✅               | 
-| es       | ✅                                                                                                                        | ✅           | 🚧                   | ✅               | 
-| gl       | ✅                                                                                                                        | ✅           | 🚧                   | ✅               | 
-| eu       | ✅                                                                                                                        | ✅           | ✅                    | ✅               | 
-| fa       | ✅                                                                                                                        | ✅           | 🚧                   | ✅               | 
-| fr       | ✅                                                                                                                        | ✅           | 🚧                   | ✅               | 
-| hu       | ✅                                                                                                                        | ✅           | 🚧                   | ✅               | 
-| it       | ✅                                                                                                                        | ✅           | 🚧                   | ✅               | 
-| nl       | ✅                                                                                                                        | ✅           | 🚧                   | ✅               | 
-| oc       | ✅                                                                                                                        | ✅           | 🚧                   | ✅               | 
-| pl       | ✅                                                                                                                        | ✅           | 🚧                   | ✅               | 
-| pt       | ✅                                                                                                                        | ✅           | 🚧                   | ✅               | 
-| ro       | ✅                                                                                                                        | ✅           | 🚧                   | ✅               | 
-| ru       | ✅                                                                                                                        | ✅           | 🚧                   | ✅               | 
-| sv       | ✅                                                                                                                        | ✅           | 🚧                   | ✅               |
-| sl       | ✅                                                                                                                        | ❌           | 🚧                   | ✅               |
-| uk       | ✅                                                                                                                        | ✅           | 🚧                   | ✅               | 
-
-## Usage
-
-### Date and Time Extraction
-
-Extract specific dates and times from a phrase. This function identifies date-related terms in natural language and
-returns both the datetime object and any remaining text.
+## 30-second quickstart
 
 ```python
+from datetime import datetime
+from ovos_date_parser import extract_datetime, extract_duration, nice_time, nice_duration
+
+# 1. text -> datetime (+ the words left over)
+when, leftover = extract_datetime("lets meet next friday at 8am", "en",
+                                  anchorDate=datetime(2024, 1, 5))
+print(when)      # 2024-01-12 08:00:00
+print(leftover)  # 'lets meet'
+
+# 2. text -> timedelta
+delta, leftover = extract_duration("set a timer for 5 minutes", "en")
+print(delta)     # 0:05:00
+
+# 3. datetime -> speakable words
+print(nice_time(datetime(2024, 1, 5, 15, 30), "en"))   # 'half past three'
+print(nice_duration(3690, "en"))                       # 'one hour one minute thirty seconds'
+```
+
+Every snippet above and in [`examples/`](examples/) runs with nothing installed
+but this package.
+
+## Use it outside OVOS
+
+The same handful of functions solve everyday text/speech problems that have
+nothing to do with voice assistants.
+
+### Temporal entity extraction (NER)
+
+Tag dates, times and durations in free text and keep the non-temporal
+remainder — useful for log mining, ticket triage or note-taking apps.
+
+```python
+from datetime import datetime
 from ovos_date_parser import extract_datetime
 
-result = extract_datetime("Meet me next Friday at 3pm", lang="en")
-print(result)  # (datetime object, "at 3pm")
+text = "call the supplier next monday at 2pm about the delayed order"
+when, rest = extract_datetime(text, "en", anchorDate=datetime(2024, 1, 5))
+# when -> 2024-01-08 14:00 ; rest -> 'call supplier delayed order'
 ```
 
-### Duration Extraction
+`anchorDate` is the "now" that relative phrases resolve against — pass a fixed
+value for reproducible extraction, or `datetime.now()` live. See
+[`examples/ner_temporal.py`](examples/ner_temporal.py).
 
-Identify duration phrases in text and convert them into a `timedelta` object. This can parse common human-friendly
-duration expressions like "30 minutes" or "two and a half hours."
+### TTS normalization
 
-```python
-from ovos_date_parser import extract_duration
-
-duration, remainder = extract_duration("It will take about 2 hours and 30 minutes", lang="en")
-print(duration)  # timedelta object
-print(remainder)  # "about"
-```
-
-### Formatting Time
-
-Generate a natural-sounding time format suitable for voice or display in different languages, allowing customization for
-speech or written text.
+Speech engines mangle raw digits. Normalize a timestamp to words *before*
+synthesis:
 
 ```python
-from ovos_date_parser import nice_time
 from datetime import datetime
+from ovos_date_parser import nice_date, nice_time
 
-dt = datetime.now()
-formatted_time = nice_time(dt, lang="en", speech=True, use_24hour=False)
-print(formatted_time)  # "three o'clock"
+dt = datetime(2024, 1, 5, 15, 30)
+spoken = f"{nice_date(dt, 'en')} at {nice_time(dt, 'en')}"
+# 'friday, january fifth, twenty twenty four at half past three'
 ```
 
-### Relative Time Descriptions
+See [`examples/tts_normalization.py`](examples/tts_normalization.py).
 
-Create relative phrases for describing dates and times in relation to the current moment or a reference datetime.
+### ASR post-processing
+
+Speech-to-text emits words; downstream logic needs structure. Convert a
+transcript into a real datetime and an action payload:
 
 ```python
-from ovos_date_parser import nice_relative_time
-from datetime import datetime, timedelta
+from datetime import datetime
+from ovos_date_parser import extract_datetime
 
-relative_time = nice_relative_time(datetime.now() + timedelta(days=1), datetime.now(), lang="en")
-print(relative_time)  # "tomorrow"
+utterance = "remind me next tuesday at nine thirty to water the plants"
+when, action = extract_datetime(utterance, "en", anchorDate=datetime(2024, 1, 5))
+# when -> 2024-01-09 09:30 ; action -> 'remind me to water plants'
+```
+
+See [`examples/asr_postproc.py`](examples/asr_postproc.py).
+
+### In an OVOS skill vs. standalone
+
+The library behaves identically in both settings; only who calls it changes.
+
+```python
+# In an OVOS skill: language and anchor come from the session
+when, _ = extract_datetime(utterance, self.lang)
+
+# Standalone scheduler / calendar / cron generator: you supply them
+when, _ = extract_datetime(user_text, "en", anchorDate=datetime.now())
+```
+
+## Core API
+
+| Function | Direction | Purpose |
+|----------|-----------|---------|
+| `extract_datetime(text, lang, anchorDate=None, default_time=None)` | text → datetime | Date/time from a phrase + leftover text |
+| `extract_duration(text, lang, *, resolution=..., replace_token="")` | text → duration | `timedelta`/`relativedelta`/float + leftover text |
+| `nice_time(dt, lang, speech=True, use_24hour=False, use_ampm=False, variant=None)` | datetime → text | Speakable or digit clock time |
+| `nice_date(dt, lang, now=None, include_weekday=True)` | datetime → text | Speakable date, shortened against `now` |
+| `nice_date_time(dt, lang, now=None, use_24hour=False, use_ampm=False)` | datetime → text | Date and time combined |
+| `nice_day` / `nice_weekday` / `nice_month` / `nice_year` | datetime → text | Individual date components |
+| `nice_duration(duration, lang, speech=True)` | seconds/timedelta → text | Speakable timespan |
+| `nice_relative_time(when, relative_to=None, lang="en-us")` | datetime → text | Short "N minutes/days" phrase |
+| `get_date_strings(dt, lang, date_format=None, time_format="full")` | datetime → dict | Display strings for GUI clients |
+
+Full signatures, return shapes and examples: [docs/api.md](docs/api.md).
+
+Dialects resolve by prefix — `"pt-BR"`, `"pt-PT"` and `"pt"` all reach the
+Portuguese implementation. Unsupported languages raise `NotImplementedError`,
+except `extract_datetime`, which first tries the `dateparser` fallback.
+
+## Language support
+
+Twenty-plus languages have dedicated, idiomatic implementations. Extraction for
+any other language falls back to `dateparser`; formatting falls back to a
+generic word-table.
+
+- ✅ dedicated implementation
+- 🚧 partial / generic (language-agnostic helper or external library)
+- ❌ not available (raises `NotImplementedError`)
+
+**Parsing**
+
+| Language | `extract_datetime` | `extract_duration` |
+|----------|:---:|:---:|
+| ar Arabic       | ✅ | ✅ |
+| ast Asturian    | ✅ | ✅ |
+| az Azerbaijani  | ✅ | ✅ |
+| ca Catalan      | ✅ | ✅ |
+| cs Czech        | ✅ | ✅ |
+| da Danish       | ✅ | ✅ |
+| de German       | ✅ | ✅ |
+| en English      | ✅ | ✅ |
+| es Spanish      | ✅ | ✅ |
+| eu Basque       | ✅ | ✅ |
+| fa Persian      | ✅ | ✅ |
+| fr French       | ✅ | ✅ |
+| gl Galician     | 🚧 | ✅ |
+| hu Hungarian    | 🚧 | ✅ |
+| it Italian      | ✅ | ✅ |
+| kab Kabyle      | ✅ | ✅ |
+| nl Dutch        | ✅ | ✅ |
+| oc Occitan      | ✅ | ✅ |
+| pl Polish       | ✅ | ✅ |
+| pt Portuguese   | ✅ | ✅ |
+| ro Romanian     | ✅ | ✅ |
+| ru Russian      | ✅ | ✅ |
+| sl Slovenian    | ✅ | ✅ |
+| sv Swedish      | ✅ | ✅ |
+| uk Ukrainian    | ✅ | ✅ |
+
+> Any language not listed uses the `dateparser` fallback for `extract_datetime`
+> (good at absolute dates, weak at conversational relative phrases). The
+> languages on the shared duration engine (all of the above except ar, ast, fa,
+> kab, sv) also support the `resolution` and `replace_token` options of
+> `extract_duration` — see [docs/api.md](docs/api.md).
+
+**Formatting**
+
+| Language | `nice_date` family | `nice_time` | `nice_duration` | `nice_relative_time` |
+|----------|:---:|:---:|:---:|:---:|
+| ar Arabic       | 🚧 | ✅ | ✅ | 🚧 |
+| ast Asturian    | ✅ | ✅ | ✅ | 🚧 |
+| az Azerbaijani  | ✅ | ✅ | ✅ | 🚧 |
+| ca Catalan      | ✅ | ✅ | ✅ | 🚧 |
+| cs Czech        | ✅ | ✅ | ✅ | 🚧 |
+| da Danish       | ✅ | ✅ | ✅ | 🚧 |
+| de German       | ✅ | ✅ | ✅ | 🚧 |
+| en English      | ✅ | ✅ | ✅ | 🚧 |
+| es Spanish      | ✅ | ✅ | ✅ | 🚧 |
+| eu Basque       | ✅ | ✅ | ✅ | ✅ |
+| fa Persian      | ✅ | ✅ | ✅ | 🚧 |
+| fr French       | ✅ | ✅ | ✅ | 🚧 |
+| gl Galician     | ✅ | ✅ | ✅ | 🚧 |
+| hu Hungarian    | ✅ | ✅ | ✅ | 🚧 |
+| it Italian      | ✅ | ✅ | ✅ | 🚧 |
+| kab Kabyle      | 🚧 | ✅ | ✅ | 🚧 |
+| nl Dutch        | ✅ | ✅ | ✅ | 🚧 |
+| oc Occitan      | ✅ | ✅ | ✅ | 🚧 |
+| pl Polish       | ✅ | ✅ | ✅ | 🚧 |
+| pt Portuguese   | ✅ | ✅ | ✅ | 🚧 |
+| ro Romanian     | ✅ | ✅ | ✅ | 🚧 |
+| ru Russian      | ✅ | ✅ | ✅ | 🚧 |
+| sl Slovenian    | ✅ | ❌ | ✅ | 🚧 |
+| sv Swedish      | ✅ | ✅ | ✅ | 🚧 |
+| uk Ukrainian    | ✅ | ✅ | ✅ | 🚧 |
+
+> `nice_relative_time` uses a shared implementation for every language except
+> Basque, which has a dedicated one; the shared version is functional but not
+> idiomatically tuned per language.
+
+Per-language quirks (Catalan bell-tower time, Occitan quarter idioms, Romanian
+"fără un sfert", Kabyle calendar names, Portuguese `15h30` style, ...) are
+documented in [docs/languages.md](docs/languages.md).
+
+## Examples
+
+Runnable, dependency-free scripts in [`examples/`](examples/):
+
+| Script | Shows |
+|--------|-------|
+| [`ner_temporal.py`](examples/ner_temporal.py) | Extract date/time/duration entities from free text |
+| [`tts_normalization.py`](examples/tts_normalization.py) | Render timestamps to speakable words before synthesis |
+| [`asr_postproc.py`](examples/asr_postproc.py) | Turn spoken transcripts into structured datetimes |
+| [`multilingual.py`](examples/multilingual.py) | Parse-then-render round trip across many languages |
+| [`extract.py`](examples/extract.py) | Minimal extraction reference |
+| [`format.py`](examples/format.py) | Minimal formatting reference |
+
+```bash
+python examples/ner_temporal.py
 ```
 
 ## Documentation
@@ -141,14 +242,13 @@ print(relative_time)  # "tomorrow"
 - [API reference](docs/api.md) — every public function and its parameters
 - [Language notes](docs/languages.md) — per-language behaviour and known gaps
 - [Adding a language](docs/adding-a-language.md) — implementation guide
-- [examples/](examples/) — runnable example scripts
 
-## Related Projects
+## Related projects
 
-- [ovos-number-parser](https://github.com/OpenVoiceOS/ovos-number-parser) - for handling numbers
-- [ovos-lang-parser](https://github.com/OVOSHatchery/ovos-lang-parser) - for handling languages
-- [ovos-color-parser](https://github.com/OVOSHatchery/ovos-color-parser) - for handling colors
+- [ovos-number-parser](https://github.com/OpenVoiceOS/ovos-number-parser) — numbers
+- [ovos-lang-parser](https://github.com/OVOSHatchery/ovos-lang-parser) — languages
+- [ovos-color-parser](https://github.com/OVOSHatchery/ovos-color-parser) — colors
 
 ## License
 
-This project is licensed under the Apache 2.0 License
+Apache 2.0.

--- a/docs/adding-a-language.md
+++ b/docs/adding-a-language.md
@@ -12,7 +12,14 @@ Parsing:
   names, month + day (+ optional year), today/tomorrow/yesterday, relative
   offsets ("in N hours/days/weeks"), morning/afternoon/evening qualifiers,
   and digit times.
-- `extract_duration_<code>(text)` — returns `(timedelta, remaining_text)`.
+- Duration parsing — the preferred path is the **shared duration engine**:
+  register a `DurationLexicon` (unit words + conjunctions) with
+  `register_duration_lexicon(...)` in `ovos_date_parser/duration.py`, then have
+  `extract_duration_<code>` delegate to
+  `extract_duration_generic(text, DURATION_LEXICONS["<code>"], ...)`. Languages
+  on this engine get `resolution` and `replace_token` support for free. A
+  standalone `extract_duration_<code>(text) -> (timedelta, remaining_text)` is
+  only needed when a language cannot use the shared lexicon.
 
 Formatting:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,7 +6,19 @@ a BCP-47 language code (`lang`). Dialects resolve by prefix (`"pt-BR"`,
 raise `NotImplementedError`; `extract_datetime` falls back to
 [dateparser](https://dateparser.readthedocs.io) before giving up.
 
-## Parsing
+```python
+from ovos_date_parser import (
+    extract_datetime, extract_duration,
+    nice_time, nice_date, nice_date_time,
+    nice_day, nice_weekday, nice_month, nice_year,
+    nice_duration, nice_relative_time, get_date_strings,
+)
+```
+
+Nothing here needs a running OVOS stack; the package is pure Python plus a few
+small parsing dependencies.
+
+## Parsing (text → structured value)
 
 ### `extract_datetime(text, lang, anchorDate=None, default_time=None)`
 
@@ -14,7 +26,7 @@ Extract a datetime from a phrase. Returns `[datetime, remaining_text]`, or
 `None` when the text contains no date or time.
 
 ```python
->>> from datetime import datetime
+>>> from datetime import datetime, time
 >>> extract_datetime("lets meet next friday at 8am", "en",
 ...                  anchorDate=datetime(2023, 1, 15))
 [datetime.datetime(2023, 1, 20, 8, 0), 'lets meet']
@@ -24,15 +36,20 @@ Extract a datetime from a phrase. Returns `[datetime, remaining_text]`, or
 None
 ```
 
-- `anchorDate` — the "now" that relative expressions are resolved against;
-  defaults to the current local time.
-- `default_time` — `datetime.time` used when the phrase names a day but no
-  time ("on friday" → friday at `default_time`).
+- `anchorDate` (`datetime`) — the "now" that relative expressions
+  ("tomorrow", "in 2 hours", "next tuesday") are resolved against; defaults to
+  the current local time. Pass a fixed value for deterministic extraction.
+- `default_time` (`datetime.time`) — used when the phrase names a day but no
+  time. `extract_datetime("on friday", "en", default_time=time(9, 0))`
+  resolves to friday at 09:00 instead of midnight.
 
-### `extract_duration(text, lang)`
+The returned `remaining_text` is the input with the recognized date/time words
+removed — the non-temporal payload, handy for intent parsing or NER.
 
-Parse a duration. Returns `(timedelta, remaining_text)`; the timedelta is
-`None` when no duration is found.
+### `extract_duration(text, lang, *, resolution=DurationResolution.TIMEDELTA, replace_token="")`
+
+Parse a duration. Returns `(duration, remaining_text)`; `duration` is `None`
+when nothing is found.
 
 ```python
 >>> extract_duration("set a timer for 5 minutes", "en")
@@ -41,7 +58,31 @@ Parse a duration. Returns `(timedelta, remaining_text)`; the timedelta is
 (None, 'nothing here')
 ```
 
-## Formatting
+`resolution` and `replace_token` are keyword-only and only supported for the
+languages on the **shared duration engine** (ar, ast, fa, kab and sv use a
+simpler dedicated parser and accept neither — passing them raises
+`NotImplementedError`).
+
+- `resolution` (`DurationResolution`) — the type to return:
+  - `TIMEDELTA` (default) — a `datetime.timedelta`.
+  - `RELATIVEDELTA` — a calendar-accurate `dateutil.relativedelta`, so
+    "2 months" stays 2 months rather than an approximate day count.
+  - single-unit totals such as `TOTAL_SECONDS`, `TOTAL_MINUTES`,
+    `TOTAL_HOURS`, `TOTAL_DAYS` — a `float` in that unit.
+- `replace_token` (`str`) — string that each consumed duration is replaced
+  with in `remaining_text`, marking where it was found.
+
+```python
+>>> from ovos_date_parser.duration import DurationResolution
+>>> extract_duration("meeting in 2 weeks", "en",
+...                  resolution=DurationResolution.RELATIVEDELTA,
+...                  replace_token="__DUR__")
+(relativedelta(days=+14), 'meeting in __DUR__')
+```
+
+Import `DurationResolution` from `ovos_date_parser.duration`.
+
+## Formatting (datetime → text)
 
 ### `nice_time(dt, lang, speech=True, use_24hour=False, use_ampm=False, variant=None)`
 
@@ -56,23 +97,59 @@ Speakable or display form of a time.
 'thirteen thirty'
 ```
 
-### `nice_date(dt, lang, now=None)`
+- `speech` — words for TTS (`True`) or a digit clock string (`False`).
+- `use_24hour` — 24-hour reading ("thirteen thirty") instead of 12-hour.
+- `use_ampm` — add the am/pm / part-of-day marker in 12-hour mode.
+- `variant` — Catalan-only register selector (`TimeVariantCA`, see below).
+  Ignored by other languages.
+
+**Catalan registers.** Catalan can read the clock in several styles. Import the
+enum and pass it as `variant`:
+
+```python
+>>> from ovos_date_parser.dates_ca import TimeVariantCA
+>>> nice_time(datetime(2023, 1, 15, 15, 30), "ca")                          # DEFAULT
+'les tres i trenta'
+>>> nice_time(datetime(2023, 1, 15, 15, 30), "ca", variant=TimeVariantCA.BELL)
+'dos quarts de quatre de la tarda'
+```
+
+`TimeVariantCA` members: `DEFAULT`, `BELL`, `FULL_BELL`, `SPANISH_LIKE`.
+
+### `nice_date(dt, lang, now=None, include_weekday=True)`
 
 Pronounceable date. When `now` is given, the output is shortened relative to
 it — same day returns "today", adjacent days "tomorrow"/"yesterday", the year
-is omitted when it matches.
+is omitted when it matches `now`. `include_weekday=False` drops the weekday.
+
+```python
+>>> nice_date(datetime(2024, 1, 5), "en")
+'friday, january fifth, twenty twenty four'
+```
 
 ### `nice_date_time(dt, lang, now=None, use_24hour=False, use_ampm=False)`
 
-Date and time combined ("tuesday, june fifth at half past one").
+Date and time combined ("tuesday, june fifth at half past one"). `now`,
+`use_24hour` and `use_ampm` behave as in `nice_date` / `nice_time`.
 
-### `nice_day(dt, lang, date_format='DMY', include_month=True)` / `nice_weekday(dt, lang)` / `nice_month(dt, lang)` / `nice_year(dt, lang, bc=False)`
+### `nice_day(dt, lang, date_format='DMY', include_month=True)`
 
-Individual date components in speakable form.
+Day number, optionally with the month, ordered by `date_format` (`'DMY'`,
+`'MDY'` or `'YMD'`).
+
+### `nice_weekday(dt, lang)` / `nice_month(dt, lang, date_format='MDY')` / `nice_year(dt, lang, bc=False)`
+
+Individual components in speakable form. `nice_year` appends a B.C. marker when
+`bc=True` (Python `datetime` cannot itself represent B.C. years).
+
+```python
+>>> nice_year(datetime(1984, 1, 1), "en")
+'nineteen eighty four'
+```
 
 ### `nice_duration(duration, lang, speech=True)`
 
-Speakable timespan. Accepts seconds (int/float) or a `timedelta`.
+Speakable timespan. Accepts seconds (`int`/`float`) or a `timedelta`.
 
 ```python
 >>> nice_duration(61, "en")
@@ -83,10 +160,18 @@ Speakable timespan. Accepts seconds (int/float) or a `timedelta`.
 
 ### `nice_relative_time(when, relative_to=None, lang="en-us")`
 
-Short relative description of a future or past instant ("in 2 hours",
-"in 5 days").
+Short relative description of an instant relative to `relative_to` (default:
+now) — "twenty four hours", "five days" style. Every language except Basque
+uses a shared, functional-but-generic implementation.
 
-### `get_date_strings(dt, lang, date_format='MDY', time_format='full')`
+### `get_date_strings(dt, lang, date_format=None, time_format="full")`
 
-Dict of display strings for GUI clients (`date_string`, `time_string`,
-`weekday_string`, `day_string`, `month_string`, `year_string`).
+Dict of display strings for GUI clients:
+
+```python
+{'date_string', 'time_string', 'month_string',
+ 'day_string', 'year_string', 'weekday_string'}
+```
+
+`date_format` defaults to the OVOS configuration value (or `'DMY'`);
+`time_format="full"` selects a 24-hour `time_string`.

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -84,8 +84,8 @@ plural declension may be imperfect (e.g. Slovenian dual forms).
 
 - Relative *past* wording ("anoche", "bart", "last night") is not handled in
   es/eu; the corresponding tests are skipped.
-- `extract_duration` is missing for eu, fr, hu, it.
 - `nice_time` is missing for sl.
-- Duration parsing understands "2 weeks", "3 months", "4 years" in most
-  languages, but common.py's generic helper only covers seconds through
-  days.
+- `gl` and `hu` `extract_datetime` are partial (🚧 in the README matrix).
+- The `resolution` / `replace_token` options of `extract_duration` are only
+  available on the shared duration engine; ar, ast, fa, kab and sv use a
+  dedicated parser that returns a plain `timedelta` and rejects those options.

--- a/examples/asr_postproc.py
+++ b/examples/asr_postproc.py
@@ -1,0 +1,39 @@
+"""ASR post-processing — spoken time phrases into structured datetimes.
+
+Speech-to-text engines emit words, not structured values. A transcript says
+"remind me next tuesday at nine thirty", and a downstream scheduler needs a
+real datetime. `extract_datetime` / `extract_duration` bridge that gap.
+
+Fully standalone: pretend the strings below came off any ASR engine.
+"""
+from datetime import datetime
+
+from ovos_date_parser import extract_datetime, extract_duration
+
+# The moment the utterance was transcribed — relative phrases resolve to it.
+NOW = datetime(2024, 1, 5, 9, 0)
+
+transcripts = [
+    ("en", "remind me next tuesday at nine thirty to water the plants"),
+    ("en", "wake me up in eight hours"),
+    ("pt", "marca uma reunião amanhã às 15h30"),
+    ("de", "weck mich morgen um sieben uhr"),
+]
+
+for lang, utterance in transcripts:
+    parsed = extract_datetime(utterance, lang, anchorDate=NOW)
+    if parsed is None:
+        print(f"[{lang}] no time understood: {utterance!r}")
+        continue
+    when, remainder = parsed
+    # `remainder` is the intent payload with the time expression stripped out.
+    print(f"[{lang}] {utterance!r}")
+    print(f"       when   = {when.isoformat()}")
+    print(f"       action = {remainder!r}")
+
+print()
+print("Spoken durations -> timedelta:")
+for lang, utterance in [("en", "cook it for twenty five minutes"),
+                        ("fr", "minuteur de deux heures et trente minutes")]:
+    delta, remainder = extract_duration(utterance, lang)
+    print(f"[{lang}] {delta}  (action: {remainder!r})")

--- a/examples/multilingual.py
+++ b/examples/multilingual.py
@@ -1,0 +1,37 @@
+"""Multilingual round-trip across several supported languages.
+
+Parse a spoken phrase into a datetime, then render it back to natural words
+in the same language. Shows the breadth of language coverage in one pass.
+Standalone — no OVOS.
+"""
+from datetime import datetime
+
+from ovos_date_parser import extract_datetime, nice_date_time, nice_duration
+
+ANCHOR = datetime(2024, 1, 5, 9, 0)
+
+phrases = [
+    ("en", "next friday at 3pm"),
+    ("es", "el 11 de agosto de 1998"),
+    ("pt", "amanhã às 15h30"),
+    ("de", "übermorgen um 10 Uhr"),
+    ("fr", "demain à 15h30"),
+    ("it", "dopodomani alle 10"),
+    ("nl", "morgen om negen uur"),
+    ("ru", "завтра в десять утра"),
+]
+
+print("== parse -> re-render ==")
+for lang, phrase in phrases:
+    parsed = extract_datetime(phrase, lang, anchorDate=ANCHOR)
+    if not parsed:
+        print(f"[{lang}] could not parse {phrase!r}")
+        continue
+    when, _ = parsed
+    print(f"[{lang}] {phrase!r}")
+    print(f"       -> {when.isoformat()}")
+    print(f"       -> {nice_date_time(when, lang)}")
+
+print("\n== the same duration in several languages ==")
+for lang in ["en", "es", "pt", "de", "fr", "it", "ru", "uk"]:
+    print(f"  [{lang}] {nice_duration(3690, lang)}")

--- a/examples/ner_temporal.py
+++ b/examples/ner_temporal.py
@@ -1,0 +1,46 @@
+"""Temporal entity extraction (NER) from free text — no OVOS required.
+
+Pull dates, times and durations out of unstructured strings the way a
+named-entity recognizer would, then keep the leftover text. Everything here
+runs with just `pip install ovos-date-parser`.
+
+Typical standalone uses: tagging log lines, mining meeting notes, enriching
+support tickets, or feeding a calendar/scheduling tool.
+"""
+from datetime import datetime
+
+from ovos_date_parser import extract_datetime, extract_duration
+
+# A fixed anchor makes relative phrases ("tomorrow", "in 2 weeks")
+# deterministic. In a live tool you would pass datetime.now() instead.
+ANCHOR = datetime(2024, 1, 5, 9, 0)  # a friday, 09:00
+
+notes = [
+    ("en", "call the supplier next monday at 2pm about the delayed order"),
+    ("en", "the maintenance window lasts 3 hours and 30 minutes"),
+    ("pt", "reunião amanhã às 15h30 na sala azul"),
+    ("es", "entregar el informe el 11 de agosto de 1998"),
+    ("de", "der Termin ist übermorgen um 10 Uhr"),
+]
+
+print("== date / time entities ==")
+for lang, text in notes:
+    found = extract_datetime(text, lang, anchorDate=ANCHOR)
+    if found is None:
+        print(f"[{lang}] no temporal entity in: {text!r}")
+        continue
+    when, leftover = found
+    print(f"[{lang}] {when.isoformat()}  <-  {text!r}")
+    print(f"       leftover (non-temporal) text: {leftover!r}")
+
+print("\n== duration entities ==")
+durations = [
+    ("en", "set a timer for 5 minutes"),
+    ("en", "3 days 8 hours and 10 minutes of processing time"),
+    ("fr", "la recette prend deux heures et trente minutes"),
+    ("it", "il corso dura due ore e trenta minuti"),
+]
+for lang, text in durations:
+    delta, leftover = extract_duration(text, lang)
+    print(f"[{lang}] {delta}  <-  {text!r}")
+    print(f"       leftover text: {leftover!r}")

--- a/examples/tts_normalization.py
+++ b/examples/tts_normalization.py
@@ -1,0 +1,37 @@
+"""TTS normalization — turn machine dates/times into speakable words.
+
+Speech synthesizers read digits poorly ("2024-01-05" -> "two thousand
+twenty four dash zero one..."). Normalize timestamps and durations into
+natural spoken words *before* handing text to any TTS engine. Standalone —
+no OVOS, no speech engine needed to run this.
+"""
+from datetime import datetime, timedelta
+
+from ovos_date_parser import (nice_date, nice_time, nice_date_time,
+                              nice_duration, nice_year)
+
+dt = datetime(2024, 1, 5, 15, 30)
+
+print("Raw timestamp:", dt.isoformat())
+print()
+
+for lang in ["en", "es", "pt", "de", "fr", "it"]:
+    print(f"--- {lang} ---")
+    print("  date :", nice_date(dt, lang))
+    print("  time :", nice_time(dt, lang))            # speakable, 12h
+    print("  24h  :", nice_time(dt, lang, use_24hour=True))
+    print("  year :", nice_year(dt, lang))
+    print("  full :", nice_date_time(dt, lang))
+
+print()
+print("Durations rendered for speech:")
+for secs in (90, 3690, 86400 * 2 + 3600 * 3):
+    print(f"  {secs:>7}s ->", nice_duration(secs, "en"))
+print("  timedelta ->", nice_duration(timedelta(hours=1, minutes=45), "en"))
+
+# A minimal 'normalize before synthesis' helper.
+def speak_timestamp(dt, lang="en"):
+    return f"{nice_date(dt, lang)} at {nice_time(dt, lang)}"
+
+print()
+print("speak_timestamp:", speak_timestamp(dt))


### PR DESCRIPTION
Polishes the documentation so both newcomers and advanced developers can get productive quickly, and makes clear the library is useful **outside** OVOS as a plain Python package.

## README
- Value prop framed as a two-way bridge between machine timestamps and human date/time/duration text.
- uv/pip install, a 30-second quickstart, and a "Use it outside OVOS" section with runnable snippets for NER/temporal entity extraction, TTS normalization and ASR post-processing, plus an OVOS-skill vs standalone contrast.
- Core-API table and refreshed parse/format language matrices reflecting the current parsers and the shared duration engine (eu/fr/hu/it duration, gl/hu partial datetime, etc.).

## docs/
- `api.md`: full signatures and return shapes, `extract_duration` `resolution`/`replace_token` options with `DurationResolution`, and the Catalan `TimeVariantCA` registers.
- `languages.md`: corrected known-gaps list.
- `adding-a-language.md`: shared duration-lexicon registration path.

## examples/ (each executed and confirmed to run)
- `ner_temporal.py`, `tts_normalization.py`, `asr_postproc.py`, `multilingual.py`

Docs-only; no library code changed.