### PR TITLE
fix: return None for malformed Dutch datetimes instead of crashing

### DIFF
--- a/ovos_date_parser/dates_nl.py
+++ b/ovos_date_parser/dates_nl.py
@@ -712,7 +712,9 @@ def extract_datetime_nl(text, anchorDate=None, default_time=None):
             if timeQualifier in timeQualifiersPM and HH < 12:
                 HH += 12
 
-            if HH > 24 or MM > 59:
+            if HH > 23 or MM > 59:
+                # a clock value like "24:00" or "25:30" is not a real time;
+                # reject it rather than building an out-of-range datetime
                 isTime = False
                 used = 0
             if isTime:
@@ -766,7 +768,13 @@ def extract_datetime_nl(text, anchorDate=None, default_time=None):
         month_num = months.index(date_parts[0]) + 1
         day_num = int(date_parts[1]) if len(date_parts) > 1 else 1
         year_num = int(date_parts[2]) if len(date_parts) > 2 else 1900
-        temp = datetime(year_num, month_num, day_num)
+        try:
+            temp = datetime(year_num, month_num, day_num)
+        except ValueError:
+            # an explicit date was spoken but it does not exist on the
+            # calendar (e.g. "30 februari" or "29 februari 2019"); report
+            # nothing rather than a wrong guess
+            return None
         extractedDate = extractedDate.replace(hour=0, minute=0, second=0)
         if not hasYear:
             temp = temp.replace(year=extractedDate.year,
@@ -794,12 +802,17 @@ def extract_datetime_nl(text, anchorDate=None, default_time=None):
         if hrOffset == 0 and minOffset == 0 and secOffset == 0:
             extractedDate = extractedDate.replace(hour=0, minute=0, second=0)
 
-    if yearOffset != 0:
-        extractedDate = extractedDate + relativedelta(years=yearOffset)
-    if monthOffset != 0:
-        extractedDate = extractedDate + relativedelta(months=monthOffset)
-    if dayOffset != 0:
-        extractedDate = extractedDate + relativedelta(days=dayOffset)
+    try:
+        if yearOffset != 0:
+            extractedDate = extractedDate + relativedelta(years=yearOffset)
+        if monthOffset != 0:
+            extractedDate = extractedDate + relativedelta(months=monthOffset)
+        if dayOffset != 0:
+            extractedDate = extractedDate + relativedelta(days=dayOffset)
+    except (OverflowError, ValueError):
+        # an absurd offset like "999999999999 uur" overflows the datetime
+        # range; report nothing rather than crashing
+        return None
     if hrAbs != -1 and minAbs != -1:
         # If no time was supplied in the string set the time to default
         # time if it's available
@@ -814,12 +827,17 @@ def extract_datetime_nl(text, anchorDate=None, default_time=None):
         if (hrAbs != 0 or minAbs != 0) and datestr == "":
             if not daySpecified and anchorDate > extractedDate:
                 extractedDate = extractedDate + relativedelta(days=1)
-    if hrOffset != 0:
-        extractedDate = extractedDate + relativedelta(hours=hrOffset)
-    if minOffset != 0:
-        extractedDate = extractedDate + relativedelta(minutes=minOffset)
-    if secOffset != 0:
-        extractedDate = extractedDate + relativedelta(seconds=secOffset)
+    try:
+        if hrOffset != 0:
+            extractedDate = extractedDate + relativedelta(hours=hrOffset)
+        if minOffset != 0:
+            extractedDate = extractedDate + relativedelta(minutes=minOffset)
+        if secOffset != 0:
+            extractedDate = extractedDate + relativedelta(seconds=secOffset)
+    except (OverflowError, ValueError):
+        # an absurd offset like "999999999999 uur" overflows the datetime
+        # range; report nothing rather than crashing
+        return None
     for idx, word in enumerate(words):
         if words[idx] == "en" and \
                 words[idx - 1] == "" and words[idx + 1] == "":

--- a/test/test_dates_nl_sentences.py
+++ b/test/test_dates_nl_sentences.py
@@ -1,0 +1,124 @@
+"""Dutch datetime extraction: natural phrasing and malformed-input hardening.
+
+The adversarial cases guard against a regression where out-of-range clock
+values, impossible calendar dates and absurd offsets raised exceptions
+instead of reporting nothing.
+"""
+import unittest
+from datetime import datetime
+
+from ovos_config.locale import get_default_tz as default_timezone
+
+import ovos_date_parser as _odp
+
+ANCHOR = datetime(1998, 1, 1)
+TZ = default_timezone()
+
+
+def extract(text, lang="nl", anchor=ANCHOR):
+    res = _odp.extract_datetime(text, lang=lang, anchorDate=anchor)
+    if res is not None and res[0] is not None and res[0].tzinfo is None:
+        res = [res[0].replace(tzinfo=TZ), res[1]]
+    return res
+
+
+def dt(y, mo, d, h=0, mi=0, s=0):
+    return datetime(y, mo, d, h, mi, s, tzinfo=TZ)
+
+
+class TestNaturalPhrasing(unittest.TestCase):
+    """Ordinary Dutch date/time sentences must keep parsing correctly."""
+
+    def test_bare_hour(self):
+        self.assertEqual(extract("om 7 uur")[0], dt(1998, 1, 1, 7))
+
+    def test_24h_hour(self):
+        self.assertEqual(extract("om 19 uur")[0], dt(1998, 1, 1, 19))
+
+    def test_relative_minutes(self):
+        self.assertEqual(extract("over 15 minuten")[0], dt(1998, 1, 1, 0, 15))
+
+    def test_relative_hours(self):
+        self.assertEqual(extract("over 3 uur")[0], dt(1998, 1, 1, 3))
+
+    def test_relative_seconds(self):
+        self.assertEqual(extract("over 5 seconden")[0], dt(1998, 1, 1, 0, 0, 5))
+
+    def test_relative_days(self):
+        self.assertEqual(extract("over 2 dagen")[0], dt(1998, 1, 3))
+
+    def test_tomorrow(self):
+        self.assertEqual(extract("morgen")[0], dt(1998, 1, 2))
+
+    def test_tomorrow_at_time(self):
+        self.assertEqual(extract("morgen om 10 uur")[0], dt(1998, 1, 2, 10))
+
+    def test_next_week(self):
+        self.assertEqual(extract("volgende week")[0], dt(1998, 1, 8))
+
+    def test_next_year(self):
+        self.assertEqual(extract("volgend jaar")[0], dt(1999, 1, 1))
+
+    def test_clock_time(self):
+        self.assertEqual(extract("23:30")[0], dt(1998, 1, 1, 23, 30))
+
+    def test_explicit_date(self):
+        self.assertEqual(extract("5 januari 2020")[0], dt(2020, 1, 5))
+
+
+class TestMalformedInputReturnsNone(unittest.TestCase):
+    """Impossible input must report nothing, never raise."""
+
+    def test_hour_24_clock(self):
+        self.assertIsNone(extract("2400"))
+
+    def test_hour_24_colon(self):
+        self.assertIsNone(extract("24:00"))
+
+    def test_hour_25(self):
+        self.assertIsNone(extract("25:30"))
+
+    def test_minute_out_of_range(self):
+        self.assertIsNone(extract("12:99"))
+
+    def test_impossible_day_in_month(self):
+        self.assertIsNone(extract("30 februari"))
+
+    def test_non_leap_29_february(self):
+        self.assertIsNone(extract("29 februari 2019"))
+
+    def test_impossible_day_number(self):
+        self.assertIsNone(extract("99 januari"))
+
+    def test_absurd_hour_offset(self):
+        self.assertIsNone(extract("999999999999 uur"))
+
+    def test_absurd_minute_offset(self):
+        self.assertIsNone(extract("over 999999999999 minuten"))
+
+    def test_absurd_day_offset(self):
+        self.assertIsNone(extract("over 999999999999 dagen"))
+
+
+class TestAdversarialDoesNotCrash(unittest.TestCase):
+    """A broad fuzz of ill-formed strings must never raise."""
+
+    CASES = [
+        "", " ", "2400", "24:00", "25:99", "99:99", "0000",
+        "30 februari", "29 februari 2019", "31 april", "32 januari",
+        "999999999999 uur", "over 999999999999 seconden",
+        "uur uur uur", "half", "kwart", "over", "om om om",
+        "-1 uur", "over -5 minuten", "13de maand", "0 februari",
+    ]
+
+    def test_no_crash(self):
+        for text in self.CASES:
+            with self.subTest(text=text):
+                try:
+                    extract(text)
+                except Exception as exc:  # noqa: BLE001
+                    self.fail(f"extract({text!r}) raised {type(exc).__name__}: {exc}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The Dutch datetime extractor raised on ill-formed input rather than reporting that nothing was found:

- an out-of-range clock value such as `24:00` or `2400` built a datetime with `hour=24` and raised `ValueError: hour must be in 0..23`
- an impossible calendar date such as `30 februari` or `29 februari 2019` raised `ValueError: day is out of range for month`
- an absurd relative offset such as `999999999999 uur` raised `OverflowError`

Each of these now returns `None`, matching the reference behaviour of the English extractor: for malformed input, reporting nothing is the correct, verifiable answer.

Changes:
- reject a clock hour of 24 or greater (`24:00` is not a valid time)
- guard the explicit-date construction and return `None` for calendar dates that do not exist
- contain overflow from the relative-offset arithmetic and return `None` for absurd magnitudes

Adversarial coverage lives in `test/test_dates_nl_sentences.py`, alongside natural-phrasing cases (`om 7 uur`, `over 15 minuten`, `morgen om 10 uur`, `5 januari 2020`) that confirm normal parsing is unaffected.