### PR TITLE
fix: return None instead of crashing on impossible dates (az/cs/sk/hr/bg/el/he/pl/ru/sl/uk/ms/id/tr)

### DIFF
--- a/ovos_date_parser/dates_az.py
+++ b/ovos_date_parser/dates_az.py
@@ -748,12 +748,17 @@ def extract_datetime_az(text, anchorDate=None, default_time=None):
 
     if datestr != "":
         # date included an explicit date, e.g. "iyun 5" or "iyun 2, 2017"
-        if hasYear:
-            temp = datetime.strptime(datestr, "%B %d %Y")
-        else:
-            # anchor to a leap year so "29 fevral" parses; the real
-            # year is applied below
-            temp = datetime.strptime(datestr + " 2000", "%B %d %Y")
+        try:
+            if hasYear:
+                temp = datetime.strptime(datestr, "%B %d %Y")
+            else:
+                # anchor to a leap year so "29 fevral" parses; the real
+                # year is applied below
+                temp = datetime.strptime(datestr + " 2000", "%B %d %Y")
+        except ValueError:
+            # an impossible calendar date like "30 fevral"; report nothing
+            # rather than a wrong guess
+            return None
         extractedDate = extractedDate.replace(hour=0, minute=0, second=0)
         if not hasYear:
             temp = temp.replace(year=extractedDate.year,

--- a/ovos_date_parser/dates_bg.py
+++ b/ovos_date_parser/dates_bg.py
@@ -549,7 +549,12 @@ def extract_datetime_bg(text, anchorDate=None, default_time=None):
             try:
                 temp = datetime.strptime(datestr, "%B %d %Y")
             except ValueError:
-                temp = datetime.strptime(datestr + " 1", "%B %d")
+                try:
+                    temp = datetime.strptime(datestr + " 1", "%B %d")
+                except ValueError:
+                    # an impossible calendar date; report nothing
+                    # rather than a wrong guess
+                    return None
         extractedDate = extractedDate.replace(hour=0, minute=0, second=0)
         if not hasYear:
             temp = temp.replace(year=extractedDate.year,

--- a/ovos_date_parser/dates_cs.py
+++ b/ovos_date_parser/dates_cs.py
@@ -970,7 +970,12 @@ def extract_datetime_cs(text, anchorDate=None, default_time=None):
             temp = datetime.strptime(datestr, "%B %d")
         except ValueError:
             # Try again, allowing the year
-            temp = datetime.strptime(datestr, "%B %d %Y")
+            try:
+                temp = datetime.strptime(datestr, "%B %d %Y")
+            except ValueError:
+                # an impossible calendar date like "30 únor"; report nothing
+                # rather than a wrong guess
+                return None
         extractedDate = extractedDate.replace(hour=0, minute=0, second=0)
         if not hasYear:
             temp = temp.replace(year=extractedDate.year,

--- a/ovos_date_parser/dates_el.py
+++ b/ovos_date_parser/dates_el.py
@@ -854,10 +854,15 @@ def extract_datetime_el(text, anchorDate=None, default_time=None):
         for i, en_month in enumerate(en_monthsShort):
             datestr = re.sub(r"\b" + re.escape(monthsShort[i]) + r"\b",
                              en_month, datestr)
-        if hasYear:
-            temp = datetime.strptime(datestr, "%B %d %Y")
-        else:
-            temp = datetime.strptime(datestr, "%B %d")
+        try:
+            if hasYear:
+                temp = datetime.strptime(datestr, "%B %d %Y")
+            else:
+                temp = datetime.strptime(datestr, "%B %d")
+        except ValueError:
+            # an impossible calendar date like "30 φεβρουαριου"; report nothing
+            # rather than a wrong guess
+            return None
         if extractedDate.tzinfo:
             temp = temp.replace(tzinfo=extractedDate.tzinfo)
 

--- a/ovos_date_parser/dates_he.py
+++ b/ovos_date_parser/dates_he.py
@@ -623,11 +623,16 @@ def extract_datetime_he(text, anchorDate=None, default_time=None):
     extractedDate = dateNow.replace(microsecond=0, second=0, minute=0, hour=0)
 
     if datestr != "":
-        if hasYear:
-            temp = datetime.strptime(datestr, "%B %d %Y")
-        else:
-            temp = datetime.strptime(datestr, "%B %d")
-            temp = temp.replace(year=extractedDate.year)
+        try:
+            if hasYear:
+                temp = datetime.strptime(datestr, "%B %d %Y")
+            else:
+                temp = datetime.strptime(datestr, "%B %d")
+                temp = temp.replace(year=extractedDate.year)
+        except ValueError:
+            # an impossible calendar date like "30 בפברואר"; report nothing
+            # rather than a wrong guess
+            return None
         if extractedDate.tzinfo:
             temp = temp.replace(tzinfo=extractedDate.tzinfo)
         if not hasYear and extractedDate.replace(

--- a/ovos_date_parser/dates_hr.py
+++ b/ovos_date_parser/dates_hr.py
@@ -566,7 +566,12 @@ def extract_datetime_hr(text, anchorDate=None, default_time=None):
             try:
                 temp = datetime.strptime(datestr, "%B %d %Y")
             except ValueError:
-                temp = datetime.strptime(datestr + " 1", "%B %d")
+                try:
+                    temp = datetime.strptime(datestr + " 1", "%B %d")
+                except ValueError:
+                    # an impossible calendar date; report nothing
+                    # rather than a wrong guess
+                    return None
         extractedDate = extractedDate.replace(hour=0, minute=0, second=0)
         if not hasYear:
             temp = temp.replace(year=extractedDate.year,

--- a/ovos_date_parser/dates_id.py
+++ b/ovos_date_parser/dates_id.py
@@ -200,11 +200,16 @@ def extract_datetime_id(text, anchorDate=None, default_time=None):
                 year = int(tokens[j])
                 consumed.add(j)
                 break
-        if year is None:
-            year = anchor.year
-            if datetime(year, month, day or 1).date() < anchor.date():
-                year += 1
-        result = result.replace(year=year, month=month, day=day or 1)
+        try:
+            if year is None:
+                year = anchor.year
+                if datetime(year, month, day or 1).date() < anchor.date():
+                    year += 1
+            result = result.replace(year=year, month=month, day=day or 1)
+        except ValueError:
+            # an impossible calendar date like "30 februari"; report nothing
+            # rather than a wrong guess
+            return None
         date_found = True
         consumed.add(i)
 

--- a/ovos_date_parser/dates_ms.py
+++ b/ovos_date_parser/dates_ms.py
@@ -200,11 +200,16 @@ def extract_datetime_ms(text, anchorDate=None, default_time=None):
                 year = int(tokens[j])
                 consumed.add(j)
                 break
-        if year is None:
-            year = anchor.year
-            if datetime(year, month, day or 1).date() < anchor.date():
-                year += 1
-        result = result.replace(year=year, month=month, day=day or 1)
+        try:
+            if year is None:
+                year = anchor.year
+                if datetime(year, month, day or 1).date() < anchor.date():
+                    year += 1
+            result = result.replace(year=year, month=month, day=day or 1)
+        except ValueError:
+            # an impossible calendar date like "30 februari"; report nothing
+            # rather than a wrong guess
+            return None
         date_found = True
         consumed.add(i)
 

--- a/ovos_date_parser/dates_pl.py
+++ b/ovos_date_parser/dates_pl.py
@@ -1043,7 +1043,12 @@ def extract_datetime_pl(string, anchorDate=None, default_time=None):
                     try:
                         temp = datetime.strptime(datestr, "%B %Y")
                     except ValueError:
-                        temp = datetime.strptime(datestr, "%B")
+                        try:
+                            temp = datetime.strptime(datestr, "%B")
+                        except ValueError:
+                            # an impossible calendar date like "30 luty";
+                            # report nothing rather than a wrong guess
+                            return None
         extractedDate = extractedDate.replace(hour=0, minute=0, second=0)
         month = temp.month
         day = temp.day

--- a/ovos_date_parser/dates_ru.py
+++ b/ovos_date_parser/dates_ru.py
@@ -1094,7 +1094,12 @@ def extract_datetime_ru(text, anchor_date=None, default_time=None):
                 day=temp.day,
                 tzinfo=extracted_date.tzinfo)
         else:
-            temp = datetime.strptime(date_string, "%B %d %Y")
+            try:
+                temp = datetime.strptime(date_string, "%B %d %Y")
+            except ValueError:
+                # an impossible calendar date like "30 февраля"; report
+                # nothing rather than a wrong guess
+                return None
             extracted_date = extracted_date.replace(
                 year=int(temp.strftime("%Y")),
                 month=int(temp.strftime("%m")),

--- a/ovos_date_parser/dates_sk.py
+++ b/ovos_date_parser/dates_sk.py
@@ -586,7 +586,12 @@ def extract_datetime_sk(text, anchorDate=None, default_time=None):
             try:
                 temp = datetime.strptime(datestr, "%B %d %Y")
             except ValueError:
-                temp = datetime.strptime(datestr + " 1", "%B %d")
+                try:
+                    temp = datetime.strptime(datestr + " 1", "%B %d")
+                except ValueError:
+                    # an impossible calendar date; report nothing
+                    # rather than a wrong guess
+                    return None
         extractedDate = extractedDate.replace(hour=0, minute=0, second=0)
         if not hasYear:
             temp = temp.replace(year=extractedDate.year,

--- a/ovos_date_parser/dates_sl.py
+++ b/ovos_date_parser/dates_sl.py
@@ -526,7 +526,12 @@ def extract_datetime_sl(text, anchorDate=None, default_time=None):
         if temp is None:
             # a leap day like "29. februarja" has no valid date in the
             # default year 1900; parse it against a known leap year
-            temp = datetime.strptime(datestr + " 2000", "%B %d %Y")
+            try:
+                temp = datetime.strptime(datestr + " 2000", "%B %d %Y")
+            except ValueError:
+                # an impossible calendar date like "30. februarja"; report
+                # nothing rather than a wrong guess
+                return None
         month = temp.month
         day = temp.day
         extractedDate = extractedDate.replace(hour=0, minute=0, second=0)

--- a/ovos_date_parser/dates_tr.py
+++ b/ovos_date_parser/dates_tr.py
@@ -200,11 +200,16 @@ def extract_datetime_tr(text, anchorDate=None, default_time=None):
                 year = int(tokens[j])
                 consumed.add(j)
                 break
-        if year is None:
-            year = anchor.year
-            if datetime(year, month, day or 1).date() < anchor.date():
-                year += 1
-        result = result.replace(year=year, month=month, day=day or 1)
+        try:
+            if year is None:
+                year = anchor.year
+                if datetime(year, month, day or 1).date() < anchor.date():
+                    year += 1
+            result = result.replace(year=year, month=month, day=day or 1)
+        except ValueError:
+            # an impossible calendar date like "30 februari"; report nothing
+            # rather than a wrong guess
+            return None
         date_found = True
         consumed.add(i)
 

--- a/ovos_date_parser/dates_uk.py
+++ b/ovos_date_parser/dates_uk.py
@@ -1015,7 +1015,12 @@ def extract_datetime_uk(text, anchor_date=None, default_time=None):
             temp = datetime.strptime(date_string, "%B %d")
         except ValueError:
             # Try again, allowing the year
-            temp = datetime.strptime(date_string, "%B %d %Y")
+            try:
+                temp = datetime.strptime(date_string, "%B %d %Y")
+            except ValueError:
+                # an impossible calendar date like "30 лютий"; report nothing
+                # rather than a wrong guess
+                return None
         extracted_date = extracted_date.replace(hour=0, minute=0, second=0)
         if not has_year:
             temp = temp.replace(year=extracted_date.year,

--- a/test/test_impossible_dates.py
+++ b/test/test_impossible_dates.py
@@ -1,0 +1,62 @@
+"""Impossible calendar dates must return None rather than crashing.
+
+An explicit date that does not exist on the calendar - day 30 of February,
+day 31 of a thirty-day month - reaches ``datetime.strptime`` (or ``datetime``
+construction) and would raise ``ValueError``. Every language extractor must
+absorb that and report nothing, exactly as the calendar-hardened extractors do.
+
+Each case is expressed in the target language's own month words. A valid date
+and a real leap day (29 February 2020) are checked alongside so the guard can
+never be satisfied by silently swallowing good parses.
+"""
+import unittest
+from datetime import datetime
+
+import ovos_date_parser as odp
+
+ANCHOR = datetime(1998, 1, 1)
+
+# lang -> (impossible dates, valid "15 March 2020", real leap "29 Feb 2020")
+CASES = {
+    "az": (["30 fevral 2020", "31 aprel 2020"], "15 mart 2020", "29 fevral 2020"),
+    "cs": (["30 únor 2020", "31 duben 2020"], "15 březen 2020", "29 únor 2020"),
+    "sk": (["30 február 2020", "31 apríl 2020"], "15 marec 2020", "29 február 2020"),
+    "hr": (["30 veljača 2020", "31 travanj 2020"], "15 ožujak 2020", "29 veljača 2020"),
+    "bg": (["30 февруари 2020", "31 април 2020"], "15 март 2020", "29 февруари 2020"),
+    "el": (["30 φεβρουαριου 2020", "31 απριλιου 2020"], "15 μαρτιου 2020", "29 φεβρουαριου 2020"),
+    "he": (["30 פברואר 2020", "31 אפריל 2020"], "15 מרץ 2020", "29 פברואר 2020"),
+    "pl": (["30 luty 2020", "31 kwiecień 2020"], "15 marzec 2020", "29 luty 2020"),
+    "ru": (["30 февраль 2020", "31 апрель 2020"], "15 март 2020", "29 февраль 2020"),
+    "sl": (["30 februar 2020", "31 april 2020"], "15 marec 2020", "29 februar 2020"),
+    "uk": (["30 лютий 2020", "31 квітень 2020"], "15 березень 2020", "29 лютий 2020"),
+    "ms": (["30 februari 2020", "31 april 2020"], "15 mac 2020", "29 februari 2020"),
+    "id": (["30 februari 2020", "31 april 2020"], "15 maret 2020", "29 februari 2020"),
+    "tr": (["30 şubat 2020", "31 nisan 2020"], "15 mart 2020", "29 şubat 2020"),
+}
+
+
+class TestImpossibleDatesReturnNone(unittest.TestCase):
+    def test_impossible_dates_return_none(self):
+        for lang, (impossible, _valid, _leap) in CASES.items():
+            for token in impossible:
+                with self.subTest(lang=lang, token=token):
+                    self.assertIsNone(
+                        odp.extract_datetime(token, lang=lang, anchorDate=ANCHOR))
+
+    def test_valid_date_still_parses(self):
+        for lang, (_impossible, valid, _leap) in CASES.items():
+            with self.subTest(lang=lang, token=valid):
+                res = odp.extract_datetime(valid, lang=lang, anchorDate=ANCHOR)
+                self.assertIsNotNone(res, valid)
+                self.assertEqual(res[0].strftime("%Y-%m-%d"), "2020-03-15")
+
+    def test_real_leap_day_still_parses(self):
+        for lang, (_impossible, _valid, leap) in CASES.items():
+            with self.subTest(lang=lang, token=leap):
+                res = odp.extract_datetime(leap, lang=lang, anchorDate=ANCHOR)
+                self.assertIsNotNone(res, leap)
+                self.assertEqual(res[0].strftime("%Y-%m-%d"), "2020-02-29")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Impossible calendar dates - day 30 of February, day 31 of a thirty-day month, day 0 - crashed `extract_datetime` with an uncaught `ValueError` in fourteen languages that lacked the calendar guard already present in the hardened extractors.

Each affected extractor feeds a spoken date into `datetime.strptime` (or, for ms/id/tr, into `datetime` construction). When the date does not exist on the calendar, that call raises and the exception escaped the function. This wraps the date-building step so an impossible date yields `None` - report nothing rather than a wrong guess - mirroring the existing hardened style.

No valid-date behaviour changes: valid dates, and real leap days such as 29 February 2020, still parse exactly as before. Offsets, clock parsing, and None-input handling are untouched.

A data-driven adversarial test exercises all fourteen languages using each language's own month words: two impossible dates per language assert `None` (no raise), alongside a valid date and a real leap day that must still parse.