### PR TITLE
fix: guard Greek datetime extractor against numeric time tokens with letter suffixes

### DIFF
--- a/ovos_date_parser/dates_el.py
+++ b/ovos_date_parser/dates_el.py
@@ -772,36 +772,36 @@ def extract_datetime_el(text, anchorDate=None, default_time=None):
                         remainder = "am" if 0 < int(strNum) < 6 else "pm"
                         used = 1
                     elif wordNext == "ωρα" and word[0] != '0' and \
-                            int(word) < 100:
-                        hrOffset = int(word)
+                            strNum and int(strNum) < 100:
+                        hrOffset = int(strNum)
                         used = 2
                         isTime = False
                         hrAbs = -1
                         minAbs = -1
                     elif wordNext == "λεπτο":
-                        minOffset = int(word)
+                        minOffset = int(strNum)
                         used = 2
                         isTime = False
                         hrAbs = -1
                         minAbs = -1
                     elif wordNext == "δευτερολεπτο":
-                        secOffset = int(word)
+                        secOffset = int(strNum)
                         used = 2
                         isTime = False
                         hrAbs = -1
                         minAbs = -1
-                    elif int(word) > 100:
-                        strHH = str(int(word) // 100)
-                        strMM = str(int(word) % 100)
+                    elif strNum and int(strNum) > 100:
+                        strHH = str(int(strNum) // 100)
+                        strMM = str(int(strNum) % 100)
                         if wordNext == "ωρα":
                             used += 1
                     elif wordNext == "" or wordNext == "ακριβωσ":
-                        strHH = word
+                        strHH = strNum
                         strMM = 0
                         if wordNext == "ακριβωσ":
                             used += 1
                     elif wordNext and wordNext[0].isdigit():
-                        strHH = word
+                        strHH = strNum
                         strMM = wordNext
                         used += 1
                         if wordNextNext == "ωρα":

--- a/test/test_dates_el.py
+++ b/test/test_dates_el.py
@@ -233,6 +233,26 @@ class TestExtractDatetimeEl(unittest.TestCase):
         self.assertIsNone(extract_datetime_el("25:99",
                                               anchorDate=self.anchor))
 
+    def test_numeric_time_letter_suffix_no_crash(self):
+        # "20h" glues digits to a trailing letter; the extractor must not
+        # feed the raw token to int() and crash on it
+        res = extract_datetime_el("20h", anchorDate=self.anchor)
+        self.assertIsNotNone(res)
+        self.assertEqual(res[0].hour, 20)
+        self.assertEqual(res[0].minute, 0)
+
+    def test_numeric_time_hhmm_letter_suffix_no_crash(self):
+        # "21h30" packs hours and minutes around a letter separator
+        res = extract_datetime_el("21h30", anchorDate=self.anchor)
+        self.assertIsNotNone(res)
+        self.assertEqual(res[0].hour, 21)
+        self.assertEqual(res[0].minute, 30)
+
+    def test_impossible_numeric_time_suffix_no_crash(self):
+        # digits glued to gibberish letters must resolve to None, not raise
+        self.assertIsNone(extract_datetime_el("99z9foo",
+                                              anchorDate=self.anchor))
+
     def test_returns_pair(self):
         res = extract_datetime_el("σήμερα", anchorDate=self.anchor)
         self.assertIsInstance(res, list)


### PR DESCRIPTION
## Problem

`extract_datetime("20h", "el")` raised `ValueError: invalid literal for int() with base 10: '20h'`. Digit-leading tokens with a trailing letter (`20h`, `21h30`) reached the time-of-day branch, which called `int()` on the raw token still carrying its letter suffix.

## Fix

Parse the digits-only prefix (`strNum`, already computed in the block) instead of the raw token, guarding each conversion on a truthy prefix. This mirrors the guarded pattern already used in the Portuguese extractor.

## Verification

- `20h` -> 20:00, `21h30` -> 21:30 (no crash)
- gibberish `99z9foo` -> None (no crash)
- Full suite green (pre-existing packaging-metadata failure unrelated); 3 adversarial tests added covering letter-suffixed and impossible numeric time tokens.