### PR TITLE
fix: resolve Swedish relative-future datetime offsets and guard impossible dates

### DIFF
--- a/ovos_date_parser/dates_sv.py
+++ b/ovos_date_parser/dates_sv.py
@@ -172,7 +172,7 @@ def extract_datetime_sv(text, anchorDate=None, default_time=None):
     timeQualifier = ""
 
     timeQualifiersList = ['morgon', 'förmiddag', 'eftermiddag', 'kväll']
-    markers = ['på', 'i', 'den här', 'kring', 'efter']
+    markers = ['på', 'i', 'den här', 'kring', 'efter', 'om']
     days = ['måndag', 'tisdag', 'onsdag', 'torsdag',
             'fredag', 'lördag', 'söndag']
     months = ['januari', 'februari', 'mars', 'april', 'maj', 'juni',
@@ -395,13 +395,21 @@ def extract_datetime_sv(text, anchorDate=None, default_time=None):
                 hrAbs = 19
             used += 1
             # parse half an hour, quarter hour
-        elif wordPrev in markers or wordPrevPrev in markers:
+        elif word in ("halvtimme", "halvtimma", "kvart", "timme", "timma",
+                      "minut", "sekund") \
+                and (wordPrev in markers or wordPrevPrev in markers):
             if word == "halvtimme" or word == "halvtimma":
                 minOffset = 30
             elif word == "kvart":
                 minOffset = 15
             elif word == "timme" or word == "timma":
                 hrOffset = 1
+            elif word == "minut":
+                minOffset = 1
+            elif word == "sekund":
+                secOffset = 1
+            if wordPrevPrev in markers:
+                words[idx - 2] = ""
             words[idx - 1] = ""
             used += 1
             hrAbs = -1
@@ -536,29 +544,24 @@ def extract_datetime_sv(text, anchorDate=None, default_time=None):
                         strMM = int(word) - strHH * 100
                         if wordNext == "hours":
                             used += 1
-                    elif (
-                            wordNext == "hours" and
-                            word[0] != '0' and
-                            (
-                                    int(word) < 100 and
-                                    int(word) > 2400
-                            )):
-                        # "in 3 hours"
+                    elif wordNext in ("timme", "timma", "timmar") and \
+                            int(word) < 100:
+                        # "om 3 timmar" = "in 3 hours"
                         hrOffset = int(word)
                         used = 2
                         isTime = False
                         hrAbs = -1
                         minAbs = -1
 
-                    elif wordNext == "minutes":
-                        # "in 10 minutes"
+                    elif wordNext in ("minut", "minuter"):
+                        # "om 10 minuter" = "in 10 minutes"
                         minOffset = int(word)
                         used = 2
                         isTime = False
                         hrAbs = -1
                         minAbs = -1
-                    elif wordNext == "seconds":
-                        # in 5 seconds
+                    elif wordNext in ("sekund", "sekunder"):
+                        # "om 5 sekunder" = "in 5 seconds"
                         secOffset = int(word)
                         used = 2
                         isTime = False
@@ -661,10 +664,14 @@ def extract_datetime_sv(text, anchorDate=None, default_time=None):
     # perform date manipulation
 
     extractedDate = dateNow
-    extractedDate = extractedDate.replace(microsecond=0,
-                                          second=0,
-                                          minute=0,
-                                          hour=0)
+    if hrOffset != 0 or minOffset != 0 or secOffset != 0:
+        # purely relative time ("om 2 timmar") keeps the anchor time of day
+        extractedDate = extractedDate.replace(microsecond=0, second=0)
+    else:
+        extractedDate = extractedDate.replace(microsecond=0,
+                                              second=0,
+                                              minute=0,
+                                              hour=0)
     if datestr != "":
         # datestr is built from Swedish month names (e.g. "juni 15"),
         # which strptime("%B") cannot parse, so map the month directly.
@@ -672,7 +679,11 @@ def extract_datetime_sv(text, anchorDate=None, default_time=None):
         month_num = months.index(dateparts[0]) + 1
         day_num = int(dateparts[1])
         if hasYear:
-            temp = datetime(int(dateparts[2]), month_num, day_num)
+            try:
+                temp = datetime(int(dateparts[2]), month_num, day_num)
+            except ValueError:
+                # impossible date such as "31 april 2020"
+                return None
             extractedDate = extractedDate.replace(
                 year=temp.year, month=temp.month, day=temp.day)
         else:
@@ -688,13 +699,19 @@ def extract_datetime_sv(text, anchorDate=None, default_time=None):
             if use_this_year:
                 year = base_year
             else:
-                year = base_year + 1
-                while True:
+                # search a bounded window (any leap cycle resolves within a
+                # few years); an impossible day/month such as "31 april" never
+                # resolves, so give up and report no date instead of looping
+                year = None
+                for candidate in range(base_year + 1, base_year + 9):
                     try:
-                        datetime(year, month_num, day_num)
+                        datetime(candidate, month_num, day_num)
+                        year = candidate
                         break
                     except ValueError:
-                        year += 1
+                        continue
+                if year is None:
+                    return None
             extractedDate = extractedDate.replace(
                 year=year, month=month_num, day=day_num)
 

--- a/test/parse_tests/test_parse_sv.py
+++ b/test/parse_tests/test_parse_sv.py
@@ -68,7 +68,7 @@ class TestNormalize(unittest.TestCase):
         testExtract("vad blir morgondagens väder",
                     "2017-06-28 00:00:00", "vad blir väder")
         testExtract("påminn mig att ringa mamma om 8 veckor och 2 dagar",
-                    "2017-08-24 00:00:00", "påminn mig att ringa mamma om och")
+                    "2017-08-24 00:00:00", "påminn mig att ringa mamma och")
         testExtract("Spela Kurt Olssons musik 2 dagar från Fredag",
                     "2017-07-02 00:00:00", "spela kurt olssons musik")
         testExtract("vi möts 20:00",

--- a/test/test_dates_sv_sentences.py
+++ b/test/test_dates_sv_sentences.py
@@ -1,0 +1,142 @@
+"""Swedish datetime extraction: natural phrasing, relative offsets and edge cases."""
+import unittest
+from datetime import datetime
+
+from ovos_config.locale import get_default_tz as default_timezone
+
+import ovos_date_parser as _odp
+
+# Afternoon anchor so purely-relative offsets ("om 3 timmar") are observable:
+# a midnight anchor would hide a time-of-day reset bug.
+ANCHOR = datetime(2117, 9, 3, 13, 30, 0)
+TZ = default_timezone()
+
+
+def extract(text, lang="sv", anchor=ANCHOR):
+    res = _odp.extract_datetime(text, lang=lang, anchorDate=anchor)
+    if res is not None and res[0] is not None and res[0].tzinfo is None:
+        res = [res[0].replace(tzinfo=TZ), res[1]]
+    return res
+
+
+def dt(y, mo, d, h=0, mi=0, s=0):
+    return datetime(y, mo, d, h, mi, s, tzinfo=TZ)
+
+
+class TestRelativeFutureOffsets(unittest.TestCase):
+    """Swedish uses "om" for relative future ("om 15 minuter" = in 15 minutes).
+
+    A purely-relative offset keeps the anchor time of day; it must not reset to
+    midnight.
+    """
+
+    def test_seconds(self):
+        self.assertEqual(extract("om 15 sekunder")[0], dt(2117, 9, 3, 13, 30, 15))
+
+    def test_minutes(self):
+        self.assertEqual(extract("om 15 minuter")[0], dt(2117, 9, 3, 13, 45))
+
+    def test_hours(self):
+        self.assertEqual(extract("om 3 timmar")[0], dt(2117, 9, 3, 16, 30))
+
+    def test_ninety_minutes_rolls_hour(self):
+        self.assertEqual(extract("om 90 minuter")[0], dt(2117, 9, 3, 15, 0))
+
+    def test_single_hour(self):
+        self.assertEqual(extract("om en timme")[0], dt(2117, 9, 3, 14, 30))
+
+    def test_single_minute(self):
+        self.assertEqual(extract("om en minut")[0], dt(2117, 9, 3, 13, 31))
+
+    def test_single_second(self):
+        self.assertEqual(extract("om en sekund")[0], dt(2117, 9, 3, 13, 30, 1))
+
+    def test_half_hour(self):
+        # "en halvtimme" = half an hour = 30 minutes
+        self.assertEqual(extract("om en halvtimme")[0], dt(2117, 9, 3, 14, 0))
+
+    def test_quarter_hour(self):
+        # "en kvart" = a quarter of an hour = 15 minutes
+        self.assertEqual(extract("om en kvart")[0], dt(2117, 9, 3, 13, 45))
+
+    def test_natural_sentence(self):
+        res = extract("påminn mig om 10 minuter")
+        self.assertEqual(res[0], dt(2117, 9, 3, 13, 40))
+        self.assertEqual(res[1], "påminn mig")
+
+
+class TestRelativeDayOffsets(unittest.TestCase):
+    def test_today(self):
+        self.assertEqual(extract("idag")[0], dt(2117, 9, 3))
+
+    def test_tomorrow(self):
+        self.assertEqual(extract("imorgon")[0], dt(2117, 9, 4))
+
+    def test_day_after_tomorrow(self):
+        self.assertEqual(extract("övermorgon")[0], dt(2117, 9, 5))
+
+    def test_next_friday(self):
+        self.assertEqual(extract("nästa fredag")[0], dt(2117, 9, 10))
+
+    def test_eight_weeks(self):
+        self.assertEqual(extract("om 8 veckor")[0], dt(2117, 10, 29))
+
+
+class TestPartOfDay(unittest.TestCase):
+    def test_tomorrow_morning(self):
+        self.assertEqual(extract("imorgon morgon")[0], dt(2117, 9, 4, 8))
+
+    def test_tomorrow_noon(self):
+        self.assertEqual(extract("imorgon middag")[0], dt(2117, 9, 4, 12))
+
+    def test_tomorrow_evening(self):
+        self.assertEqual(extract("imorgon kväll")[0], dt(2117, 9, 4, 19))
+
+
+class TestAbsoluteDates(unittest.TestCase):
+    def test_this_year_christmas(self):
+        # 25 december is still ahead of the September anchor -> same year
+        self.assertEqual(extract("25 december")[0], dt(2117, 12, 25))
+
+    def test_next_occurrence_rolls_year(self):
+        # 15 juli already passed this year -> next occurrence
+        self.assertEqual(extract("15 juli")[0], dt(2118, 7, 15))
+
+    def test_leap_day_rolls_to_leap_year(self):
+        # 29 februari only exists in a leap year; 2120 is the next one
+        self.assertEqual(extract("29 februari")[0], dt(2120, 2, 29))
+
+
+class TestClock(unittest.TestCase):
+    def test_time_rolls_to_next_day(self):
+        # 10:45 already passed today -> next day
+        self.assertEqual(extract("klockan 10:45")[0], dt(2117, 9, 4, 10, 45))
+
+
+class TestImpossibleAndEmpty(unittest.TestCase):
+    """Impossible or empty input must return None, never crash or hang."""
+
+    def test_empty(self):
+        self.assertEqual(extract(""), None)
+
+    def test_april_31(self):
+        self.assertEqual(extract("31 april"), None)
+
+    def test_april_31_with_year(self):
+        self.assertEqual(extract("31 april 2020"), None)
+
+    def test_february_30(self):
+        self.assertEqual(extract("30 februari"), None)
+
+    def test_june_31(self):
+        self.assertEqual(extract("31 juni"), None)
+
+    def test_impossible_clock(self):
+        self.assertEqual(extract("klockan 25:70"), None)
+
+    def test_no_date(self):
+        self.assertEqual(extract("det finns ingen tid här"), None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Swedish `extract_datetime` recognised relative time units only through leftover English keywords and never treated "om" as a future marker, so common relative-future phrases returned `None`:

- "om 15 sekunder" → None
- "om 15 minuter" → None
- "om 3 timmar" → None

## Changes

- Recognise the Swedish relative units `timme`/`timmar`, `minut`/`minuter`, `sekund`/`sekunder`, and treat "om" as a future marker.
- Keep the anchor time of day for purely relative offsets ("om 3 timmar" from 13:30 → 16:30) instead of resetting to midnight.
- Guard the half-hour/quarter-hour marker branch so it only fires on its own unit words, not on any marker-preceded token.
- Return `None` for impossible dates such as "31 april" or "30 februari" instead of looping forever while searching for a valid year.

## Verification

- "om en halvtimme" → +30 min, "om en kvart" → +15 min, "om en minut"/"om en sekund" → +1 unit.
- Next-occurrence and leap-year semantics preserved ("15 juli" rolls to next year, "29 februari" rolls to the next leap year).
- New natural-sentence suite in `test/test_dates_sv_sentences.py`; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)