### PR TITLE
fix: guard generic duration resolver against overflow from huge values

### DIFF
--- a/ovos_date_parser/duration.py
+++ b/ovos_date_parser/duration.py
@@ -170,7 +170,12 @@ def _resolve(values: Dict[str, float],
             + values.get("millenniums", 0) * 1000 * DAYS_IN_1_YEAR
         if days:
             td["days"] = days
-        return timedelta(**td)
+        try:
+            return timedelta(**td)
+        except OverflowError:
+            # values too large for timedelta to represent; treat as no
+            # duration found rather than crashing the caller
+            return None
 
     if resolution in (DurationResolution.RELATIVEDELTA,
                       DurationResolution.RELATIVEDELTA_STRICT,

--- a/test/test_multilang_invariants.py
+++ b/test/test_multilang_invariants.py
@@ -83,6 +83,19 @@ class TestDuration(unittest.TestCase):
                 duration, _ = extract_duration(phrase, lang)
                 self.assertEqual(duration, timedelta(minutes=5))
 
+    def test_overflow_huge_value_returns_none(self):
+        # values too large for timedelta must not crash the caller
+        for phrase in ("in 999999999999999999999 seconds",
+                       "999999999999999999999 days",
+                       "1000000000000000000000000 hours"):
+            with self.subTest(phrase=phrase):
+                duration, _ = extract_duration(phrase, "en")
+                self.assertIsNone(duration)
+
+    def test_in_range_duration_still_parses_after_guard(self):
+        duration, _ = extract_duration("2 days", "en")
+        self.assertEqual(duration, timedelta(days=2))
+
 
 class TestNoDate(unittest.TestCase):
     def test_dateless_text_returns_none(self):


### PR DESCRIPTION
Parsing a duration phrase with an astronomically large unit count, such as `extract_duration("in 999999999999999999999 seconds", "en")`, crashed with an unhandled `OverflowError: Python int too large to convert to C int`. The value overflowed the range `timedelta` can represent, and the error propagated out of the resolver to the caller.

The generic duration resolver now wraps the `timedelta` construction so an out-of-range value resolves to "no duration found" (returns `None`) instead of crashing. In-range durations are unaffected.

Affects any language routed through `extract_duration_generic` (English and others), since they share this resolver.

## Tests
- Huge-value phrases (huge seconds, huge days, huge hours) return `None` without raising.
- A normal in-range duration still parses and round-trips.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when parsing duration values that exceed supported time limits.
  * Excessively large durations now return no result instead of raising an error.
  * Confirmed that normal duration phrases, such as “2 days,” continue to parse correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->