### PR TITLE
fix: preserve anchor clock and guard impossible dates in Asturian datetime

### DIFF
--- a/ovos_date_parser/dates_ast.py
+++ b/ovos_date_parser/dates_ast.py
@@ -899,10 +899,13 @@ def extract_datetime_ast(text, anchorDate=None, default_time=None):
     # manipulación de la data
 
     extractedDate = dateNow
-    extractedDate = extractedDate.replace(microsecond=0,
-                                          second=0,
-                                          minute=0,
-                                          hour=0)
+    if hrOffset != 0 or minOffset != 0 or secOffset != 0:
+        extractedDate = extractedDate.replace(microsecond=0, second=0)
+    else:
+        extractedDate = extractedDate.replace(microsecond=0,
+                                              second=0,
+                                              minute=0,
+                                              hour=0)
     if datestr != "":
         en_months = ['january', 'february', 'march', 'april', 'may', 'june',
                      'july', 'august', 'september', 'october', 'november',
@@ -928,7 +931,12 @@ def extract_datetime_ast(text, anchorDate=None, default_time=None):
         else:
             # parse against a leap year so 29 of february never raises here,
             # then resolve the actual year below
-            temp = datetime.strptime(datestr + " 2000", "%B %d %Y")
+            try:
+                temp = datetime.strptime(datestr + " 2000", "%B %d %Y")
+            except ValueError:
+                # impossible date that exists in no year (e.g. 31 of
+                # february) -> no date to extract
+                return None
             month, day = temp.month, temp.day
             year = int(currentYear)
             # advance to the next year where this day exists and is in the

--- a/test/test_dates_ast_sentences.py
+++ b/test/test_dates_ast_sentences.py
@@ -1,0 +1,165 @@
+"""Asturian datetime extraction: natural phrasing, clock words and edge cases."""
+import unittest
+from datetime import datetime
+
+from ovos_config.locale import get_default_tz as default_timezone
+
+import ovos_date_parser as _odp
+
+# whole-second anchor with a non-trivial time of day, so a relative offset
+# that ignored the anchor clock would be obvious
+ANCHOR = datetime(2117, 9, 3, 13, 30, 0)
+TZ = default_timezone()
+
+
+def extract(text, anchor=ANCHOR):
+    res = _odp.extract_datetime(text, lang="ast", anchorDate=anchor)
+    if res is not None and res[0] is not None and res[0].tzinfo is None:
+        res = [res[0].replace(tzinfo=TZ), res[1]]
+    return res
+
+
+def dt(y, mo, d, h=0, mi=0, s=0):
+    return datetime(y, mo, d, h, mi, s, tzinfo=TZ)
+
+
+class TestRelativeOffsetKeepsAnchorClock(unittest.TestCase):
+    """A bare hr/min/sec offset must be added to the anchor time of day,
+    not to midnight."""
+
+    def test_seconds(self):
+        self.assertEqual(extract("en 15 segundos")[0], dt(2117, 9, 3, 13, 30, 15))
+
+    def test_minutes(self):
+        self.assertEqual(extract("en 15 minutos")[0], dt(2117, 9, 3, 13, 45))
+
+    def test_hours(self):
+        self.assertEqual(extract("en 3 hores")[0], dt(2117, 9, 3, 16, 30))
+
+    def test_singular_units(self):
+        self.assertEqual(extract("en 1 segundu")[0], dt(2117, 9, 3, 13, 30, 1))
+        self.assertEqual(extract("en 1 minutu")[0], dt(2117, 9, 3, 13, 31))
+        self.assertEqual(extract("en 1 hora")[0], dt(2117, 9, 3, 14, 30))
+
+    def test_half_hour(self):
+        self.assertEqual(extract("en media hora")[0], dt(2117, 9, 3, 14, 0))
+
+    def test_minute_offset_carries_into_next_hour(self):
+        self.assertEqual(extract("en 90 minutos")[0], dt(2117, 9, 3, 15, 0))
+
+    def test_hour_offset_crosses_midnight(self):
+        self.assertEqual(extract("en 25 hores")[0], dt(2117, 9, 4, 14, 30))
+
+    def test_alarm_phrasing(self):
+        self.assertEqual(extract("pon una alarma en 10 minutos")[0],
+                         dt(2117, 9, 3, 13, 40))
+
+    def test_reminder_phrasing(self):
+        self.assertEqual(extract("recuérdame en 2 hores")[0],
+                         dt(2117, 9, 3, 15, 30))
+
+    def test_offset_seconds_are_exact(self):
+        # a whole-second offset must not leak fractional seconds
+        self.assertEqual(extract("en 30 segundos")[0].second, 30)
+        self.assertEqual(extract("en 30 segundos")[0].microsecond, 0)
+
+
+class TestAbsoluteClock(unittest.TestCase):
+    """Absolute spoken clock times ignore the anchor time of day."""
+
+    def test_bare_hour_word(self):
+        # 3:00 is earlier than the 13:30 anchor -> next day
+        self.assertEqual(extract("a les tres")[0], dt(2117, 9, 4, 3))
+
+    def test_one_oclock_feminine(self):
+        self.assertEqual(extract("a la una")[0], dt(2117, 9, 4, 1))
+
+    def test_afternoon_adds_twelve(self):
+        self.assertEqual(extract("a les 8 de la tarde")[0], dt(2117, 9, 3, 20))
+        self.assertEqual(extract("a les cinco de la tarde")[0],
+                         dt(2117, 9, 3, 17))
+
+    def test_morning_stays_am(self):
+        self.assertEqual(extract("a les ocho de la mañana")[0],
+                         dt(2117, 9, 4, 8))
+
+    def test_night(self):
+        self.assertEqual(extract("a les nueve de la nueche")[0],
+                         dt(2117, 9, 3, 21))
+
+    def test_bare_24h(self):
+        self.assertEqual(extract("a les 15")[0], dt(2117, 9, 3, 15))
+
+    def test_half_past(self):
+        # spoken hour is in the future -> rolls to the next day
+        self.assertEqual(extract("a les 8 y media")[0], dt(2117, 9, 4, 8, 30))
+
+    def test_quarter_past(self):
+        self.assertEqual(extract("a les 8 y cuartu")[0], dt(2117, 9, 4, 8, 15))
+
+    def test_quarter_to(self):
+        self.assertEqual(extract("a les 8 menos cuartu")[0],
+                         dt(2117, 9, 4, 7, 45))
+
+    def test_on_the_dot(self):
+        self.assertEqual(extract("a les 8 en puntu")[0], dt(2117, 9, 4, 8))
+
+
+class TestDayAndCalendar(unittest.TestCase):
+    """Day offsets and calendar dates."""
+
+    def test_day_word_offset(self):
+        self.assertEqual(extract("pa mañana")[0], dt(2117, 9, 4))
+
+    def test_today(self):
+        self.assertEqual(extract("güei")[0], dt(2117, 9, 3))
+
+    def test_yesterday(self):
+        self.assertEqual(extract("ayeri")[0], dt(2117, 9, 2))
+
+    def test_next_week(self):
+        self.assertEqual(extract("la selmana que vien")[0], dt(2117, 9, 10))
+
+    def test_in_n_days(self):
+        self.assertEqual(extract("en 3 díes")[0], dt(2117, 9, 6))
+
+    def test_day_of_month_digits(self):
+        # the day exists this year but is in the past -> next occurrence
+        self.assertEqual(extract("11 de xineru")[0], dt(2118, 1, 11))
+
+    def test_explicit_year(self):
+        self.assertEqual(extract("15 de xineru de 2020")[0], dt(2020, 1, 15))
+
+
+class TestImpossibleAndBoundaryDates(unittest.TestCase):
+    """Impossible or out-of-range inputs must resolve safely, never crash."""
+
+    def test_leap_day_resolves_to_next_leap_year(self):
+        self.assertEqual(extract("el 29 de febreru")[0], dt(2120, 2, 29))
+
+    def test_leap_day_non_leap_explicit_year(self):
+        self.assertIsNone(extract("el 29 de febreru de 2021"))
+
+    def test_february_thirty_first_is_none(self):
+        # february never has 31 days in any year -> no date, no crash
+        self.assertIsNone(extract("el 31 de febreru"))
+
+    def test_february_thirtieth_is_none(self):
+        self.assertIsNone(extract("el 30 de febreru"))
+
+    def test_april_thirty_first_is_none(self):
+        self.assertIsNone(extract("el 31 d'abril"))
+
+    def test_day_thirty_two_is_none(self):
+        self.assertIsNone(extract("el 32 de xineru"))
+
+    def test_hour_out_of_range_is_none(self):
+        self.assertIsNone(extract("a les 25"))
+
+    def test_empty_and_garbage(self):
+        self.assertIsNone(extract(""))
+        self.assertIsNone(extract("una frase ensin data"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Two datetime-parsing bugs in the Asturian (`ast`) extractor:

1. **Relative offsets ignored the anchor clock.** A bare hour/minute/second
   offset was applied on a midnight base instead of the anchor time of day.
   Against an anchor of `13:30`:
   - `en 15 segundos` returned `00:00:15` (want `13:30:15`)
   - `en 15 minutos` returned `00:15:00` (want `13:45:00`)
   - `en 3 hores` returned `03:00:00` (want `16:30:00`)

2. **Impossible dates crashed.** A calendar date with no explicit year that
   exists in no year (e.g. `el 31 de febreru`) reached `strptime` against a
   leap year and raised `ValueError`, crashing extraction instead of
   returning `None`.

## Fix

- Only zero the clock in final assembly when no relative offset is present;
  otherwise keep the anchor time of day.
- Guard the yearless date parse and return `None` for dates that exist in no
  year.

## Tests

New `test/test_dates_ast_sentences.py` covers relative offsets (seconds,
minutes, hours, singular/plural units, carry and midnight wrap, alarm and
reminder phrasing), absolute spoken clock times, day offsets, calendar
dates, and impossible/out-of-range inputs. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)