### PR TITLE
fix: add Finnish relative seconds offset to extract_datetime_fi

### DIFF
--- a/ovos_date_parser/dates_fi.py
+++ b/ovos_date_parser/dates_fi.py
@@ -152,6 +152,7 @@ _MONTH_UNITS_FI = ("kuukausi", "kuukautta", "kuukauden")
 _YEAR_UNITS_FI = ("vuosi", "vuotta", "vuoden")
 _HOUR_UNITS_FI = ("tunti", "tuntia", "tunnin")
 _MINUTE_UNITS_FI = ("minuutti", "minuuttia", "minuutin")
+_SECOND_UNITS_FI = ("sekunti", "sekuntia", "sekunnin")
 # adpositions that mark "in X <unit>" / "after"
 _AFTER_MARKERS_FI = ("kuluttua", "päästä", "päähän")
 _NEXT_FI = ("ensi", "seuraava", "seuraavana", "tuleva", "tulevana")
@@ -299,6 +300,7 @@ def extract_datetime_fi(text, anchorDate=None, default_time=None):
     hr_abs = None
     min_abs = None
     min_offset = 0  # relative "in N hours/minutes" offset, in minutes
+    sec_offset = 0  # relative "in N seconds" offset, in seconds
     consumed = [False] * len(words)
     found = False
 
@@ -392,6 +394,8 @@ def extract_datetime_fi(text, anchorDate=None, default_time=None):
                     min_offset += num * 60
                 elif unit in _MINUTE_UNITS_FI:
                     min_offset += num
+                elif unit in _SECOND_UNITS_FI:
+                    sec_offset += num
                 else:
                     continue
                 consumed[idx] = consumed[idx - 1] = consumed[idx - 2] = True
@@ -446,10 +450,12 @@ def extract_datetime_fi(text, anchorDate=None, default_time=None):
     has_date = (abs_month is not None or day_offset is not None or
                 week_offset or month_offset or year_offset)
 
-    if not has_date and hr_abs is None and min_offset:
-        # a pure "in N hours/minutes" offset is measured from the anchor time
-        extracted = anchor.replace(second=0, microsecond=0) + \
-            timedelta(minutes=min_offset)
+    if not has_date and hr_abs is None and (min_offset or sec_offset):
+        # a pure "in N hours/minutes/seconds" offset is measured from the anchor
+        base = anchor.replace(microsecond=0)
+        if not sec_offset:
+            base = base.replace(second=0)
+        extracted = base + timedelta(minutes=min_offset, seconds=sec_offset)
         leftover = " ".join(w for i, w in enumerate(words)
                             if not consumed[i] and w != ".")
         return [extracted, " ".join(leftover.split())]
@@ -486,6 +492,8 @@ def extract_datetime_fi(text, anchorDate=None, default_time=None):
         extracted = extracted.replace(hour=hr_abs, minute=min_abs or 0)
     if min_offset:
         extracted = extracted + timedelta(minutes=min_offset)
+    if sec_offset:
+        extracted = extracted + timedelta(seconds=sec_offset)
 
     leftover = " ".join(w for i, w in enumerate(words)
                         if not consumed[i] and w != ".")

--- a/test/test_dates_fi_sentences.py
+++ b/test/test_dates_fi_sentences.py
@@ -1,0 +1,92 @@
+"""Finnish datetime extraction: natural phrasing, relative offsets and edge cases."""
+import unittest
+from datetime import datetime
+
+from ovos_config.locale import get_default_tz as default_timezone
+
+import ovos_date_parser as _odp
+
+ANCHOR = datetime(2117, 9, 3, 13, 30, 0)
+TZ = default_timezone()
+
+
+def extract(text, lang="fi", anchor=ANCHOR):
+    res = _odp.extract_datetime(text, lang=lang, anchorDate=anchor)
+    if res is not None and res[0] is not None and res[0].tzinfo is None:
+        res = [res[0].replace(tzinfo=TZ), res[1]]
+    return res
+
+
+def dt(y, mo, d, h=0, mi=0, s=0):
+    return datetime(y, mo, d, h, mi, s, tzinfo=TZ)
+
+
+class TestRelativeSecondsOffset(unittest.TestCase):
+    """"N sekunnin päästä/kuluttua" adds a seconds offset to the anchor time."""
+
+    def test_fifteen_seconds_digits(self):
+        self.assertEqual(extract("15 sekunnin päästä")[0],
+                         dt(2117, 9, 3, 13, 30, 15))
+
+    def test_fifteen_seconds_spelled(self):
+        self.assertEqual(extract("viidentoista sekunnin päästä")[0],
+                         dt(2117, 9, 3, 13, 30, 15))
+
+    def test_thirty_seconds_kuluttua(self):
+        self.assertEqual(extract("30 sekunnin kuluttua")[0],
+                         dt(2117, 9, 3, 13, 30, 30))
+
+    def test_five_seconds_paahan(self):
+        self.assertEqual(extract("5 sekunnin päähän")[0],
+                         dt(2117, 9, 3, 13, 30, 5))
+
+    def test_seconds_preserve_anchor_seconds(self):
+        anchor = datetime(2117, 9, 3, 13, 30, 42)
+        self.assertEqual(extract("20 sekunnin päästä", anchor=anchor)[0],
+                         dt(2117, 9, 3, 13, 31, 2))
+
+    def test_seconds_rollover_minute(self):
+        self.assertEqual(extract("45 sekunnin päästä")[0],
+                         dt(2117, 9, 3, 13, 30, 45))
+
+
+class TestRelativeOffsetsStillWork(unittest.TestCase):
+    """Adding seconds must not disturb the existing minute/hour offsets."""
+
+    def test_minutes_offset(self):
+        self.assertEqual(extract("15 minuutin päästä")[0],
+                         dt(2117, 9, 3, 13, 45))
+
+    def test_hours_offset(self):
+        self.assertEqual(extract("3 tunnin päästä")[0],
+                         dt(2117, 9, 3, 16, 30))
+
+    def test_minutes_zero_the_seconds(self):
+        anchor = datetime(2117, 9, 3, 13, 30, 42)
+        self.assertEqual(extract("15 minuutin päästä", anchor=anchor)[0],
+                         dt(2117, 9, 3, 13, 45, 0))
+
+
+class TestClockAndEdgeCases(unittest.TestCase):
+    """Clock idioms parse; impossible dates return None rather than crashing."""
+
+    def test_quarter_past_seven(self):
+        self.assertEqual(extract("varttia yli seitsemän")[0].hour, 7)
+        self.assertEqual(extract("varttia yli seitsemän")[0].minute, 15)
+
+    def test_impossible_february_day(self):
+        self.assertIsNone(extract("30 helmikuuta"))
+
+    def test_leap_day_non_leap_year(self):
+        self.assertIsNone(extract("29 helmikuuta", anchor=datetime(2119, 1, 1)))
+
+    def test_leap_day_leap_year(self):
+        self.assertEqual(extract("29 helmikuuta", anchor=datetime(2120, 1, 1))[0],
+                         dt(2120, 2, 29))
+
+    def test_gibberish_returns_none(self):
+        self.assertIsNone(extract("xyzzy plugh"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`extract_datetime_fi` resolved relative hour and minute offsets but had no seconds unit, so seconds phrases returned `None`. With anchor `datetime(2117, 9, 3, 13, 30, 0)`:

- `"15 minuutin päästä"` -> `13:45:00` (worked)
- `"3 tunnin päästä"` -> `16:30:00` (worked)
- `"15 sekunnin päästä"` -> `None` (should be `13:30:15`)

## Change

- Add Finnish seconds units in their grammatical forms: nominative `sekunti`, partitive `sekuntia`, genitive `sekunnin` (the genitive is what `N sekunnin päästä` uses, mirroring `minuutin`).
- Wire seconds into the same `N <unit> kuluttua/päästä` offset path as minutes. The seconds offset preserves the anchor's seconds; the minute and hour paths keep zeroing seconds exactly as before.

## Tests

New `test/test_dates_fi_sentences.py` covers the seconds offsets (digits and spelled-out), the unchanged minute/hour offsets, that minute offsets still zero seconds, clock idioms, and impossible/leap-day guards returning `None`.