### PR TITLE
fix: resolve Basque relative-future datetime offsets

### DIFF
--- a/ovos_date_parser/dates_eu.py
+++ b/ovos_date_parser/dates_eu.py
@@ -778,32 +778,33 @@ def extract_datetime_eu(input_str, anchorDate=None, default_time=None):
                         strMM = int(strNum) - strHH * 100
                         if wordNext == "orduak":
                             used += 1
-                    elif (
-                            wordNext == "orduak" and
-                            word[0] != '0' and
-                            (
-                                    int(strNum) < 100 and
-                                    int(strNum) > 2400
-                            )):
-                        # ignores military time
-                        # "in 3 hours"
+                    elif (wordNext == "ordu" or wordNext == "orduak") \
+                            and word[0] != '0' and int(strNum) < 100:
+                        # "3 ordu barru" -> in 3 hours
                         hrOffset = int(strNum)
                         used = 2
+                        if wordNextNext in suffix_nexts:
+                            used = 3
                         isTime = False
                         hrAbs = -1
                         minAbs = -1
 
-                    elif wordNext == "minutu":
-                        # "in 10 minutes"
+                    elif wordNext == "minutu" or wordNext == "minutuak":
+                        # "10 minutu barru" -> in 10 minutes
                         minOffset = int(strNum)
                         used = 2
+                        if wordNextNext in suffix_nexts:
+                            used = 3
                         isTime = False
                         hrAbs = -1
                         minAbs = -1
-                    elif wordNext == "segundu":
-                        # in 5 seconds
+                    elif wordNext == "segundo" or wordNext == "segundu" \
+                            or wordNext == "segunduak":
+                        # "5 segundo barru" -> in 5 seconds
                         secOffset = int(strNum)
                         used = 2
+                        if wordNextNext in suffix_nexts:
+                            used = 3
                         isTime = False
                         hrAbs = -1
                         minAbs = -1
@@ -881,10 +882,13 @@ def extract_datetime_eu(input_str, anchorDate=None, default_time=None):
     # perform date manipulation
 
     extractedDate = dateNow
-    extractedDate = extractedDate.replace(microsecond=0,
-                                          second=0,
-                                          minute=0,
-                                          hour=0)
+    if hrOffset != 0 or minOffset != 0 or secOffset != 0:
+        # a purely relative hour/minute/second offset keeps the
+        # anchor time of day instead of resetting to midnight
+        extractedDate = extractedDate.replace(microsecond=0, second=0)
+    else:
+        extractedDate = extractedDate.replace(microsecond=0, second=0,
+                                              minute=0, hour=0)
     if datestr != "":
         en_months = ['january', 'february', 'march', 'april', 'may', 'june',
                      'july', 'august', 'september', 'october', 'november',

--- a/test/test_dates_eu_sentences.py
+++ b/test/test_dates_eu_sentences.py
@@ -1,0 +1,82 @@
+"""Basque datetime extraction: relative offsets, clock words and edge cases."""
+import unittest
+from datetime import datetime
+
+from ovos_config.locale import get_default_tz as default_timezone
+
+import ovos_date_parser as _odp
+
+ANCHOR = datetime(2117, 9, 3, 13, 30, 0)
+TZ = default_timezone()
+
+
+def extract(text, lang="eu", anchor=ANCHOR):
+    res = _odp.extract_datetime(text, lang=lang, anchorDate=anchor)
+    if res is not None and res[0] is not None and res[0].tzinfo is None:
+        res = [res[0].replace(tzinfo=TZ), res[1]]
+    return res
+
+
+def dt(y, mo, d, h=0, mi=0, s=0):
+    return datetime(y, mo, d, h, mi, s, tzinfo=TZ)
+
+
+class TestRelativeFuture(unittest.TestCase):
+    """"<n> <unit> barru" means "in <n> <unit>" and keeps the anchor clock."""
+
+    def test_seconds(self):
+        res = extract("15 segundo barru")
+        self.assertEqual(res[0], dt(2117, 9, 3, 13, 30, 15))
+        self.assertEqual(res[1], "")
+
+    def test_minutes(self):
+        res = extract("15 minutu barru")
+        self.assertEqual(res[0], dt(2117, 9, 3, 13, 45, 0))
+        self.assertEqual(res[1], "")
+
+    def test_hours(self):
+        res = extract("3 ordu barru")
+        self.assertEqual(res[0], dt(2117, 9, 3, 16, 30, 0))
+        self.assertEqual(res[1], "")
+
+    def test_one_minute(self):
+        self.assertEqual(extract("1 minutu barru")[0], dt(2117, 9, 3, 13, 31, 0))
+
+    def test_one_hour(self):
+        self.assertEqual(extract("1 ordu barru")[0], dt(2117, 9, 3, 14, 30, 0))
+
+    def test_one_second(self):
+        self.assertEqual(extract("1 segundo barru")[0], dt(2117, 9, 3, 13, 30, 1))
+
+    def test_five_minutes(self):
+        self.assertEqual(extract("5 minutu barru")[0], dt(2117, 9, 3, 13, 35, 0))
+
+    def test_marker_consumed(self):
+        for phrase in ("15 segundo barru", "15 minutu barru", "3 ordu barru"):
+            with self.subTest(phrase=phrase):
+                self.assertEqual(extract(phrase)[1], "")
+
+
+class TestRelativeAndClock(unittest.TestCase):
+    """Absolute day words reset the clock; part-of-day shifts to pm."""
+
+    def test_afternoon_hour(self):
+        self.assertEqual(extract("arratsaldeko 5ak")[0], dt(2117, 9, 3, 17, 0))
+
+    def test_bare_day_words(self):
+        self.assertEqual(extract("bihar")[0], dt(2117, 9, 4, 0, 0))
+        self.assertEqual(extract("gaur")[0], dt(2117, 9, 3, 0, 0))
+        self.assertEqual(extract("atzo")[0], dt(2117, 9, 2, 0, 0))
+
+
+class TestImpossibleDates(unittest.TestCase):
+    """Impossible or empty inputs must return None, never crash."""
+
+    def test_impossible_dates_return_none(self):
+        for phrase in ("otsailak 30", "urtarrilak 45", "", "xyzzy", "ordu barru"):
+            with self.subTest(phrase=phrase):
+                self.assertIsNone(extract(phrase))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Basque relative-future datetime offsets ("<n> <unit> barru", i.e. "in <n> <unit>") were largely broken.

## Bugs fixed

- **Seconds unrecognised**: `15 segundo barru` returned `None` because the matcher looked for a non-existent spelling instead of the canonical `segundo`.
- **Hours unrecognised**: `3 ordu barru` returned `None`, gated behind an unsatisfiable numeric condition; now keyed on the `ordu` unit.
- **Marker left over**: the trailing `barru` was not consumed, leaking into the remainder text.
- **Midnight base**: a purely relative hour/minute/second offset reset the clock to midnight; it now keeps the anchor time of day, so `3 ordu barru` advances three hours from the anchor.

## Behaviour (anchor 2117-09-03 13:30:00)

| Input | Before | After |
|-------|--------|-------|
| `15 segundo barru` | None | 13:30:15 |
| `15 minutu barru` | 00:15 + "barru" leftover | 13:45:00 |
| `3 ordu barru` | None | 16:30:00 |

## Tests

Adds `test/test_dates_eu_sentences.py` with natural-sentence coverage for relative offsets (singular and plural), clock/part-of-day words, and impossible-date inputs that must return `None` without crashing.