### PR TITLE
fix: return None for impossible Galician calendar dates instead of crashing

### DIFF
--- a/ovos_date_parser/dates_gl.py
+++ b/ovos_date_parser/dates_gl.py
@@ -932,10 +932,15 @@ def extract_datetime_gl(text, anchorDate=None, default_time=None):
             datestr = re.sub(r"\b" + re.escape(monthsShort[idx]) + r"\b",
                              en_month, datestr)
 
-        if hasYear:
-            temp = datetime.strptime(datestr, "%B %d %Y")
-        else:
-            temp = datetime.strptime(datestr, "%B %d")
+        try:
+            if hasYear:
+                temp = datetime.strptime(datestr, "%B %d %Y")
+            else:
+                temp = datetime.strptime(datestr, "%B %d")
+        except ValueError:
+            # an impossible calendar date like "30 de febreiro"; report nothing
+            # rather than a wrong guess
+            return None
         if extractedDate.tzinfo:
             temp = temp.replace(tzinfo=extractedDate.tzinfo)
 

--- a/test/test_dates_gl.py
+++ b/test/test_dates_gl.py
@@ -114,6 +114,16 @@ class TestExtractDatetimeGL(unittest.TestCase):
     def test_no_date(self):
         self.assertIsNone(self._dt("pon a mesa e limpa o chan"))
 
+    def test_impossible_dates_return_none(self):
+        for token in ["30 de febreiro", "31 de abril", "29 de febreiro",
+                      "31 de abril 2020"]:
+            with self.subTest(token=token):
+                self.assertIsNone(self._dt(token))
+
+    def test_leap_day_in_leap_year_parses(self):
+        dt, _ = self._dt("29 de febreiro 2020")
+        self.assertEqual(dt, datetime(2020, 2, 29, 0, 0))
+
 
 class TestExtractDurationGL(unittest.TestCase):
 


### PR DESCRIPTION
An impossible spoken date such as `30 de febreiro` or `31 de abril` reached `strptime` and raised `ValueError`. The date parsing is now wrapped and returns `None` for a non-existent calendar date, mirroring the English extractor. A real leap day (`29 de febreiro 2020`) still parses.

Extends the Galician datetime suite with impossible-date and leap-day cases. Full suite green (pre-existing packaging test excepted).