### PR TITLE
fix: guard Asturian datetime extractor against numeric time tokens with letter suffixes

### DIFF
--- a/ovos_date_parser/dates_ast.py
+++ b/ovos_date_parser/dates_ast.py
@@ -806,35 +806,35 @@ def extract_datetime_ast(text, anchorDate=None, default_time=None):
                         used = 1
                     elif (wordNext == "hora" and
                           word[0] != '0' and
-                          int(word) < 100):
+                          strNum and int(strNum) < 100):
                         # en 3 hores
-                        hrOffset = int(word)
+                        hrOffset = int(strNum)
                         used = 2
                         isTime = False
                         hrAbs = -1
                         minAbs = -1
                     elif wordNext == "minutu":
                         # en 10 minutos
-                        minOffset = int(word)
+                        minOffset = int(strNum)
                         used = 2
                         isTime = False
                         hrAbs = -1
                         minAbs = -1
                     elif wordNext == "segundu":
                         # en 5 segundos
-                        secOffset = int(word)
+                        secOffset = int(strNum)
                         used = 2
                         isTime = False
                         hrAbs = -1
                         minAbs = -1
-                    elif int(word) > 100:
-                        strHH = str(int(word) // 100)
-                        strMM = str(int(word) % 100)
+                    elif strNum and int(strNum) > 100:
+                        strHH = str(int(strNum) // 100)
+                        strMM = str(int(strNum) % 100)
                         if wordNext == "hora":
                             used += 1
                     elif wordNext == "" or (
                             wordNext == "en" and wordNextNext == "puntu"):
-                        strHH = word
+                        strHH = strNum
                         strMM = 00
                         if wordNext == "en" and wordNextNext == "puntu":
                             used += 2
@@ -851,7 +851,7 @@ def extract_datetime_ast(text, anchorDate=None, default_time=None):
                                     remainder = "pm"
                                 used += 1
                     elif wordNext[0].isdigit():
-                        strHH = word
+                        strHH = strNum
                         strMM = wordNext
                         used += 1
                         if wordNextNext == "hora":

--- a/test/test_dates_ast_sentences.py
+++ b/test/test_dates_ast_sentences.py
@@ -161,5 +161,34 @@ class TestImpossibleAndBoundaryDates(unittest.TestCase):
         self.assertIsNone(extract("una frase ensin data"))
 
 
+class TestNumericTimeWithLetterSuffix(unittest.TestCase):
+    """A numeric time token carrying a trailing letter (``20h``, ``21h30``)
+    must parse from its digit prefix instead of crashing on ``int()``."""
+
+    def test_bare_hour_suffix(self):
+        self.assertEqual(extract("20h")[0], dt(2117, 9, 3, 20, 0))
+
+    def test_hour_suffix_with_preposition(self):
+        self.assertEqual(extract("a les 20h")[0], dt(2117, 9, 3, 20, 0))
+
+    def test_hour_and_minutes_suffix(self):
+        self.assertEqual(extract("21h30")[0], dt(2117, 9, 3, 21, 30))
+
+    def test_hour_and_minutes_suffix_with_preposition(self):
+        self.assertEqual(extract("a les 21h30")[0], dt(2117, 9, 3, 21, 30))
+
+    def test_hour_suffix_on_the_dot(self):
+        self.assertEqual(
+            extract("a les 20h en puntu")[0], dt(2117, 9, 3, 20, 0))
+
+    def test_letter_only_token_does_not_crash(self):
+        # no digit prefix at all: must fall through, never reach int("")
+        self.assertIsNone(extract("hhh"))
+
+    def test_impossible_hour_suffix_is_none(self):
+        # 25h is out of range once parsed; must reject, not raise
+        self.assertIsNone(extract("a les 25h"))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Asturian time extraction crashed on numeric tokens that carry a trailing letter.

## Bug

`extract_datetime("a les 20h", "ast")` raised `ValueError: invalid literal for int() with base 10: '20h'`. Native clock phrasings like "20h", "21h30" hit the time-of-day branch, where the raw glued token was passed to `int()`.

## Fix

The block already computes `strNum`, the digit-only prefix of the token. The time-of-day branch now reads the hour and minutes from `strNum` (guarded by truthiness for the military-time and offset cases), mirroring the pattern already used in the Portuguese extractor. Letter-only or out-of-range tokens now fall through and return `None` instead of raising.

- `a les 20h` -> 20:00 (was: crash)
- `21h30` -> 21:30
- `a les 25h` / `hhh` -> `None` (no crash)

## Tests

Adds `TestNumericTimeWithLetterSuffix` covering the digit+letter parses, on-the-dot phrasing, a letter-only token, and an impossible hour — including break-the-code cases that must not raise. Full suite green (pre-existing packaging-metadata test aside).