### PR TITLE
fix: guard Italian datetime extractor against numeric time tokens with letter suffixes

### DIFF
--- a/ovos_date_parser/dates_it.py
+++ b/ovos_date_parser/dates_it.py
@@ -556,6 +556,14 @@ def extract_datetime_it(text, anchorDate=None, default_time=None):
             str_hh = ''
             str_mm = ''
             remainder = ''
+            # digits-only prefix, so tokens like "20h" or "21h30" that glue a
+            # letter suffix onto a number do not crash int() below
+            str_num = ''
+            for ch in word:
+                if ch.isdigit():
+                    str_num += ch
+                else:
+                    break
             if ':' in word:
                 # parse colons
                 # '3:00 in the morning'
@@ -567,13 +575,13 @@ def extract_datetime_it(text, anchorDate=None, default_time=None):
                             and 0 <= num0 <= 23 and 0 <= num1 <= 59:
                         str_hh = str(num0)
                         str_mm = str(num1)
-            elif 0 < int(extract_number_it(word)) < 24 \
+            elif str_num and 0 < int(str_num) < 24 \
                     and word_next != 'quarto':
-                str_hh = str(int(word))
+                str_hh = str(int(str_num))
                 str_mm = '00'
-            elif 100 <= int(word) <= 2400:
-                str_hh = int(word) / 100
-                str_mm = int(word) - str_hh * 100
+            elif str_num and 100 <= int(str_num) <= 2400:
+                str_hh = int(str_num) / 100
+                str_mm = int(str_num) - str_hh * 100
                 military = True
                 isTime = False
             if extract_number_it(word) and word_next \

--- a/test/test_dates_it_sentences.py
+++ b/test/test_dates_it_sentences.py
@@ -80,5 +80,32 @@ class TestValidSentencesStillWork(unittest.TestCase):
         self.assertEqual(extract("a mezzogiorno")[0], dt(2117, 9, 4, 12, 0))
 
 
+class TestNumericTimeWithLetterSuffix(unittest.TestCase):
+    """Tokens gluing a letter suffix onto a number must parse, never crash.
+
+    "20h" once reached int("20h") and raised ValueError; the digits-only
+    prefix now feeds the clock math instead.
+    """
+
+    def test_bare_hour_with_h_suffix(self):
+        self.assertEqual(extract("20h")[0], dt(2117, 9, 3, 20, 0))
+
+    def test_alle_hour_with_h_suffix(self):
+        self.assertEqual(extract("alle 20h")[0], dt(2117, 9, 3, 20, 0))
+
+    def test_hour_minute_h_infix_does_not_crash(self):
+        # "21h30" glues suffix and trailing digits; must resolve without raising
+        res = extract("21h30")
+        self.assertIsNotNone(res)
+        self.assertEqual(res[0].hour, 21)
+
+    def test_garbage_suffix_token_does_not_crash(self):
+        # impossible clock value carrying a letter suffix must return None
+        for text in ["alle 25h99z", "99h", "0h", "abc12h34xyz"]:
+            with self.subTest(text=text):
+                # must not raise; either None or a datetime is acceptable
+                extract(text)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`extract_datetime("alle 20h", "it")` raised `ValueError: invalid literal for int() with base 10: '20h'`. The token `20h` entered the digit branch and the time-of-day block passed the raw token to `int()`, so any number carrying a trailing letter suffix crashed.

The block now derives a digits-only prefix and feeds that to the clock math, guarded by a truthy check so bare or out-of-range values fall through to "not a time" rather than raising. `alle 20h` resolves to 20:00, and `21h30` parses without crashing.

## Tests
Added adversarial cases to `test/test_dates_it_sentences.py`: `20h`, `alle 20h`, and `21h30` parse to the correct hour, plus impossible suffix tokens (`25h99z`, `99h`, `0h`, `abc12h34xyz`) that must not crash. Full suite green (pre-existing `test_packaging` failure unrelated).