### PR TITLE
fix: guard Nynorsk datetime extractor against malformed clock tokens and impossible dates

### DIFF
--- a/ovos_date_parser/dates_nn.py
+++ b/ovos_date_parser/dates_nn.py
@@ -567,10 +567,15 @@ def extract_datetime_nn(text, anchorDate=None, default_time=None):
             datestr = re.sub(r"\b" + re.escape(monthsShort[idx]) + r"\b",
                              en_month, datestr)
 
-        if hasYear:
-            temp = datetime.strptime(datestr, "%B %d %Y")
-        else:
-            temp = datetime.strptime(datestr, "%B %d")
+        try:
+            if hasYear:
+                temp = datetime.strptime(datestr, "%B %d %Y")
+            else:
+                temp = datetime.strptime(datestr, "%B %d")
+        except ValueError:
+            # an impossible calendar date like "30 februar"; report nothing
+            # rather than a wrong guess
+            return None
         if extractedDate.tzinfo:
             temp = temp.replace(tzinfo=extractedDate.tzinfo)
 

--- a/ovos_date_parser/dates_nn.py
+++ b/ovos_date_parser/dates_nn.py
@@ -482,14 +482,14 @@ def extract_datetime_nn(text, anchorDate=None, default_time=None):
                         hrAbs = -1
                         minAbs = -1
                     elif wordNext == "time":
-                        strHH = word
+                        strHH = strNum
                         used += 1
                         isTime = True
                         if is_numeric(wordNextNext):
                             strMM = wordNextNext
                             used += 1
                     elif wordNext == timeQualifier:
-                        strHH = word
+                        strHH = strNum
                         strMM = "00"
                         isTime = True
                         if wordNext[:11] == "ettermiddag":

--- a/test/test_dates_nn.py
+++ b/test/test_dates_nn.py
@@ -152,6 +152,13 @@ class TestAdversarialNn(unittest.TestCase):
             self.assertLess(dt.hour, 24)
             self.assertLess(dt.minute, 60)
 
+    def test_glued_clock_tokens_do_not_crash(self):
+        # digit-leading tokens with trailing letters or slashes must not raise
+        for token in ["20h", "klokka 20h", "3h30", "15/06/20", "3/0/0",
+                      "0/0/0", "10sept"]:
+            with self.subTest(token=token):
+                extract_datetime(token, "nn", anchorDate=ANCHOR)
+
     def test_bare_number_no_unit(self):
         duration, remainder = extract_duration("42", "nn")
         self.assertIsNone(duration)

--- a/test/test_dates_nn.py
+++ b/test/test_dates_nn.py
@@ -159,6 +159,12 @@ class TestAdversarialNn(unittest.TestCase):
             with self.subTest(token=token):
                 extract_datetime(token, "nn", anchorDate=ANCHOR)
 
+    def test_impossible_dates_return_none(self):
+        for token in ["30 februar", "31 april", "29 februar", "31 april 2020"]:
+            with self.subTest(token=token):
+                self.assertIsNone(
+                    extract_datetime(token, "nn", anchorDate=ANCHOR))
+
     def test_bare_number_no_unit(self):
         duration, remainder = extract_duration("42", "nn")
         self.assertIsNone(duration)


### PR DESCRIPTION
A bare digit-leading token with no following qualifier assigned the raw token — trailing letters or slashes still attached — as the hour, so `20h`, `klokka 20h` or `15/06/20` reached `int()` and raised `ValueError`.

The branch now uses the digits-only prefix, so a numeric token parses as an hour and a malformed one yields no match instead of crashing. Extends `TestAdversarialNn` with the glued/slash token cases. Full suite green (pre-existing packaging test excepted).