### PR TITLE
fix: return None for empty Swedish duration input instead of crashing

### DIFF
--- a/ovos_date_parser/dates_sv.py
+++ b/ovos_date_parser/dates_sv.py
@@ -783,6 +783,10 @@ def extract_duration_sv(text):
     """
     tokens = tokenize(text)
     number_tok_map = _find_numbers_in_text(tokens)
+    if not number_tok_map:
+        # No numbers means no duration; also avoids indexing an empty
+        # token list downstream when the input is empty or whitespace.
+        return None
     # Combine adjacent numbers
     simplified = _combine_adjacent_numbers(number_tok_map)
 

--- a/test/test_dates_sv_sentences.py
+++ b/test/test_dates_sv_sentences.py
@@ -138,5 +138,33 @@ class TestImpossibleAndEmpty(unittest.TestCase):
         self.assertEqual(extract("det finns ingen tid här"), None)
 
 
+class TestDurationEdgeCases(unittest.TestCase):
+    """extract_duration must signal 'no duration' with None, never crash."""
+
+    def test_empty_string(self):
+        self.assertIsNone(_odp.extract_duration("", lang="sv"))
+
+    def test_whitespace_only(self):
+        self.assertIsNone(_odp.extract_duration("   ", lang="sv"))
+
+    def test_tabs_and_newlines(self):
+        self.assertIsNone(_odp.extract_duration("\t\n  ", lang="sv"))
+
+    def test_gibberish(self):
+        self.assertIsNone(_odp.extract_duration("blahonga foo bar", lang="sv"))
+
+    def test_words_without_numbers(self):
+        self.assertIsNone(_odp.extract_duration("minuter och sekunder", lang="sv"))
+
+    def test_normal_duration_still_parses(self):
+        td, remainder = _odp.extract_duration("5 minuter", lang="sv")
+        self.assertEqual(td.total_seconds(), 300)
+
+    def test_compound_duration_still_parses(self):
+        td, remainder = _odp.extract_duration(
+            "2 timmar och 30 minuter", lang="sv")
+        self.assertEqual(td.total_seconds(), 2 * 3600 + 30 * 60)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

`extract_duration("", "sv")` and `extract_duration("   ", "sv")` raised `IndexError: list index out of range`. Empty or whitespace-only input tokenized to an empty number map, which was then indexed by its last element downstream.

## Fix

`extract_duration_sv` now returns `None` when no numbers are found in the input, matching the existing "no duration found" return shape. Whitespace-only, empty, and number-free gibberish inputs return `None`; normal Swedish durations are unaffected.

## Behavior

| Input | Before | After |
|-------|--------|-------|
| `""` | IndexError | `None` |
| `"   "` | IndexError | `None` |
| `"blahonga foo bar"` | `None` | `None` |
| `"5 minuter"` | `(0:05:00, "")` | `(0:05:00, "")` |

## Tests

Added a `TestDurationEdgeCases` suite covering empty, whitespace, tabs/newlines, gibberish, number-free words, and round-trip parsing of simple and compound durations.