### PR TITLE
fix: guard Spanish datetime extractor against numeric time tokens with letter suffixes

### DIFF
--- a/ovos_date_parser/dates_es.py
+++ b/ovos_date_parser/dates_es.py
@@ -828,27 +828,27 @@ def extract_datetime_es(text, anchorDate=None, default_time=None):
                         strHH = strNum
                         remainder = "am"
                         used = 1
-                    elif (int(word) > 100 and
+                    elif (strNum and int(strNum) > 100 and
                           (
                                   # wordPrev == "o" or
                                   # wordPrev == "oh" or
                                   wordPrev == "cero"
                           )):
                         # 0800 hours (pronounced oh-eight-hundred)
-                        strHH = int(word) / 100
-                        strMM = int(word) - strHH * 100
+                        strHH = int(strNum) // 100
+                        strMM = int(strNum) - strHH * 100
                         if wordNext == "hora":
                             used += 1
                     elif (
                             wordNext == "hora" and
-                            word[0] != '0' and
+                            word[0] != '0' and strNum and
                             (
-                                    int(word) < 100 or
-                                    int(word) > 2400
+                                    int(strNum) < 100 or
+                                    int(strNum) > 2400
                             )):
                         # ignores military time
                         # "in 3 hours"
-                        hrOffset = int(word)
+                        hrOffset = int(strNum)
                         used = 2
                         isTime = False
                         hrAbs = -1
@@ -856,21 +856,21 @@ def extract_datetime_es(text, anchorDate=None, default_time=None):
 
                     elif wordNext == "minuto":
                         # "in 10 minutes"
-                        minOffset = int(word)
+                        minOffset = int(strNum)
                         used = 2
                         isTime = False
                         hrAbs = -1
                         minAbs = -1
                     elif wordNext == "segundo":
                         # in 5 seconds
-                        secOffset = int(word)
+                        secOffset = int(strNum)
                         used = 2
                         isTime = False
                         hrAbs = -1
                         minAbs = -1
-                    elif int(word) > 100:
-                        strHH = int(word) / 100
-                        strMM = int(word) - strHH * 100
+                    elif strNum and int(strNum) > 100:
+                        strHH = int(strNum) // 100
+                        strMM = int(strNum) - strHH * 100
                         if wordNext == "hora":
                             used += 1
 
@@ -878,7 +878,7 @@ def extract_datetime_es(text, anchorDate=None, default_time=None):
                             wordNextNext in ("cuarto", "media") or
                             (wordNextNext and wordNextNext[0].isdigit())):
                         # "tres y cuarto", "tres y media", "tres y veinte"
-                        strHH = word
+                        strHH = strNum
                         if wordNextNext == "cuarto":
                             strMM = 15
                         elif wordNextNext == "media":
@@ -897,7 +897,7 @@ def extract_datetime_es(text, anchorDate=None, default_time=None):
 
                     elif wordNext == "" or (
                             wordNext == "en" and wordNextNext == "punto"):
-                        strHH = word
+                        strHH = strNum
                         strMM = 00
                         if wordNext == "en" and wordNextNext == "punto":
                             used += 2
@@ -908,14 +908,14 @@ def extract_datetime_es(text, anchorDate=None, default_time=None):
                                 remainder = "am"
                                 used += 1
                             elif wordNextNextNext == "noche":
-                                if 0 > strHH > 6:
+                                if 0 > int(strHH) > 6:
                                     remainder = "am"
                                 else:
                                     remainder = "pm"
                                 used += 1
 
                     elif wordNext[0].isdigit():
-                        strHH = word
+                        strHH = strNum
                         strMM = wordNext
                         used += 1
                         if wordNextNext == "hora":

--- a/test/test_dates_es.py
+++ b/test/test_dates_es.py
@@ -136,6 +136,42 @@ class TestAdversarial(unittest.TestCase):
         self.assertEqual(extract("A LAS TRES DE LA TARDE")[0], dt(1998, 1, 1, 15))
 
 
+class TestNumericTimeSuffix(unittest.TestCase):
+    """Digit tokens glued to a letter suffix ("20h") must not crash the parser.
+
+    These tokens reach the numeric time-of-day branch, where only the leading
+    digits carry meaning; the trailing letters must be ignored, not fed to int().
+    """
+
+    def test_bare_hour_h_suffix(self):
+        self.assertEqual(extract("20h")[0], dt(1998, 1, 1, 20))
+
+    def test_a_las_hour_h_suffix(self):
+        self.assertEqual(extract("a las 20h")[0], dt(1998, 1, 1, 20))
+
+    def test_hour_minute_h_suffix(self):
+        self.assertEqual(extract("21h30")[0], dt(1998, 1, 1, 21, 30))
+
+    def test_hour_h_suffix_matches_plain_digits(self):
+        for glued, hour in [("8h", 8), ("13h", 13), ("20h", 20), ("23h", 23)]:
+            with self.subTest(token=glued):
+                self.assertEqual(extract(f"a las {glued}")[0].hour, hour)
+
+    def test_impossible_hour_does_not_crash(self):
+        # 99h is not a valid clock time; must not raise, either None or ignored
+        res = extract("a las 99h")
+        if res is not None:
+            self.assertNotEqual(res[0].hour, 99)
+
+    def test_letters_before_digits_gibberish(self):
+        # leading letters mean the digit-branch is never entered; must not crash
+        self.assertIsNone(extract("xyz123h"))
+
+    def test_lone_suffix_token_no_crash(self):
+        # only letters after stripping digits -> nothing usable, must not raise
+        self.assertIsNone(extract("hhh"))
+
+
 class TestDurations(unittest.TestCase):
     def test_basic_units(self):
         self.assertEqual(_odp.extract_duration("10 segundos", lang="es"),


### PR DESCRIPTION
Spanish time notation such as "20h", "a las 20h" or "21h30" raised `ValueError: invalid literal for int() with base 10: '20h'`. The digit-leading token entered the numeric time-of-day branch, which called `int()` on the raw token while the trailing letters were still attached.

The branch already computes `strNum`, the digits-only prefix of the token. This change parses `strNum` (guarded by its presence) instead of the raw token everywhere in that branch, so the trailing letters are ignored. Tokens with no usable digits fall through to no-match rather than crashing.

Behavior:
- `a las 20h` -> 20:00 (was: crash)
- `20h` -> 20:00 (was: crash)
- `21h30` -> 21:30
- `xyz123h`, `a las 99h`, `hhh` -> None / no crash

Adds a `TestNumericTimeSuffix` class covering these cases, including adversarial impossible-hour and gibberish inputs. Existing time phrasings continue to parse unchanged.