### PR TITLE
fix: guard English datetime extractor against malformed clock and offset input

### DIFF
--- a/ovos_date_parser/dates_en.py
+++ b/ovos_date_parser/dates_en.py
@@ -1096,18 +1096,23 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
                                                   minute=default_time.minute,
                                                   second=default_time.second)
 
-    if yearOffset != 0:
-        extractedDate = extractedDate + relativedelta(years=yearOffset)
-    if monthOffset != 0:
-        extractedDate = extractedDate + relativedelta(months=monthOffset)
-    if dayOffset != 0:
-        extractedDate = extractedDate + relativedelta(days=dayOffset)
-    if hrOffset != 0:
-        extractedDate = extractedDate + relativedelta(hours=hrOffset)
-    if minOffset != 0:
-        extractedDate = extractedDate + relativedelta(minutes=minOffset)
-    if secOffset != 0:
-        extractedDate = extractedDate + relativedelta(seconds=secOffset)
+    try:
+        if yearOffset != 0:
+            extractedDate = extractedDate + relativedelta(years=yearOffset)
+        if monthOffset != 0:
+            extractedDate = extractedDate + relativedelta(months=monthOffset)
+        if dayOffset != 0:
+            extractedDate = extractedDate + relativedelta(days=dayOffset)
+        if hrOffset != 0:
+            extractedDate = extractedDate + relativedelta(hours=hrOffset)
+        if minOffset != 0:
+            extractedDate = extractedDate + relativedelta(minutes=minOffset)
+        if secOffset != 0:
+            extractedDate = extractedDate + relativedelta(seconds=secOffset)
+    except (OverflowError, ValueError):
+        # a relative offset so large it cannot be represented as a datetime
+        # (e.g. "999999999999 hours"); report nothing rather than a wrong guess
+        return None
 
     if hrAbs != -1 and minAbs != -1 and not hrOffset and not minOffset and not secOffset:
         # If no time was supplied in the string set the time to default
@@ -1118,8 +1123,13 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
             hrAbs = hrAbs or 0
             minAbs = minAbs or 0
 
-        extractedDate = extractedDate.replace(hour=hrAbs,
-                                              minute=minAbs)
+        try:
+            extractedDate = extractedDate.replace(hour=hrAbs,
+                                                  minute=minAbs)
+        except ValueError:
+            # an out-of-range clock value such as "2400" or "24:00" that maps
+            # to hour 24 or beyond; report nothing rather than a wrong guess
+            return None
 
         if (hrAbs != 0 or minAbs != 0) and datestr == "":
             if not daySpecified and anchorDate > extractedDate:

--- a/test/test_dates_en_sentences.py
+++ b/test/test_dates_en_sentences.py
@@ -1,0 +1,60 @@
+"""English datetime extraction: malformed input must never raise."""
+import unittest
+from datetime import datetime
+
+from ovos_config.locale import get_default_tz as default_timezone
+
+import ovos_date_parser as _odp
+
+ANCHOR = datetime(2117, 9, 3, 13, 30, 0)
+TZ = default_timezone()
+
+
+def extract(text, lang="en", anchor=ANCHOR):
+    res = _odp.extract_datetime(text, lang=lang, anchorDate=anchor)
+    if res is not None and res[0] is not None and res[0].tzinfo is None:
+        res = [res[0].replace(tzinfo=TZ), res[1]]
+    return res
+
+
+def dt(y, mo, d, h=0, mi=0):
+    return datetime(y, mo, d, h, mi, tzinfo=TZ)
+
+
+class TestMalformedClockValues(unittest.TestCase):
+    """Out-of-range clock values must return None, never raise."""
+
+    def test_bare_2400_returns_none(self):
+        # "2400" maps to hour 24, which is not a valid clock time
+        self.assertIsNone(extract("2400"))
+
+    def test_colon_2400_returns_none(self):
+        # "24:00" likewise exceeds the 0..23 hour range
+        self.assertIsNone(extract("24:00"))
+
+
+class TestOversizedOffsets(unittest.TestCase):
+    """Relative offsets too large to represent must return None, never raise."""
+
+    def test_absurd_hour_offset_returns_none(self):
+        self.assertIsNone(extract("999999999999 hours"))
+
+    def test_absurd_year_offset_returns_none(self):
+        self.assertIsNone(extract("in 999999999999 years"))
+
+
+class TestValidSentencesUnaffected(unittest.TestCase):
+    """Well-formed inputs must keep parsing correctly."""
+
+    def test_tomorrow_at_five_pm(self):
+        self.assertEqual(extract("tomorrow at 5pm")[0], dt(2117, 9, 4, 17, 0))
+
+    def test_in_two_hours(self):
+        self.assertEqual(extract("in 2 hours")[0], dt(2117, 9, 3, 15, 30))
+
+    def test_explicit_calendar_date(self):
+        self.assertEqual(extract("june 5")[0], dt(2118, 6, 5, 0, 0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`extract_datetime` for English raised on two malformed edge inputs instead of declining to parse:

- `"2400"` and `"24:00"` built a datetime with hour 24 → `ValueError: hour must be in 0..23`
- `"999999999999 hours"` added an unrepresentable relative offset → `OverflowError: Python int too large to convert to C int`

Both now return `None`, matching the existing behaviour for impossible calendar dates like `"february 29 2019"`. `None` is the safe, verifiable result: no defensible non-null value exists for an offset that cannot be represented, and for a 24:00 clock value either interpretation would be a guess.

## Changes

- Wrap the relative-offset arithmetic in a guard that returns `None` on `OverflowError`/`ValueError`.
- Wrap the clock-hour replacement in a guard that returns `None` on out-of-range hours.
- Add `test/test_dates_en_sentences.py`: the two crash inputs (plus an oversized year offset) now return `None`, alongside valid natural sentences proving no regression.

Full suite green (the pre-existing `test_installed_metadata_matches_source` env artifact aside).

🤖 Generated with [Claude Code](https://claude.com/claude-code)