### PR TITLE
fix: guard Catalan datetime extractor against numeric time tokens with letter suffixes

### DIFF
--- a/ovos_date_parser/dates_ca.py
+++ b/ovos_date_parser/dates_ca.py
@@ -1155,28 +1155,28 @@ def extract_datetime_ca(text, anchorDate=None, default_time=None):
                         strHH = strNum
                         remainder = "am"
                         used = 1
-                    elif (int(word) > 100 and
+                    elif (strNum and int(strNum) > 100 and
                           (
                                   wordPrev == "o" or
                                   wordPrev == "oh" or
                                   wordPrev == "zero"
                           )):
                         # 0800 hours (pronounced oh-eight-hundred)
-                        strHH = int(word) / 100
-                        strMM = int(word) - strHH * 100
+                        strHH = int(strNum) // 100
+                        strMM = int(strNum) - strHH * 100
                         military = True
                         if wordNext == "hora":
                             used += 1
                     elif (
                             wordNext == "hora" and
-                            word[0] != '0' and
+                            word[0] != '0' and strNum and
                             (
-                                    int(word) < 100 or
-                                    int(word) > 2400
+                                    int(strNum) < 100 or
+                                    int(strNum) > 2400
                             )):
                         # ignores military time
                         # "in 3 hours"
-                        hrOffset = int(word)
+                        hrOffset = int(strNum)
                         used = 2
                         isTime = False
                         hrAbs = -1
@@ -1184,28 +1184,28 @@ def extract_datetime_ca(text, anchorDate=None, default_time=None):
 
                     elif wordNext == "minut":
                         # "in 10 minutes"
-                        minOffset = int(word)
+                        minOffset = int(strNum)
                         used = 2
                         isTime = False
                         hrAbs = -1
                         minAbs = -1
                     elif wordNext == "segon":
                         # in 5 seconds
-                        secOffset = int(word)
+                        secOffset = int(strNum)
                         used = 2
                         isTime = False
                         hrAbs = -1
                         minAbs = -1
-                    elif int(word) > 100:
-                        strHH = int(word) / 100
-                        strMM = int(word) - strHH * 100
+                    elif strNum and int(strNum) > 100:
+                        strHH = int(strNum) // 100
+                        strMM = int(strNum) - strHH * 100
                         military = True
                         if wordNext == "hora":
                             used += 1
 
                     elif wordNext == "" or (
                             wordNext == "en" and wordNextNext == "punt"):
-                        strHH = word
+                        strHH = strNum
                         strMM = 00
                         if wordNext == "en" and wordNextNext == "punt":
                             used += 2
@@ -1223,7 +1223,7 @@ def extract_datetime_ca(text, anchorDate=None, default_time=None):
                                 used += 1
 
                     elif wordNext[0].isdigit():
-                        strHH = word
+                        strHH = strNum
                         strMM = wordNext
                         military = True
                         used += 1

--- a/test/test_dates_ca_sentences.py
+++ b/test/test_dates_ca_sentences.py
@@ -141,5 +141,29 @@ class TestNoDateReturnsNone(unittest.TestCase):
         self.assertIsNone(extract("посылка"))
 
 
+class TestNumericTimeWithLetterSuffix(unittest.TestCase):
+    """Glued time tokens like "20h" must parse, never raise on int() of the raw token."""
+
+    def test_bare_hour_suffix(self):
+        self.assertEqual(extract("20h")[0], dt(2117, 9, 3, 20, 0))
+
+    def test_a_les_hour_suffix(self):
+        self.assertEqual(extract("a les 20h")[0], dt(2117, 9, 3, 20, 0))
+
+    def test_hour_minute_suffix(self):
+        self.assertEqual(extract("21h30")[0], dt(2117, 9, 3, 21, 30))
+
+    def test_a_les_hour_minute_suffix(self):
+        self.assertEqual(extract("a les 21h30")[0], dt(2117, 9, 3, 21, 30))
+
+    def test_impossible_hour_suffix_no_crash(self):
+        # out-of-range hour must resolve to None, not raise
+        self.assertIsNone(extract("a les 99h"))
+
+    def test_non_numeric_suffix_no_crash(self):
+        # gibberish glued token must not reach int() and blow up
+        self.assertIsNone(extract("a les xxh"))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Catalan `extract_datetime` raised `ValueError: invalid literal for int()` on time tokens that glue digits to a letter — "20h", "a les 20h", "21h30" — because the time-of-day branch called `int()` on the raw token.

The digit-only prefix is now parsed into `strNum` and the numeric branches are guarded on it, matching the pattern already used by the Portuguese extractor. Glued tokens resolve to a clock time and gibberish resolves to None, neither raises.

- "20h" / "a les 20h" -> 20:00
- "21h30" -> 21:30
- out-of-range and non-numeric suffixes return None

Adds six extraction tests covering the glued-token cases and the break-the-code paths. Full suite green (pre-existing packaging metadata test unaffected).