### PR TITLE
fix: harden Arabic datetime extraction (proclitics, within, out-of-range clock)

### DIFF
--- a/ovos_date_parser/dates_ar.py
+++ b/ovos_date_parser/dates_ar.py
@@ -5,6 +5,13 @@ Time is told with the feminine ordinal hour names after "الساعة"
 "التاسعة والنصف" = 9:30, "التاسعة إلا ربعاً" = quarter to nine.
 Extraction accepts both Western and Eastern Arabic-Indic digits and
 tolerates unvocalized spelling variants.
+
+Counted-noun agreement follows Wright, "A Grammar of the Arabic
+Language" Vol. I: the dual endings -āni (nominative) / -aini (oblique)
+give يومان/يومين = "two days" (§299), and cardinal numerals 3-10 take
+the gender opposite the counted noun (§319-§321), so the feminine
+nouns ساعة/دقيقة/ثانية take the bare numeral forms ثلاث/أربع/خمس while
+the masculine يوم takes ثلاثة/أربعة/خمسة.
 """
 import re
 from datetime import timedelta
@@ -63,8 +70,15 @@ _MONTHS_LOOKUP_AR[_normalize_ar("اثنين")] = None  # guard, see weekdays
 del _MONTHS_LOOKUP_AR[_normalize_ar("اثنين")]
 _WEEKDAYS_LOOKUP_AR = {}
 for _i, _w in _WEEKDAYS_AR.items():
-    _WEEKDAYS_LOOKUP_AR[_normalize_ar(_w)] = _i
-    _WEEKDAYS_LOOKUP_AR[_normalize_ar(_w)[2:]] = _i  # without the article
+    _name = _normalize_ar(_w)  # e.g. "الجمعه" (article + bare noun)
+    _bare = _name[2:]  # drop the "ال" article -> "جمعه"
+    _WEEKDAYS_LOOKUP_AR[_name] = _i
+    _WEEKDAYS_LOOKUP_AR[_bare] = _i  # without the article
+    # ب/ل proclitics fused onto the article: "بالجمعة" (on Friday),
+    # "للجمعة" (for/until Friday). With ل the article's alif elides
+    # (li + al -> lil), so build it from the bare noun.
+    _WEEKDAYS_LOOKUP_AR["ب" + _name] = _i
+    _WEEKDAYS_LOOKUP_AR["لل" + _bare] = _i
 
 _HOUR_LOOKUP_AR = {}
 for _n, _name in _HOUR_NAMES_AR.items():
@@ -163,7 +177,9 @@ def _count_unit_ar(count, singular, dual, plural, feminine):
     """A counted noun with Arabic number agreement.
 
     1 and 2 use the bare singular/dual, 3-10 take the plural with the
-    polarity-opposed numeral, 11+ take the singular."""
+    polarity-opposed numeral, 11+ take the singular. The reverse gender
+    polarity of 3-10 follows Wright, "A Grammar of the Arabic Language"
+    Vol. I §319: the numeral takes the gender opposite the counted noun."""
     if count == 1:
         return singular
     if count == 2:
@@ -318,7 +334,10 @@ _MIDNIGHT_WORD = _normalize_ar("منتصفالليل")
 _NEXT_WORDS = {_normalize_ar("القادم"), _normalize_ar("القادمة"),
                _normalize_ar("المقبل"), _normalize_ar("المقبلة")}
 _PREV_WORDS = {_normalize_ar("الماضي"), _normalize_ar("الماضية")}
-_AFTER_WORD = _normalize_ar("بعد")
+# forward-looking relatives: بعد (after), خلال (within/during),
+# غضون (the noun in "في غضون" = within); all place the offset in the future
+_AFTER_WORDS = {_normalize_ar("بعد"), _normalize_ar("خلال"),
+                _normalize_ar("غضون")}
 _BEFORE_WORDS = {_normalize_ar("قبل"), _normalize_ar("منذ")}
 _CLOCK_WORDS = {_normalize_ar("الساعة"), _normalize_ar("ساعة")}
 _CALENDAR_UNITS = {
@@ -341,9 +360,15 @@ _IN_WORD = _normalize_ar("في")
 def extract_datetime_ar(text, anchorDate=None, default_time=None):
     """Convert a human date reference in Arabic into an exact datetime.
 
-    Handles relative days (اليوم, غداً, أمس, بعد غد), weekdays, Gregorian
-    month names, relative offsets ("بعد ثلاثة أيام", "الأسبوع القادم") and
-    clock times ("الساعة التاسعة والنصف مساءً", "5:30").
+    Handles relative days (اليوم, غداً, أمس, بعد غد), weekdays (including
+    the ب/ل proclitics بالجمعة/للجمعة), Gregorian month names, relative
+    offsets and clock times ("الساعة التاسعة والنصف مساءً", "5:30").
+
+    Forward-looking markers بعد / خلال / في غضون ("after" / "within")
+    place the offset in the future; قبل / منذ ("before" / "since") place
+    it in the past. Dual offsets use the -āni/-aini forms يومين/ساعتين
+    = "two days"/"two hours" (Wright, "A Grammar of the Arabic Language"
+    Vol. I §299).
 
     Args:
         text (str): string containing date words
@@ -361,7 +386,8 @@ def extract_datetime_ar(text, anchorDate=None, default_time=None):
     normalized = normalized.replace("بعد غد", "بعدغد") \
         .replace("اول امس", "اولامس").replace("امس الاول", "اولامس") \
         .replace("منتصف الليل", "منتصفالليل") \
-        .replace("بعد الظهر", "بعدالظهر")
+        .replace("بعد الظهر", "بعدالظهر") \
+        .replace("في غضون", "غضون")  # "within" -> single forward marker
     tokens = _tokenize_ar(normalized)
 
     if not anchorDate:
@@ -549,8 +575,8 @@ def extract_datetime_ar(text, anchorDate=None, default_time=None):
             date_found = True
             i += 2
             continue
-        if tok == _AFTER_WORD or tok in _BEFORE_WORDS:
-            sign = 1 if tok == _AFTER_WORD else -1
+        if tok in _AFTER_WORDS or tok in _BEFORE_WORDS:
+            sign = 1 if tok in _AFTER_WORDS else -1
             duration, j = _parse_duration_span(tokens, i + 1)
             if duration is not None:
                 delta += sign * duration[0]
@@ -579,6 +605,9 @@ def extract_datetime_ar(text, anchorDate=None, default_time=None):
             # "الساعة 5" or "الساعة 5:30"
             if i + 1 < n:
                 m = _HHMM_RE.match(tokens[i + 1])
+                if m and not (0 <= int(m.group(1)) < 24 and
+                              0 <= int(m.group(2)) < 60):
+                    m = None  # out-of-range clock like "5:70"; not a time
                 val = None
                 if not m:
                     val, jj = _parse_number_span(tokens, i + 1)

--- a/test/parse_tests/test_parse_ar.py
+++ b/test/parse_tests/test_parse_ar.py
@@ -254,6 +254,52 @@ class TestExtractDatetimeArabicHardening(unittest.TestCase):
         # voweled spelling must parse identically to the bare form
         self.assertEqual(self._dt("الساعة الثَّالِثة صباحاً")[0].hour, 3)
 
+    def test_weekday_proclitics(self):
+        # anchor is a Friday; ب/ل proclitics fuse onto the article
+        base = self.A.replace(hour=0, minute=0)
+        self.assertEqual(self._dt("بالجمعة")[0].date(), base.date())
+        self.assertEqual(self._dt("للجمعة")[0].date(), base.date())
+        # بالأحد -> the coming Sunday (two days after a Friday anchor)
+        self.assertEqual(self._dt("بالأحد")[0].date(),
+                         (base + timedelta(days=2)).date())
+
+    def test_within_marks_future(self):
+        # خلال / في غضون ("within") look forward like بعد
+        self.assertEqual(self._dt("خلال ساعتين")[0], self.A + timedelta(hours=2))
+        base = self.A.replace(hour=0, minute=0)
+        self.assertEqual(self._dt("في غضون ثلاثة أيام")[0],
+                         base + timedelta(days=3))
+        self.assertEqual(self._dt("خلال ثلاثة أيام")[0],
+                         base + timedelta(days=3))
+
+    def test_ago_marks_past(self):
+        # قبل / منذ resolve to the past, not the future
+        self.assertEqual(self._dt("قبل ثلاث ساعات")[0],
+                         self.A - timedelta(hours=3))
+        base = self.A.replace(hour=0, minute=0)
+        self.assertEqual(self._dt("منذ ثلاثة أيام")[0],
+                         base - timedelta(days=3))
+
+    def test_out_of_range_clock_does_not_crash(self):
+        # an impossible clock must not raise; it is simply not a time
+        self.assertIsNone(self._dt("الساعة 5:70"))
+        self.assertIsNone(self._dt("الساعة ١٧:٧٠"))
+        self.assertIsNone(self._dt("الساعة 25"))
+        # a valid boundary still parses
+        self.assertEqual((self._dt("الساعة 23:59")[0].hour,
+                          self._dt("الساعة 23:59")[0].minute), (23, 59))
+
+    def test_and_a_third_past_the_hour(self):
+        # "وثلث" / "والثلث" = twenty past
+        self.assertEqual(self._dt("الساعة الثالثة والثلث")[0].minute, 20)
+        self.assertEqual(self._dt("الساعة الثالثة وثلث")[0].minute, 20)
+
+    def test_noon_and_midnight_words(self):
+        self.assertEqual((self._dt("منتصف الليل")[0].hour,
+                          self._dt("منتصف الليل")[0].minute), (0, 0))
+        self.assertEqual(self._dt("الظهر")[0].hour, 12)
+        self.assertEqual(self._dt("ظهراً")[0].hour, 12)
+
 
 class TestExtractDurationArabicHardening(unittest.TestCase):
     def _d(self, text):


### PR DESCRIPTION
Deep QA pass over Modern Standard Arabic (`ar`) date/time support. Three bugs found and fixed; MSA stays the base with no dialect guessing.

## Bugs fixed

1. **Weekday ب/ل proclitics dropped.** `بالجمعة` / `للجمعة` (on/for Friday) returned `None` — the proclitic fused onto the article was not in the weekday lookup. Now resolves to the weekday. The ل form is built from the bare noun so the article's elided alif is respected (`لِلجمعة`, not `لالجمعة`).

2. **"Within" not forward-looking.** `خلال` and `في غضون` ("within") returned `None`; only `بعد` looked forward. They now place the offset in the future, mirroring `بعد`, while `قبل` / `منذ` stay in the past.

3. **Out-of-range clock crashed.** `الساعة 5:70` raised `ValueError: minute must be in 0..59`. The clock-word `HH:MM` branch (unlike the top-level one) did not validate ranges. It now rejects impossible clocks in both Western and Eastern-Indic digits and yields no time instead of raising.

## Grounding

Counted-noun agreement and dual forms are cross-checked against Wright, *A Grammar of the Arabic Language* Vol. I — §299 (the dual: nom. `-āni` / oblique `-aini`, يومان/يومين) and §319–§321 (cardinal 3–10 take the gender opposite the counted noun: masc يوم → ثلاثة, fem ساعة/دقيقة → bare ثلاث). The existing gender-polarity handling matches the source; citations added to the module and method docstrings.

## Tests

Six new adversarial/idiom cases: ب/ل proclitics, خلال/في غضون future direction, قبل/منذ past direction, out-of-range clocks, "and a third" past the hour, noon/midnight words. Full suite green (the single pre-existing `test_packaging` metadata artifact is unrelated).