### PR TITLE
fix: compute Romance relative time offsets from the anchor time

### DIFF
--- a/ovos_date_parser/dates_es.py
+++ b/ovos_date_parser/dates_es.py
@@ -836,7 +836,7 @@ def extract_datetime_es(text, anchorDate=None, default_time=None):
                             wordNext == "hora" and
                             word[0] != '0' and
                             (
-                                    int(word) < 100 and
+                                    int(word) < 100 or
                                     int(word) > 2400
                             )):
                         # ignores military time
@@ -935,10 +935,14 @@ def extract_datetime_es(text, anchorDate=None, default_time=None):
     # perform date manipulation
 
     extractedDate = dateNow
-    extractedDate = extractedDate.replace(microsecond=0,
-                                          second=0,
-                                          minute=0,
-                                          hour=0)
+    if hrOffset != 0 or minOffset != 0 or secOffset != 0:
+        # purely relative time ("dentro de dos horas") keeps the anchor time of day
+        extractedDate = extractedDate.replace(microsecond=0, second=0)
+    else:
+        extractedDate = extractedDate.replace(microsecond=0,
+                                              second=0,
+                                              minute=0,
+                                              hour=0)
     if datestr != "":
         en_months = ['january', 'february', 'march', 'april', 'may', 'june',
                      'july', 'august', 'september', 'october', 'november',

--- a/ovos_date_parser/dates_fr.py
+++ b/ovos_date_parser/dates_fr.py
@@ -581,10 +581,14 @@ def extract_datetime_fr(text, anchorDate=None, default_time=None):
 
     # perform date manipulation
     extractedDate = dateNow
-    extractedDate = extractedDate.replace(microsecond=0,
-                                          second=0,
-                                          minute=0,
-                                          hour=0)
+    if hrOffset != 0 or minOffset != 0 or secOffset != 0:
+        # purely relative time ("dans deux heures") keeps the anchor time of day
+        extractedDate = extractedDate.replace(microsecond=0, second=0)
+    else:
+        extractedDate = extractedDate.replace(microsecond=0,
+                                              second=0,
+                                              minute=0,
+                                              hour=0)
     if datestr != "":
         if not hasYear:
             temp = datetime.strptime(datestr, "%B %d")

--- a/ovos_date_parser/dates_gl.py
+++ b/ovos_date_parser/dates_gl.py
@@ -911,10 +911,14 @@ def extract_datetime_gl(text, anchorDate=None, default_time=None):
     # manipulación da data
 
     extractedDate = dateNow
-    extractedDate = extractedDate.replace(microsecond=0,
-                                          second=0,
-                                          minute=0,
-                                          hour=0)
+    if hrOffset != 0 or minOffset != 0 or secOffset != 0:
+        # purely relative time ("dentro de dúas horas") keeps the anchor time of day
+        extractedDate = extractedDate.replace(microsecond=0, second=0)
+    else:
+        extractedDate = extractedDate.replace(microsecond=0,
+                                              second=0,
+                                              minute=0,
+                                              hour=0)
     if datestr != "":
         en_months = ['january', 'february', 'march', 'april', 'may', 'june',
                      'july', 'august', 'september', 'october', 'november',

--- a/test/test_romance_relative_offset.py
+++ b/test/test_romance_relative_offset.py
@@ -1,0 +1,101 @@
+"""Relative future-offset regression tests for the Romance family.
+
+A phrase like "in two hours" must be computed from the anchor time of day,
+not from midnight: "dentro de dos horas" at 13:04 resolves to 15:04, never
+to 02:00. These tests pin the expected datetimes by hand against a fixed
+non-midnight anchor so engine output can never be used to justify the result.
+"""
+from datetime import datetime
+
+import pytest
+
+from ovos_date_parser import extract_datetime
+
+# Fixed, deliberately non-midnight anchor: 2017-06-27 13:04:00.
+ANCHOR = datetime(2017, 6, 27, 13, 4, 0)
+
+
+def _extract(text, lang):
+    res = extract_datetime(text, anchorDate=ANCHOR, lang=lang)
+    assert res is not None, f"no datetime extracted from {text!r} ({lang})"
+    return res[0]
+
+
+# Each case: (lang, phrase, expected datetime) — hand-derived from the anchor.
+HOUR_OFFSET_CASES = [
+    # Spanish
+    ("es", "en 2 horas", datetime(2017, 6, 27, 15, 4)),
+    ("es", "dentro de 2 horas", datetime(2017, 6, 27, 15, 4)),
+    ("es", "en 3 horas", datetime(2017, 6, 27, 16, 4)),
+    ("es", "en 5 horas", datetime(2017, 6, 27, 18, 4)),
+    # French
+    ("fr", "dans 2 heures", datetime(2017, 6, 27, 15, 4)),
+    ("fr", "dans deux heures", datetime(2017, 6, 27, 15, 4)),
+    ("fr", "dans 5 heures", datetime(2017, 6, 27, 18, 4)),
+    # Galician
+    ("gl", "dentro de 2 horas", datetime(2017, 6, 27, 15, 4)),
+    ("gl", "dentro de 5 horas", datetime(2017, 6, 27, 18, 4)),
+    # Portuguese
+    ("pt", "em 3 horas", datetime(2017, 6, 27, 16, 4)),
+    ("pt", "daqui a 2 horas", datetime(2017, 6, 27, 15, 4)),
+    # Italian
+    ("it", "tra 2 ore", datetime(2017, 6, 27, 15, 4)),
+    ("it", "tra 3 ore", datetime(2017, 6, 27, 16, 4)),
+]
+
+MINUTE_OFFSET_CASES = [
+    ("es", "en 30 minutos", datetime(2017, 6, 27, 13, 34)),
+    ("es", "en 45 minutos", datetime(2017, 6, 27, 13, 49)),
+    ("fr", "dans 30 minutes", datetime(2017, 6, 27, 13, 34)),
+    ("fr", "dans 45 minutes", datetime(2017, 6, 27, 13, 49)),
+    ("gl", "dentro de 30 minutos", datetime(2017, 6, 27, 13, 34)),
+    ("gl", "dentro de 45 minutos", datetime(2017, 6, 27, 13, 49)),
+    ("pt", "em 45 minutos", datetime(2017, 6, 27, 13, 49)),
+    ("it", "tra 45 minuti", datetime(2017, 6, 27, 13, 49)),
+]
+
+SECOND_OFFSET_CASES = [
+    ("es", "en 10 segundos", datetime(2017, 6, 27, 13, 4, 10)),
+    ("fr", "dans 20 secondes", datetime(2017, 6, 27, 13, 4, 20)),
+    ("it", "tra 15 secondi", datetime(2017, 6, 27, 13, 4, 15)),
+]
+
+
+@pytest.mark.parametrize("lang, phrase, expected", HOUR_OFFSET_CASES)
+def test_relative_hour_offset_from_anchor(lang, phrase, expected):
+    assert _extract(phrase, lang).replace(tzinfo=None) == expected
+
+
+@pytest.mark.parametrize("lang, phrase, expected", MINUTE_OFFSET_CASES)
+def test_relative_minute_offset_from_anchor(lang, phrase, expected):
+    assert _extract(phrase, lang).replace(tzinfo=None) == expected
+
+
+@pytest.mark.parametrize("lang, phrase, expected", SECOND_OFFSET_CASES)
+def test_relative_second_offset_from_anchor(lang, phrase, expected):
+    assert _extract(phrase, lang).replace(tzinfo=None) == expected
+
+
+# The offset must never collapse to a midnight base (the original bug):
+# a correct anchor-relative result stays on the same afternoon.
+@pytest.mark.parametrize("lang, phrase, expected", HOUR_OFFSET_CASES)
+def test_relative_hour_offset_is_not_from_midnight(lang, phrase, expected):
+    result = _extract(phrase, lang).replace(tzinfo=None)
+    assert result.hour >= ANCHOR.hour, \
+        f"{phrase!r} ({lang}) resolved to {result}, likely computed from midnight"
+    assert result.minute == ANCHOR.minute, \
+        f"{phrase!r} ({lang}) dropped the anchor minutes"
+
+
+# Absolute clock parsing must remain unaffected by the fix.
+ABSOLUTE_CASES = [
+    ("es", "a las 5 de la tarde", (17, 0)),
+    ("fr", "à 17h30", (17, 30)),
+    ("gl", "ás 5 da tarde", (17, 0)),
+]
+
+
+@pytest.mark.parametrize("lang, phrase, hm", ABSOLUTE_CASES)
+def test_absolute_clock_still_parses(lang, phrase, hm):
+    result = _extract(phrase, lang)
+    assert (result.hour, result.minute) == hm


### PR DESCRIPTION
Relative future offsets in the Romance family were computed from a midnight base instead of the anchor time of day.

## The bug

Phrases like `dentro de dos horas` (es), `dans deux heures` (fr), and `dentro de dúas horas` (gl) reset the working date to midnight before adding the offset, so at an anchor of 13:04 they resolved to 02:00 instead of 15:04. Italian and Portuguese already kept the anchor time; Spanish, French, and Galician did not.

Spanish had a second, compounding defect: the guard that captures the hour count, `int(word) < 100 and int(word) > 2400`, can never be true, so every `en N horas` collapsed to a single hour regardless of N.

| input (anchor 2017-06-27 13:04) | before | after |
|---|---|---|
| es `en 2 horas` | 01:00 | 15:04 |
| es `dentro de 3 horas` | (dropped) | 16:04 |
| fr `dans deux heures` | 02:00 | 15:04 |
| gl `dentro de 2 horas` | 02:00 | 15:04 |
| es `en 30 minutos` | 00:30 | 13:34 |

## The fix

Shared bug, duplicated across three per-language extractors (there is no common helper for this assembly step), so it is fixed in each: `dates_es.py`, `dates_fr.py`, `dates_gl.py` now keep the anchor time of day when a purely relative hour/minute/second offset is present, mirroring the existing English and Italian logic. Spanish also gets the hour-count guard corrected (`and` -> `or`).

Digit-offset handling, minute/second offsets, and absolute clock parsing (`a las 5 de la tarde`, `à 17h30`) are unaffected.

## Tests

New `test/test_romance_relative_offset.py` pins 40 cases across es/fr/gl/pt/it against a fixed non-midnight anchor (2017-06-27 13:04), with expected datetimes derived by hand — hour, minute, and second offsets, an explicit not-from-midnight assertion, and absolute-clock regression guards.

Full suite: 469 passed, 2 skipped. The single pre-existing `test_packaging` version-metadata failure is unrelated and present on `dev`.