### PR TITLE
fix: guard Swedish datetime extractor against numeric time tokens with letter suffixes

### DIFF
--- a/ovos_date_parser/dates_sv.py
+++ b/ovos_date_parser/dates_sv.py
@@ -534,20 +534,20 @@ def extract_datetime_sv(text, anchorDate=None, default_time=None):
                         remainder = "am"
                         used = 1
                     elif (
-                            int(word) > 100 and
+                            int(strNum) > 100 and
                             (
                                     wordPrev == "o" or
                                     wordPrev == "oh"
                             )):
                         # 0800 hours (pronounced oh-eight-hundred)
-                        strHH = int(word) / 100
-                        strMM = int(word) - strHH * 100
+                        strHH = int(strNum) / 100
+                        strMM = int(strNum) - strHH * 100
                         if wordNext == "hours":
                             used += 1
                     elif wordNext in ("timme", "timma", "timmar") and \
-                            int(word) < 100:
+                            int(strNum) < 100:
                         # "om 3 timmar" = "in 3 hours"
-                        hrOffset = int(word)
+                        hrOffset = int(strNum)
                         used = 2
                         isTime = False
                         hrAbs = -1
@@ -555,25 +555,25 @@ def extract_datetime_sv(text, anchorDate=None, default_time=None):
 
                     elif wordNext in ("minut", "minuter"):
                         # "om 10 minuter" = "in 10 minutes"
-                        minOffset = int(word)
+                        minOffset = int(strNum)
                         used = 2
                         isTime = False
                         hrAbs = -1
                         minAbs = -1
                     elif wordNext in ("sekund", "sekunder"):
                         # "om 5 sekunder" = "in 5 seconds"
-                        secOffset = int(word)
+                        secOffset = int(strNum)
                         used = 2
                         isTime = False
                         hrAbs = -1
                         minAbs = -1
-                    elif int(word) > 100:
-                        strHH = int(word) / 100
-                        strMM = int(word) - strHH * 100
+                    elif int(strNum) > 100:
+                        strHH = int(strNum) / 100
+                        strMM = int(strNum) - strHH * 100
                         if wordNext == "hours":
                             used += 1
                     elif wordNext and wordNext[0].isdigit():
-                        strHH = word
+                        strHH = strNum
                         strMM = wordNext
                         used += 1
                         if wordNextNext == "hours":
@@ -587,7 +587,7 @@ def extract_datetime_sv(text, anchorDate=None, default_time=None):
                                             wordNextNext == timeQualifier
                                     )
                             )):
-                        strHH = word
+                        strHH = strNum
                         strMM = 00
                         if wordNext == "o'clock":
                             used += 1

--- a/test/test_dates_sv_sentences.py
+++ b/test/test_dates_sv_sentences.py
@@ -137,6 +137,16 @@ class TestImpossibleAndEmpty(unittest.TestCase):
     def test_no_date(self):
         self.assertEqual(extract("det finns ingen tid här"), None)
 
+    def test_glued_clock_tokens_do_not_crash(self):
+        # digit-leading tokens with trailing letters or slashes must not raise
+        for token in ["20h", "klockan 20h", "3h30", "15/06/20", "3/0/0",
+                      "0/0/0", "10sept", "1er"]:
+            with self.subTest(token=token):
+                extract(token)
+
+    def test_bare_hour_h_suffix(self):
+        self.assertEqual(extract("20h")[0], dt(2117, 9, 3, 20))
+
 
 class TestDurationEdgeCases(unittest.TestCase):
     """extract_duration must signal 'no duration' with None, never crash."""


### PR DESCRIPTION
Time notation like `20h` or `klockan 20h` produced a digit-leading token that entered the numeric time-of-day branch, where the raw token was passed to `int()` with its trailing letters still attached, raising `ValueError`. Slash-dates and glued tokens (`15/06/20`, `10sept`) hit the same branch.

The numeric branch now parses the digits-only prefix, so `20h` resolves to 20:00 and a malformed token yields no match instead of crashing. This mirrors the guard already applied to the Spanish and Italian extractors. Extends the Swedish sentence suite with the glued-token cases and a bare `20h` assertion. Full suite green (pre-existing packaging test excepted).