### PR TITLE
fix: keep Italian duration-unit words out of ordinal digit conversion

### DIFF
--- a/ovos_date_parser/dates_it.py
+++ b/ovos_date_parser/dates_it.py
@@ -435,8 +435,11 @@ def extract_datetime_it(text, anchorDate=None, default_time=None):
     # digit-based time parser just like "alle 3" does; the indefinite
     # article and the fraction words keep their own meaning and are left
     # untouched
+    # the duration-unit words must survive: "secondo" is also the ordinal
+    # "second", so converting it to a digit would turn "15 secondo" into
+    # "15 2" and lose the seconds offset
     _keep_words = {'un', 'uno', 'una', "un'", 'mezzo', 'mezza', 'mezzora',
-                   'quarto', 'quarti', 'paio'}
+                   'quarto', 'quarti', 'paio', 'secondo', 'minuto', 'ora'}
     for _i, _w in enumerate(words):
         if not _w or _w[0].isdigit() or _w in _keep_words:
             continue


### PR DESCRIPTION
The spoken-clock preprocessing in extract_datetime_it rewrote any word parsing as a 1-24 numeral to its digit, but 'secondo' is also the Italian ordinal 'second', so 'tra 15 secondi' became '15 2' and the seconds offset was dropped (resolved to a bogus clock time). Keeping secondo/minuto/ora out of that conversion restores second-level offsets while preserving spoken-clock hours (alle tre, alle otto e mezza). Full suite green.