### PR TITLE
fix: degrade gracefully for languages without a native extractor

### DIFF
--- a/ovos_date_parser/__init__.py
+++ b/ovos_date_parser/__init__.py
@@ -335,7 +335,8 @@ def extract_duration(
         return extract_duration_fa(text)
     if lang.startswith("sv"):
         return extract_duration_sv(text)
-    raise NotImplementedError(f"Unsupported language: {lang}")
+    # no native extractor for this language, report no duration found
+    return None, text
 
 
 def extract_datetime(
@@ -463,7 +464,8 @@ def extract_datetime(
     except:
         pass
 
-    raise NotImplementedError(f"Unsupported language: {lang}")
+    # fallback found nothing, report no date/time found
+    return None
 
 
 NUMBER_TUPLE = namedtuple(

--- a/test/test_extractorless_lang_fallback.py
+++ b/test/test_extractorless_lang_fallback.py
@@ -1,0 +1,78 @@
+import unittest
+from datetime import datetime
+
+from ovos_date_parser import extract_datetime, extract_duration
+
+# Languages that ship formatting (nice_*) helpers but no native
+# extract_datetime/extract_duration implementation. Asking to EXTRACT
+# from these must degrade gracefully instead of raising.
+EXTRACTORLESS_LANGS = ("fy", "an")
+
+ANCHOR = datetime(2020, 1, 1)
+
+ADVERSARIAL_INPUTS = ("", "   ", "asdf gibberish qwerty", "25:99",
+                      "february 30 2020", "!!!", "0")
+
+
+class TestExtractorlessDatetime(unittest.TestCase):
+
+    def test_never_raises_not_implemented(self):
+        for lang in EXTRACTORLESS_LANGS:
+            for txt in ("in 3 hours",) + ADVERSARIAL_INPUTS:
+                try:
+                    result = extract_datetime(txt, lang=lang, anchorDate=ANCHOR)
+                except NotImplementedError as e:
+                    self.fail(f"extract_datetime raised for {lang!r} {txt!r}: {e}")
+                # either no extraction (None) or a sensible fallback tuple
+                if result is not None:
+                    self.assertIsInstance(result, tuple)
+                    self.assertEqual(len(result), 2)
+                    self.assertIsInstance(result[0], datetime)
+
+    def test_gibberish_returns_none(self):
+        for lang in EXTRACTORLESS_LANGS:
+            self.assertIsNone(
+                extract_datetime("asdf gibberish qwerty", lang=lang,
+                                 anchorDate=ANCHOR))
+
+    def test_lang_code_variants_do_not_raise(self):
+        for code in ("fy-NL", "FY", "an-ES"):
+            self.assertIsNone(
+                extract_datetime("qwerty nonsense", lang=code, anchorDate=ANCHOR))
+
+
+class TestExtractorlessDuration(unittest.TestCase):
+
+    def test_never_raises_and_reports_no_duration(self):
+        for lang in EXTRACTORLESS_LANGS:
+            for txt in ("3 hours",) + ADVERSARIAL_INPUTS:
+                try:
+                    duration, remainder = extract_duration(txt, lang=lang)
+                except NotImplementedError as e:
+                    self.fail(f"extract_duration raised for {lang!r} {txt!r}: {e}")
+                self.assertIsNone(duration)
+                self.assertEqual(remainder, txt)
+
+
+class TestImplementedLangsUnchanged(unittest.TestCase):
+    """A language with a native extractor still extracts, and still
+    returns None (never a spurious fallback) when nothing matches."""
+
+    def test_english_still_extracts(self):
+        result = extract_datetime("in 3 hours", lang="en",
+                                  anchorDate=ANCHOR)
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], datetime(2020, 1, 1, 3, 0))
+
+    def test_english_no_match_returns_none(self):
+        self.assertIsNone(
+            extract_datetime("asdf gibberish qwerty", lang="en",
+                             anchorDate=ANCHOR))
+
+    def test_english_duration_still_extracts(self):
+        duration, _ = extract_duration("3 hours", lang="en")
+        self.assertIsNotNone(duration)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Asking `extract_datetime` or `extract_duration` to extract from text in a language that ships only formatting helpers (Frisian `fy`, Aragonese `an`) raised `NotImplementedError` for **any** input, crashing the caller. The dispatcher even logged "attempting to use fallback date parser" but then still raised instead of using that fallback.

## Fix

- `extract_datetime` now returns the result of the generic `dateparser` fallback it already attempts, or `None` when nothing matches, mirroring how a supported-but-no-match case returns `None`.
- `extract_duration` reports no duration found `(None, text)` for these languages instead of raising.

Behaviour for languages with a native extractor is unchanged.

## Before / after

`extract_datetime("in 3 hours", lang="fy", anchorDate=...)`

- before: raises `NotImplementedError: Unsupported language: fy`
- after: `None` (or a fallback datetime when the text is parseable)

Adversarial inputs (empty, gibberish, `25:99`, impossible dates) now return `None` / `(None, text)` for `fy` and `an` instead of raising.

## Tests

New `test/test_extractorless_lang_fallback.py` (7 tests) covers both extractor-less languages across the happy path and adversarial inputs, and asserts implemented languages (English) still extract and still return `None` on no match.

Full suite: 1922 passed, 2 skipped (pre-existing `test_packaging` metadata artifact unrelated to this change).