### PR TITLE
fix: guard French datetime extractor against malformed date and clock tokens

### DIFF
--- a/ovos_date_parser/dates_fr.py
+++ b/ovos_date_parser/dates_fr.py
@@ -606,8 +606,14 @@ def extract_datetime_fr(text, anchorDate=None, default_time=None):
                                               minute=0,
                                               hour=0)
     if datestr != "":
+        try:
+            temp = datetime.strptime(datestr,
+                                     "%B %d %Y" if hasYear else "%B %d")
+        except ValueError:
+            # an impossible calendar date like "30 février"; report nothing
+            # rather than a wrong guess
+            return None
         if not hasYear:
-            temp = datetime.strptime(datestr, "%B %d")
             if extractedDate.tzinfo:
                 temp = temp.replace(tzinfo=extractedDate.tzinfo)
             temp = temp.replace(year=extractedDate.year)
@@ -624,7 +630,6 @@ def extract_datetime_fr(text, anchorDate=None, default_time=None):
                     month=int(temp.strftime("%m")),
                     day=int(temp.strftime("%d")))
         else:
-            temp = datetime.strptime(datestr, "%B %d %Y")
             extractedDate = extractedDate.replace(
                 year=int(temp.strftime("%Y")),
                 month=int(temp.strftime("%m")),

--- a/ovos_date_parser/dates_fr.py
+++ b/ovos_date_parser/dates_fr.py
@@ -271,7 +271,9 @@ def extract_datetime_fr(text, anchorDate=None, default_time=None):
             used += 1
             datestr = months_en[m]
             if wordPrev and (wordPrev[0].isdigit()):
-                datestr += " " + wordPrev
+                # keep only the leading digits so ordinals like "1er"
+                # ("1er janvier") do not leak letters into strptime
+                datestr += " " + re.match(r"\d+", wordPrev).group()
                 start -= 1
                 used += 1
             else:
@@ -506,18 +508,18 @@ def extract_datetime_fr(text, anchorDate=None, default_time=None):
                                 words[idxHr] in ["minutes", "minute"]:
                             used += 1
                             idxHr += 1
-                elif wordNext == "minutes":
+                elif word.isdigit() and wordNext == "minutes":
                     # "dans 10 minutes"
                     if wordPrev in words_in:
                         minOffset = int(word)
                     else:
                         minAbs = int(word)
                     used = 2
-                elif wordNext == "secondes":
+                elif word.isdigit() and wordNext == "secondes":
                     # "dans 5 secondes"
                     secOffset = int(word)
                     used = 2
-                elif int(word) > 100:
+                elif word.isdigit() and int(word) > 100:
                     # format militaire
                     hrAbs = int(word) / 100
                     minAbs = int(word) - hrAbs * 100

--- a/test/test_dates_fr.py
+++ b/test/test_dates_fr.py
@@ -1,0 +1,96 @@
+"""French datetime extraction: natural phrasing, clock notation and edge cases.
+
+Anchors verified against French usage (24-hour clock, "1er" for the first of
+the month), not pinned from engine output.
+"""
+import unittest
+from datetime import datetime
+
+from ovos_config.locale import get_default_tz as default_timezone
+
+import ovos_date_parser as _odp
+
+ANCHOR = datetime(2117, 9, 3, 13, 30)  # a fixed non-midnight anchor
+TZ = default_timezone()
+
+
+def extract(text, lang="fr", anchor=ANCHOR):
+    res = _odp.extract_datetime(text, lang=lang, anchorDate=anchor)
+    if res is not None and res[0] is not None and res[0].tzinfo is None:
+        res = [res[0].replace(tzinfo=TZ), res[1]]
+    return res
+
+
+def dt(y, mo, d, h=0, mi=0):
+    return datetime(y, mo, d, h, mi, tzinfo=TZ)
+
+
+class TestClockNotation(unittest.TestCase):
+    """The "h" hour separator is the standard French clock notation."""
+
+    def test_bare_hour_h_suffix(self):
+        self.assertEqual(extract("20h")[0], dt(2117, 9, 3, 20))
+
+    def test_a_hour_h_suffix(self):
+        self.assertEqual(extract("à 20h")[0], dt(2117, 9, 3, 20))
+
+    def test_hour_minute_h_separator(self):
+        self.assertEqual(extract("20h30")[0], dt(2117, 9, 3, 20, 30))
+
+    def test_spelled_hours(self):
+        self.assertEqual(extract("à trois heures")[0].hour, 3)
+
+
+class TestOrdinalFirstOfMonth(unittest.TestCase):
+    """"1er" is the ordinary way to say the first day of a month."""
+
+    def test_premier_janvier(self):
+        self.assertEqual(extract("1er janvier")[0], dt(2118, 1, 1))
+
+    def test_le_premier_janvier(self):
+        self.assertEqual(extract("le 1er janvier")[0], dt(2118, 1, 1))
+
+    def test_premier_janvier_with_time(self):
+        self.assertEqual(extract("1er janvier à 20h")[0], dt(2118, 1, 1, 20))
+
+    def test_plain_day_month(self):
+        self.assertEqual(extract("15 juillet")[0], dt(2118, 7, 15))
+
+
+class TestRelativeOffsets(unittest.TestCase):
+    """Relative offsets keep the anchor time of day."""
+
+    def test_in_hours(self):
+        self.assertEqual(extract("dans 3 heures")[0], dt(2117, 9, 3, 16, 30))
+
+    def test_in_minutes(self):
+        self.assertEqual(extract("dans 10 minutes")[0], dt(2117, 9, 3, 13, 40))
+
+
+class TestAdversarial(unittest.TestCase):
+    """Malformed digit-leading tokens must not crash the extractor."""
+
+    def test_digit_letter_tokens(self):
+        for token in ["10sept", "7d", "5m", "20h99z"]:
+            with self.subTest(token=token):
+                # must not raise; a non-time gibberish token yields no match
+                extract(token)
+
+    def test_slash_date_tokens(self):
+        for token in ["15/06/20", "3/0/0", "0/0/0"]:
+            with self.subTest(token=token):
+                extract(token)
+
+    def test_empty_and_gibberish(self):
+        self.assertIsNone(extract(""))
+        self.assertIsNone(extract("   "))
+        self.assertIsNone(extract("azerty qwerty"))
+
+    def test_impossible_hour_no_crash(self):
+        res = extract("à 99h")
+        if res is not None and res[0] is not None:
+            self.assertNotEqual(res[0].hour, 99)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_dates_fr.py
+++ b/test/test_dates_fr.py
@@ -91,6 +91,15 @@ class TestAdversarial(unittest.TestCase):
         if res is not None and res[0] is not None:
             self.assertNotEqual(res[0].hour, 99)
 
+    def test_impossible_dates_return_none(self):
+        for token in ["30 février", "31 avril", "30 février 2020",
+                      "février 30", "31 avril 2020"]:
+            with self.subTest(token=token):
+                self.assertIsNone(extract(token))
+
+    def test_valid_dates_still_parse(self):
+        self.assertEqual(extract("15 juillet 2020")[0], dt(2020, 7, 15))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This hardens the French datetime extractor against three crash classes, all on natural French phrasing:

1. **`1er` ordinal for the first of the month.** `1er` is the ordinary way to write the first day of a month, but the day parser appended the raw ordinal to the internal date string, so `1er janvier` reached `strptime` as `january 1er` and raised `ValueError`. It now keeps only the leading digits.

2. **Digit-leading tokens with trailing letters or slashes** (`10sept`, `15/06/20`, `7d`, `3/0/0`) fell through to the military-time branch where the raw token was passed to `int()`. The numeric branches are now guarded with `isdigit()`, mirroring the other Romance extractors.

3. **Impossible calendar dates** (`30 février`, `31 avril`) reached `strptime` / `datetime.replace` and raised `ValueError`. The date parsing is now wrapped and returns `None` for a non-existent date, mirroring the English extractor.

Adds `test/test_dates_fr.py` covering clock notation (`20h`, `20h30`), the `1er` ordinal, relative offsets from a non-midnight anchor, impossible dates, and adversarial malformed input. Full suite green (pre-existing packaging test excepted).