### PR TITLE
fix: guard Occitan datetime extractor against numeric time tokens with letter suffixes

### DIFF
--- a/ovos_date_parser/dates_oc.py
+++ b/ovos_date_parser/dates_oc.py
@@ -780,16 +780,16 @@ def extract_datetime_oc(text, anchorDate=None, default_time=None):
                         isTime = False
                         hrAbs = -1
                         minAbs = -1
-                    elif int(word) > 100:
-                        strHH = str(int(word) // 100)
-                        strMM = str(int(word) % 100)
+                    elif strNum and int(strNum) > 100:
+                        strHH = str(int(strNum) // 100)
+                        strMM = str(int(strNum) % 100)
                         if wordNext == "ora":
                             used += 1
                     elif wordNext == "":
-                        strHH = word
+                        strHH = strNum
                         strMM = 00
                     elif wordNext[0].isdigit():
-                        strHH = word
+                        strHH = strNum
                         strMM = wordNext
                         used += 1
                         if wordNextNext == "ora":

--- a/test/test_dates_oc_sentences.py
+++ b/test/test_dates_oc_sentences.py
@@ -143,5 +143,31 @@ class TestImpossibleAndAbsentDates(unittest.TestCase):
         self.assertEqual(extract("1 de genier de 2119")[0], dt(2119, 1, 1, 0, 0))
 
 
+class TestNumericTimeTokensWithLetterSuffix(unittest.TestCase):
+    """Glued time tokens like '20h' must parse without raising ValueError."""
+
+    def test_bare_hour_suffix(self):
+        self.assertEqual(extract("20h")[0], dt(2117, 9, 3, 20, 0))
+
+    def test_preposition_hour_suffix(self):
+        self.assertEqual(extract("a 20h")[0], dt(2117, 9, 3, 20, 0))
+
+    def test_hour_minute_suffix(self):
+        self.assertEqual(extract("21h30")[0], dt(2117, 9, 3, 21, 30))
+
+    def test_impossible_glued_hour_does_not_raise(self):
+        # 99h is not a valid clock reading; must not crash on the letter suffix
+        try:
+            extract("99h")
+        except ValueError:
+            self.fail("extract('99h') raised ValueError")
+
+    def test_letter_only_token_does_not_raise(self):
+        try:
+            self.assertIsNone(extract("hhh"))
+        except ValueError:
+            self.fail("extract('hhh') raised ValueError")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Time-of-day tokens with a glued letter suffix, such as `20h`, `a 20h` or `21h30`, reached the Occitan time parsing branch and were passed directly to `int()`, raising `ValueError: invalid literal for int() with base 10: '20h'`.

The fix uses the digits-only prefix already computed for the token (`strNum`) for the hour value, guarded by a truthy check, mirroring the pattern used in the equivalent branches of the other Romance-language extractors. Glued tokens now resolve to the correct hour instead of crashing.

Verified: `a 20h` and `20h` resolve to 20:00, `21h30` to 21:30. Added adversarial tests covering the glued forms plus impossible (`99h`) and letter-only (`hhh`) tokens that must not raise.