### PR TITLE
fix: return None for impossible Romanian calendar dates instead of crashing

### DIFF
--- a/ovos_date_parser/dates_ro.py
+++ b/ovos_date_parser/dates_ro.py
@@ -910,10 +910,15 @@ def extract_datetime_ro(text, anchorDate=None, default_time=None):
             datestr = re.sub(r"\b" + re.escape(monthsShort_ro[idx]) + r"\b",
                              en_month, datestr)
 
-        if hasYear:
-            temp = datetime.strptime(datestr, "%B %d %Y")
-        else:
-            temp = datetime.strptime(datestr, "%B %d")
+        try:
+            if hasYear:
+                temp = datetime.strptime(datestr, "%B %d %Y")
+            else:
+                temp = datetime.strptime(datestr, "%B %d")
+        except ValueError:
+            # an impossible calendar date like "30 februarie"; report nothing
+            # rather than a wrong guess
+            return None
         if extractedDate.tzinfo:
             temp = temp.replace(tzinfo=extractedDate.tzinfo)
 

--- a/test/test_dates_ro.py
+++ b/test/test_dates_ro.py
@@ -53,6 +53,16 @@ class TestExtractDatetimeRO(unittest.TestCase):
         for text in ["", "h", "ora", "la ora"]:
             self.assertIsNone(self._extract(text))
 
+    def test_impossible_dates_return_none(self):
+        for text in ["30 februarie", "31 aprilie", "29 februarie",
+                     "31 aprilie 2020"]:
+            with self.subTest(text=text):
+                self.assertIsNone(self._extract(text))
+
+    def test_leap_day_in_leap_year_parses(self):
+        result = self._extract("29 februarie 2020")
+        self.assertEqual(result[0], datetime(2020, 2, 29, 0, 0))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
An impossible spoken date such as `30 februarie` or `31 aprilie` reached `strptime` and raised `ValueError`. The date parsing is now wrapped and returns `None` for a non-existent calendar date, mirroring the English extractor. A real leap day (`29 februarie 2020`) still parses.

Extends the Romanian datetime suite with impossible-date and leap-day cases. Full suite green (pre-existing packaging test excepted).