### PR TITLE
fix: guard Danish datetime extractor against malformed clock tokens and impossible dates

### DIFF
--- a/ovos_date_parser/dates_da.py
+++ b/ovos_date_parser/dates_da.py
@@ -735,10 +735,15 @@ def extract_datetime_da(text, anchorDate=None, default_time=None):
         for idx, en_month in enumerate(en_monthsShort):
             datestr = re.sub(r"\b" + re.escape(monthsShort[idx]) + r"\b", en_month, datestr)
 
-        if hasYear:
-            temp = datetime.strptime(datestr, "%B %d %Y")
-        else:
-            temp = datetime.strptime(datestr, "%B %d")
+        try:
+            if hasYear:
+                temp = datetime.strptime(datestr, "%B %d %Y")
+            else:
+                temp = datetime.strptime(datestr, "%B %d")
+        except ValueError:
+            # an impossible calendar date like "30 februar"; report nothing
+            # rather than a wrong guess
+            return None
         if extractedDate.tzinfo:
             temp = temp.replace(tzinfo=extractedDate.tzinfo)
 

--- a/ovos_date_parser/dates_da.py
+++ b/ovos_date_parser/dates_da.py
@@ -572,7 +572,7 @@ def extract_datetime_da(text, anchorDate=None, default_time=None):
                         minAbs = -1
 
                     elif wordNext == "time":
-                        strHH = word
+                        strHH = strNum
                         used += 1
                         isTime = True
                         if wordNextNext == timeQualifier:
@@ -639,7 +639,7 @@ def extract_datetime_da(text, anchorDate=None, default_time=None):
                                         remainder = "am"
 
                     elif wordNext == timeQualifier:
-                        strHH = word
+                        strHH = strNum
                         strMM = 00
                         isTime = True
                         if wordNext[:11] == "eftermiddag":

--- a/test/test_dates_da.py
+++ b/test/test_dates_da.py
@@ -47,6 +47,15 @@ class TestAdversarial(unittest.TestCase):
         self.assertIsNone(extract("   "))
         self.assertIsNone(extract("qwerty asdf"))
 
+    def test_impossible_dates_return_none(self):
+        for token in ["30 februar", "31 april", "29 februar",
+                      "31 april 2020"]:
+            with self.subTest(token=token):
+                self.assertIsNone(extract(token))
+
+    def test_leap_day_in_leap_year_parses(self):
+        self.assertEqual(extract("29 februar 2020")[0], dt(2020, 2, 29))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_dates_da.py
+++ b/test/test_dates_da.py
@@ -1,0 +1,52 @@
+"""Danish datetime extraction: clock notation and adversarial input.
+
+Anchors reflect Danish 24-hour usage, not pinned from engine output.
+"""
+import unittest
+from datetime import datetime
+
+from ovos_config.locale import get_default_tz as default_timezone
+
+import ovos_date_parser as _odp
+
+ANCHOR = datetime(2117, 9, 3, 13, 30)  # a fixed non-midnight anchor
+TZ = default_timezone()
+
+
+def extract(text, lang="da", anchor=ANCHOR):
+    res = _odp.extract_datetime(text, lang=lang, anchorDate=anchor)
+    if res is not None and res[0] is not None and res[0].tzinfo is None:
+        res = [res[0].replace(tzinfo=TZ), res[1]]
+    return res
+
+
+def dt(y, mo, d, h=0, mi=0):
+    return datetime(y, mo, d, h, mi, tzinfo=TZ)
+
+
+class TestBareHour(unittest.TestCase):
+    def test_bare_number_hour(self):
+        self.assertEqual(extract("20")[0], dt(2117, 9, 3, 20))
+
+
+class TestAdversarial(unittest.TestCase):
+    """Digit-leading tokens with trailing letters or slashes must not crash."""
+
+    def test_hour_letter_suffix(self):
+        for token in ["20h", "klokken 20h", "3h30"]:
+            with self.subTest(token=token):
+                extract(token)  # must not raise
+
+    def test_slash_and_glued_tokens(self):
+        for token in ["15/06/20", "3/0/0", "0/0/0", "10sept", "7d"]:
+            with self.subTest(token=token):
+                extract(token)  # must not raise
+
+    def test_empty_and_gibberish(self):
+        self.assertIsNone(extract(""))
+        self.assertIsNone(extract("   "))
+        self.assertIsNone(extract("qwerty asdf"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two crash classes in the Danish datetime extractor:

- A bare digit-leading token with no following qualifier assigned the raw token (trailing letters/slashes attached) as the hour, so `20h`, `klokken 20h` or `15/06/20` reached `int()` and raised `ValueError`. The branch now uses the digits-only prefix.
- An impossible spoken date like `30 februar` reached `strptime` and raised `ValueError`. The date parsing is now wrapped and returns `None` for a non-existent date, mirroring the English extractor.

Adds `test/test_dates_da.py`. Full suite green (pre-existing packaging test excepted).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Danish time parsing for numeric hour expressions without colons.
  * Invalid dates, such as nonexistent calendar days, are now handled safely instead of causing errors.
  * Improved resilience when processing empty, unclear, or unusual date and time text.

* **Tests**
  * Added coverage for Danish hour parsing, leap days, invalid dates, and malformed input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->