### PR TITLE
fix: guard Romanian datetime extractor against numeric time tokens with letter suffixes

### DIFF
--- a/ovos_date_parser/dates_ro.py
+++ b/ovos_date_parser/dates_ro.py
@@ -800,36 +800,36 @@ def extract_datetime_ro(text, anchorDate=None, default_time=None):
                             remainder = "pm"
                         used = 1
                     elif (wordNext == "oră" and
-                          word[0] != '0' and
-                          int(word) < 100):
+                          word[0] != '0' and strNum and
+                          int(strNum) < 100):
                         # peste 3 ore
-                        hrOffset = int(word)
+                        hrOffset = int(strNum)
                         used = 2
                         isTime = False
                         hrAbs = -1
                         minAbs = -1
                     elif wordNext == "minut":
                         # peste 10 minute
-                        minOffset = int(word)
+                        minOffset = int(strNum)
                         used = 2
                         isTime = False
                         hrAbs = -1
                         minAbs = -1
                     elif wordNext == "secundă":
                         # peste 5 secunde
-                        secOffset = int(word)
+                        secOffset = int(strNum)
                         used = 2
                         isTime = False
                         hrAbs = -1
                         minAbs = -1
-                    elif int(word) > 100:
-                        strHH = str(int(word) // 100)
-                        strMM = str(int(word) % 100)
+                    elif strNum and int(strNum) > 100:
+                        strHH = str(int(strNum) // 100)
+                        strMM = str(int(strNum) % 100)
                         if wordNext == "oră":
                             used += 1
                     elif wordNext == "fix" or wordNext == "" or \
                             wordPrev == "ora" or wordPrev == "la":
-                        strHH = word
+                        strHH = strNum
                         strMM = 00
                         if wordNext == "fix":
                             used += 1
@@ -843,7 +843,7 @@ def extract_datetime_ro(text, anchorDate=None, default_time=None):
                                 remainder = "pm"
                                 used += 1
                     elif wordNext[0].isdigit():
-                        strHH = word
+                        strHH = strNum
                         strMM = wordNext
                         used += 1
                         if wordNextNext == "oră":

--- a/test/test_dates_ro.py
+++ b/test/test_dates_ro.py
@@ -1,0 +1,58 @@
+import unittest
+from datetime import datetime
+
+from ovos_date_parser.dates_ro import extract_datetime_ro
+
+
+class TestExtractDatetimeRO(unittest.TestCase):
+    """Romanian datetime extraction must survive numeric tokens carrying a
+    letter suffix (e.g. "20h") without raising on int() of the raw token."""
+
+    anchor = datetime(2117, 9, 3, 13, 30, 0)
+
+    def _extract(self, text):
+        return extract_datetime_ro(text, anchorDate=self.anchor)
+
+    def test_glued_hour_suffix(self):
+        # "20h" is a single token whose int() would fail on the trailing "h"
+        result = self._extract("20h")
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0].hour, 20)
+        self.assertEqual(result[0].minute, 0)
+
+    def test_la_glued_hour_suffix(self):
+        result = self._extract("la 20h")
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0].hour, 20)
+        self.assertEqual(result[0].minute, 0)
+
+    def test_glued_hour_minute_suffix(self):
+        # "21h30" collapses to 21:30 without crashing
+        result = self._extract("21h30")
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0].hour, 21)
+        self.assertEqual(result[0].minute, 30)
+
+    def test_ora_glued_hour_suffix(self):
+        result = self._extract("la ora 20h")
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0].hour, 20)
+
+    def test_gibberish_with_suffix_does_not_crash(self):
+        # a non-time token containing digits+letters must not raise
+        result = self._extract("fkjdslf20h ceva")
+        # no meaningful time to extract, but the call must return, not raise
+        self.assertIsNone(result)
+
+    def test_impossible_hour_token_does_not_crash(self):
+        # 99h is not a valid clock hour; extractor must reject it gracefully
+        result = self._extract("la 99h")
+        self.assertIsNone(result)
+
+    def test_empty_and_pure_letter_tokens_do_not_crash(self):
+        for text in ["", "h", "ora", "la ora"]:
+            self.assertIsNone(self._extract(text))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Romanian time tokens that glue a digit run to a trailing letter — "20h", "la 20h", "21h30" — reached the time-of-day branch and were passed straight to `int()`, raising `ValueError: invalid literal for int() with base 10: '20h'`.

The block already computes `strNum`, the digits-only prefix of the token. This change routes the affected `int()` calls through `strNum` with a truthiness guard, mirroring the pattern already used in the Portuguese extractor. Glued tokens now resolve to a clock time instead of crashing.

- `la 20h` -> 20:00
- `21h30` -> 21:30
- gibberish and impossible-hour tokens (`fkjdslf20h`, `la 99h`) return no match instead of raising

Adds `test/test_dates_ro.py` covering the glued-suffix cases plus adversarial break-the-code inputs.