### PR TITLE
fix: Catalan relative time offsets and impossible dates

### DIFF
--- a/ovos_date_parser/dates_ca.py
+++ b/ovos_date_parser/dates_ca.py
@@ -1171,7 +1171,7 @@ def extract_datetime_ca(text, anchorDate=None, default_time=None):
                             wordNext == "hora" and
                             word[0] != '0' and
                             (
-                                    int(word) < 100 and
+                                    int(word) < 100 or
                                     int(word) > 2400
                             )):
                         # ignores military time
@@ -1272,10 +1272,14 @@ def extract_datetime_ca(text, anchorDate=None, default_time=None):
     # perform date manipulation
 
     extractedDate = dateNow
-    extractedDate = extractedDate.replace(microsecond=0,
-                                          second=0,
-                                          minute=0,
-                                          hour=0)
+    if hrOffset != 0 or minOffset != 0 or secOffset != 0:
+        # purely relative time ("d'aquí a dues hores") keeps the anchor time of day
+        extractedDate = extractedDate.replace(microsecond=0, second=0)
+    else:
+        extractedDate = extractedDate.replace(microsecond=0,
+                                              second=0,
+                                              minute=0,
+                                              hour=0)
     if datestr != "":
         en_months = ['january', 'february', 'march', 'april', 'may', 'june',
                      'july', 'august', 'september', 'october', 'november',
@@ -1288,10 +1292,14 @@ def extract_datetime_ca(text, anchorDate=None, default_time=None):
         for idx, en_month in enumerate(en_monthsShort):
             datestr = re.sub(r"\b" + re.escape(monthsShort[idx]) + r"\b", en_month, datestr)
 
-        if hasYear:
-            temp = datetime.strptime(datestr, "%B %d %Y")
-        else:
-            temp = datetime.strptime(datestr, "%B %d")
+        try:
+            if hasYear:
+                temp = datetime.strptime(datestr, "%B %d %Y")
+            else:
+                temp = datetime.strptime(datestr, "%B %d")
+        except ValueError:
+            # impossible calendar date ("el 31 de febrer") -> not a valid date
+            return None
         if extractedDate.tzinfo:
             temp = temp.replace(tzinfo=extractedDate.tzinfo)
 
@@ -1351,7 +1359,7 @@ def extract_datetime_ca(text, anchorDate=None, default_time=None):
 
 def _ca_pruning(text, symbols=True, accents=False, agressive=True):
     # agressive ca word pruning
-    words = ["l", "la", "el", "els", "les", "de", "dels",
+    words = ["l", "la", "el", "els", "les", "de", "dels", "d", "aquí",
              "ell", "ells", "me", "és", "som", "al", "a", "dins", "per",
              "aquest", "aquesta", "això", "aixina", "en", "aquell", "aquella",
              "va", "vam", "vaig", "quin", "quina"]

--- a/test/parse_tests/test_parse_ca.py
+++ b/test/parse_tests/test_parse_ca.py
@@ -83,7 +83,7 @@ class TestNormalize(unittest.TestCase):
         testExtract("quin dia va ser abans d'abans d'ahir",
                     "2017-06-24 00:00:00", "dia ser")
         testExtract("fer el sopar d'aquí 5 dies",
-                    "2017-07-02 00:00:00", "fer sopar aquí")
+                    "2017-07-02 00:00:00", "fer sopar")
         testExtract("fer el sopar en 5 dies",
                     "2017-07-02 00:00:00", "fer sopar")
         testExtract("quin temps farà demà?",
@@ -99,7 +99,7 @@ class TestNormalize(unittest.TestCase):
         testExtract("quin temps fa el divendres de matí",
                     "2017-06-30 08:00:00", "temps fa")
         testExtract("truca'm per a quedar d'aquí a 8 setmanes i 2 dies",
-                    "2017-08-24 00:00:00", "truca m quedar aquí i")
+                    "2017-08-24 00:00:00", "truca m quedar i")
         testExtract("Toca black-metal 2 dies després de divendres",
                     "2017-07-02 00:00:00", "toca black-metal")
         testExtract("Toca satanic black metal 2 dies per a aquest divendres",
@@ -111,7 +111,7 @@ class TestNormalize(unittest.TestCase):
         testExtract("dilluns, compra formatge",
                     "2017-07-03 00:00:00", "compra formatge")
         testExtract("Envia felicitacions d'aquí a 5 anys",
-                    "2022-06-27 00:00:00", "envia felicitacions aquí")
+                    "2022-06-27 00:00:00", "envia felicitacions")
         testExtract("Envia felicitacions en 5 anys",
                     "2022-06-27 00:00:00", "envia felicitacions")
         testExtract("Truca per Skype a la mare pròxim dijous a les 12:45 pm",
@@ -160,7 +160,7 @@ class TestNormalize(unittest.TestCase):
         # testExtract("dorm 3 dies després de demà",
         #            "2017-07-02 00:00:00", "dorm")
         testExtract("concerta cita d'aquí a 2 setmanes i 6 dies després de dissabte",
-                    "2017-07-21 00:00:00", "concerta cita aquí i")
+                    "2017-07-21 00:00:00", "concerta cita i")
         testExtract("comença la festa a les 8 en punt de la nit de dijous",
                     "2017-06-29 20:00:00", "comença festa")
 

--- a/test/test_dates_ca_sentences.py
+++ b/test/test_dates_ca_sentences.py
@@ -1,0 +1,145 @@
+"""Catalan datetime extraction: natural phrasing, relative offsets and edge cases."""
+import unittest
+from datetime import datetime
+
+from ovos_config.locale import get_default_tz as default_timezone
+
+import ovos_date_parser as _odp
+
+# anchor carries a non-trivial time of day so relative offsets are exercised
+ANCHOR = datetime(2117, 9, 3, 13, 30, 0)
+TZ = default_timezone()
+
+
+def extract(text, anchor=ANCHOR):
+    res = _odp.extract_datetime(text, lang="ca", anchorDate=anchor)
+    if res is not None and res[0] is not None and res[0].tzinfo is None:
+        res = [res[0].replace(tzinfo=TZ), res[1]]
+    return res
+
+
+def dt(y, mo, d, h=0, mi=0, s=0):
+    return datetime(y, mo, d, h, mi, s, tzinfo=TZ)
+
+
+class TestRelativeOffsetKeepsAnchorTime(unittest.TestCase):
+    """Purely relative offsets must add onto the anchor time of day, not midnight."""
+
+    def test_seconds(self):
+        date, leftover = extract("d'aquí a 15 segons")
+        self.assertEqual(date, dt(2117, 9, 3, 13, 30, 15))
+        self.assertEqual(leftover, "")
+
+    def test_one_second_singular(self):
+        self.assertEqual(extract("d'aquí a 1 segon")[0], dt(2117, 9, 3, 13, 30, 1))
+
+    def test_minutes(self):
+        date, leftover = extract("d'aquí a 15 minuts")
+        self.assertEqual(date, dt(2117, 9, 3, 13, 45))
+        self.assertEqual(leftover, "")
+
+    def test_one_minute_singular(self):
+        self.assertEqual(extract("d'aquí a 1 minut")[0], dt(2117, 9, 3, 13, 31))
+
+    def test_ninety_minutes_rolls_hour(self):
+        self.assertEqual(extract("d'aquí a 90 minuts")[0], dt(2117, 9, 3, 15, 0))
+
+    def test_hours(self):
+        date, leftover = extract("d'aquí a 3 hores")
+        self.assertEqual(date, dt(2117, 9, 3, 16, 30))
+        self.assertEqual(leftover, "")
+
+    def test_one_hour_singular(self):
+        self.assertEqual(extract("d'aquí a 1 hora")[0], dt(2117, 9, 3, 14, 30))
+
+    def test_two_hours(self):
+        self.assertEqual(extract("d'aquí a 2 hores")[0], dt(2117, 9, 3, 15, 30))
+
+    def test_twenty_four_hours_rolls_day(self):
+        self.assertEqual(extract("d'aquí a 24 hores")[0], dt(2117, 9, 4, 13, 30))
+
+    def test_future_marker_fully_consumed(self):
+        # the "d'aquí a" future marker must not leak into the remainder
+        for phrase in ("d'aquí a 15 segons", "d'aquí a 15 minuts",
+                       "d'aquí a 3 hores"):
+            with self.subTest(phrase=phrase):
+                self.assertEqual(extract(phrase)[1], "")
+
+
+class TestRelativeDayOffset(unittest.TestCase):
+    """Day-level relative offsets resolve to midnight of the target day."""
+
+    def test_five_days(self):
+        self.assertEqual(extract("d'aquí a 5 dies")[0], dt(2117, 9, 8))
+
+    def test_tomorrow(self):
+        self.assertEqual(extract("demà")[0], dt(2117, 9, 4))
+
+    def test_yesterday(self):
+        self.assertEqual(extract("ahir")[0], dt(2117, 9, 2))
+
+    def test_today(self):
+        self.assertEqual(extract("avui")[0], dt(2117, 9, 3))
+
+
+class TestAbsoluteClockTimes(unittest.TestCase):
+    """Explicit clock times and parts of day."""
+
+    def test_afternoon(self):
+        self.assertEqual(extract("a les 3 de la tarda")[0], dt(2117, 9, 3, 15))
+
+    def test_colon_evening(self):
+        self.assertEqual(extract("a les 23:30")[0], dt(2117, 9, 3, 23, 30))
+
+    def test_colon_midnight(self):
+        self.assertEqual(extract("a les 00:00")[0], dt(2117, 9, 3, 0, 0))
+
+    def test_morning_rolls_to_next_day(self):
+        # 08:00 already passed relative to the 13:30 anchor -> next day
+        self.assertEqual(extract("a les 8 del matí")[0], dt(2117, 9, 4, 8))
+
+
+class TestCalendarDates(unittest.TestCase):
+    """Explicit calendar dates with an explicit year."""
+
+    def test_day_month_year(self):
+        self.assertEqual(extract("el 15 de març de 2030")[0], dt(2030, 3, 15))
+
+    def test_valid_leap_day(self):
+        self.assertEqual(extract("el 29 de febrer de 2020")[0], dt(2020, 2, 29))
+
+
+class TestImpossibleDatesReturnNone(unittest.TestCase):
+    """Out-of-range calendar dates must return None, never raise."""
+
+    def test_february_31(self):
+        self.assertIsNone(extract("el 31 de febrer"))
+
+    def test_february_30(self):
+        self.assertIsNone(extract("el 30 de febrer de 2020"))
+
+    def test_non_leap_february_29(self):
+        self.assertIsNone(extract("reunió el 29 de febrer de 2021"))
+
+    def test_impossible_hour(self):
+        self.assertIsNone(extract("a les 25:00"))
+
+    def test_impossible_minute(self):
+        self.assertIsNone(extract("a les 15:70"))
+
+
+class TestNoDateReturnsNone(unittest.TestCase):
+    """Text with no temporal content yields None rather than a spurious date."""
+
+    def test_empty(self):
+        self.assertIsNone(extract(""))
+
+    def test_plain_sentence(self):
+        self.assertIsNone(extract("posa una cançó"))
+
+    def test_non_latin_junk(self):
+        self.assertIsNone(extract("посылка"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bugs fixed

**Relative offsets reset the anchor time of day.** With anchor `2117-09-03 13:30:00`:

| Phrase | Before | After |
|---|---|---|
| `d'aquí a 15 segons` | `00:00:15` (leftover `d aquí`) | `13:30:15` (clean) |
| `d'aquí a 15 minuts` | `00:15:00` | `13:45:00` |
| `d'aquí a 3 hores` | `01:00:00` | `16:30:00` |

Three underlying causes:
- Final assembly reset the base to midnight unconditionally. Purely relative offsets now keep the anchor time of day; the midnight reset applies only to day-level results.
- The "N hours" branch used an always-false guard (`int(word) < 100 and int(word) > 2400`), so the hour count fell through and collapsed to a single hour via the "half/quarter hour" path. Switched to `or` so only military `HHMM` values are excluded.
- The `d'aquí a` future marker leaked into the remainder; it is now consumed.

**Impossible calendar dates raised `ValueError`.** `el 31 de febrer`, `el 30 de febrer de 2020`, and non-leap `el 29 de febrer de 2021` now return `None` instead of crashing. Valid leap dates (`el 29 de febrer de 2020`) still parse.

## Tests

New `test/test_dates_ca_sentences.py` (28 cases): relative second/minute/hour offsets with singular and plural units, day offsets, absolute clock times and parts of day, calendar dates, impossible dates returning `None`, and no-date/junk input. Stale leftover expectations in `test_parse_ca.py` that pinned the uncleaned `aquí` marker were updated.

Full suite green (the unrelated `test_installed_metadata_matches_source` env artifact excepted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)