### PR TITLE
fix: return None for impossible Spanish calendar dates instead of crashing

### DIFF
--- a/ovos_date_parser/dates_es.py
+++ b/ovos_date_parser/dates_es.py
@@ -983,10 +983,15 @@ def extract_datetime_es(text, anchorDate=None, default_time=None):
         for idx, en_month in enumerate(en_monthsShort):
             datestr = re.sub(r"\b" + re.escape(monthsShort[idx]) + r"\b", en_month, datestr)
 
-        if hasYear:
-            temp = datetime.strptime(datestr, "%B %d %Y")
-        else:
-            temp = datetime.strptime(datestr, "%B %d")
+        try:
+            if hasYear:
+                temp = datetime.strptime(datestr, "%B %d %Y")
+            else:
+                temp = datetime.strptime(datestr, "%B %d")
+        except ValueError:
+            # an impossible calendar date like "30 de febrero"; report nothing
+            # rather than a wrong guess
+            return None
         if extractedDate.tzinfo:
             temp = temp.replace(tzinfo=extractedDate.tzinfo)
 

--- a/test/test_dates_es.py
+++ b/test/test_dates_es.py
@@ -135,6 +135,15 @@ class TestAdversarial(unittest.TestCase):
     def test_uppercase(self):
         self.assertEqual(extract("A LAS TRES DE LA TARDE")[0], dt(1998, 1, 1, 15))
 
+    def test_impossible_dates_return_none(self):
+        for token in ["30 de febrero", "31 de abril", "29 de febrero",
+                      "31 de abril de 2020"]:
+            with self.subTest(token=token):
+                self.assertIsNone(extract(token))
+
+    def test_leap_day_in_leap_year_parses(self):
+        self.assertEqual(extract("29 de febrero 2020")[0], dt(2020, 2, 29))
+
 
 class TestNumericTimeSuffix(unittest.TestCase):
     """Digit tokens glued to a letter suffix ("20h") must not crash the parser.


### PR DESCRIPTION
An impossible spoken date such as `30 de febrero` or `31 de abril` reached `strptime` and raised `ValueError`. The date parsing is now wrapped and returns `None` for a non-existent calendar date, mirroring the English extractor. A real leap day (`29 de febrero 2020`) still parses.

Extends `TestAdversarial` with impossible-date and leap-day cases. Full suite green (pre-existing packaging test excepted).