### PR TITLE
fix: guard Galician datetime extractor against numeric time tokens with letter suffixes

### DIFF
--- a/ovos_date_parser/dates_gl.py
+++ b/ovos_date_parser/dates_gl.py
@@ -817,36 +817,36 @@ def extract_datetime_gl(text, anchorDate=None, default_time=None):
                             remainder = "pm"
                         used = 1
                     elif (wordNext == "hora" and
-                          word[0] != '0' and
-                          int(word) < 100):
+                          word[0] != '0' and strNum and
+                          int(strNum) < 100):
                         # en 3 horas
-                        hrOffset = int(word)
+                        hrOffset = int(strNum)
                         used = 2
                         isTime = False
                         hrAbs = -1
                         minAbs = -1
                     elif wordNext == "minuto":
                         # en 10 minutos
-                        minOffset = int(word)
+                        minOffset = int(strNum)
                         used = 2
                         isTime = False
                         hrAbs = -1
                         minAbs = -1
                     elif wordNext == "segundo":
                         # en 5 segundos
-                        secOffset = int(word)
+                        secOffset = int(strNum)
                         used = 2
                         isTime = False
                         hrAbs = -1
                         minAbs = -1
-                    elif int(word) > 100:
-                        strHH = str(int(word) // 100)
-                        strMM = str(int(word) % 100)
+                    elif strNum and int(strNum) > 100:
+                        strHH = str(int(strNum) // 100)
+                        strMM = str(int(strNum) % 100)
                         if wordNext == "hora":
                             used += 1
                     elif wordNext == "" or (
                             wordNext == "en" and wordNextNext == "punto"):
-                        strHH = word
+                        strHH = strNum
                         strMM = 00
                         if wordNext == "en" and wordNextNext == "punto":
                             used += 2
@@ -863,7 +863,7 @@ def extract_datetime_gl(text, anchorDate=None, default_time=None):
                                     remainder = "pm"
                                 used += 1
                     elif wordNext[0].isdigit():
-                        strHH = word
+                        strHH = strNum
                         strMM = wordNext
                         used += 1
                         if wordNextNext == "hora":

--- a/test/test_dates_gl.py
+++ b/test/test_dates_gl.py
@@ -146,5 +146,38 @@ class TestExtractDurationGL(unittest.TestCase):
         self.assertEqual(extract_duration_gl("pon a mesa"), (None, "pon a mesa"))
 
 
+class TestExtractDatetimeNumericTimeSuffixGL(unittest.TestCase):
+    """Numeric time tokens carrying a letter suffix ("20h", "21h30")
+    must parse without crashing on int() of the raw glued token."""
+
+    def setUp(self):
+        self.anchor = datetime(2117, 9, 3, 13, 30, 0)
+
+    def _dt(self, text):
+        return extract_datetime_gl(text, anchorDate=self.anchor)
+
+    def test_hour_with_h_suffix(self):
+        dt, _ = self._dt("20h")
+        self.assertEqual(dt, datetime(2117, 9, 3, 20, 0))
+
+    def test_as_hour_with_h_suffix(self):
+        dt, _ = self._dt("ás 20h")
+        self.assertEqual(dt, datetime(2117, 9, 3, 20, 0))
+
+    def test_hour_minute_glued_suffix(self):
+        dt, _ = self._dt("21h30")
+        self.assertEqual(dt, datetime(2117, 9, 3, 21, 30))
+
+    def test_gibberish_after_time_token_does_not_crash(self):
+        # impossible / junk trailing content must not raise, just yield None
+        self.assertIsNone(self._dt("ás 20h e 45m gzqx 99h"))
+
+    def test_bare_letter_suffix_token_does_not_crash(self):
+        # a suffixed 4-digit-ish number must not crash on int() of "500x";
+        # the digit prefix drives military-time parsing instead
+        dt, _ = self._dt("blah 500x blah")
+        self.assertEqual(dt, datetime(2117, 9, 4, 5, 0))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Galician time notations like "20h", "ás 20h" and "21h30" produce a digit-leading token that still carries its trailing letters. The clock-parsing branch called `int()` on the raw token, so `extract_datetime("ás 20h", "gl")` raised `ValueError: invalid literal for int() with base 10: '20h'`.

The block already computes `strNum`, the digits-only prefix. This change routes every integer conversion in that branch through `strNum` under a truthy guard, matching the Portuguese extractor which already handles these tokens. `"ás 20h"` now yields 20:00 and `"21h30"` yields 21:30, while junk input returns `None` instead of crashing.

Adds adversarial coverage for suffixed hour, `ás`-prefixed hour, glued hour+minute, trailing gibberish, and a bare suffixed number.