### PR TITLE
fix(da): correct hundrede spelling and 60=tres (not treds)

### DIFF
--- a/ovos_date_parser/res/da/date_time.json
+++ b/ovos_date_parser/res/da/date_time.json
@@ -8,12 +8,12 @@
     "default": "{number}"
   },
   "hundreds_format": {
-    "1": {"match": "^1\\d{2}$", "format": "et hundred"},
-    "2": {"match": "^\\d{3}$", "format": "{x_in_x00} hundred"},
+    "1": {"match": "^1\\d{2}$", "format": "et hundrede"},
+    "2": {"match": "^\\d{3}$", "format": "{x_in_x00} hundrede"},
     "default": "{number}"
   },
   "thousand_format": {
-    "1": {"match": "^1[1-9]\\d{2}$", "format": "{xx_in_xx00} hundred"},
+    "1": {"match": "^1[1-9]\\d{2}$", "format": "{xx_in_xx00} hundrede"},
     "2": {"match": "^1\\d{3}$", "format": "et tusind"},
     "3": {"match": "^\\d{4}$", "format": "{x_in_x000} tusind"},
     "default": "{number}"
@@ -120,7 +120,7 @@
     "30": "tredive",
     "40": "fyrre",
     "50": "halvtreds",
-    "60": "treds",
+    "60": "tres",
     "70": "halvfjerds",
     "80": "firs",
     "90": "halvfems",

--- a/ovos_date_parser/res/da/date_time_test.json
+++ b/ovos_date_parser/res/da/date_time_test.json
@@ -1,19 +1,19 @@
 {
   "test_nice_year": {
       "1": {"datetime_param": "2017, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "to tusind og sytten"},
-      "2": {"datetime_param": "1984, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "nitten hundred og fire og firs"},
-      "3": {"datetime_param": "1906, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "nitten hundred og seks"},
-      "4": {"datetime_param": "1802, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "atten hundred og to" },
-      "5": {"datetime_param": "806, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "otte hundred og seks" },
-      "6": {"datetime_param": "1800, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "atten hundred" },
+      "2": {"datetime_param": "1984, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "nitten hundrede og fire og firs"},
+      "3": {"datetime_param": "1906, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "nitten hundrede og seks"},
+      "4": {"datetime_param": "1802, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "atten hundrede og to" },
+      "5": {"datetime_param": "806, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "otte hundrede og seks" },
+      "6": {"datetime_param": "1800, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "atten hundrede" },
       "7": {"datetime_param": "1, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "et" },
-      "8": {"datetime_param": "103, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "et hundred og tre" },
+      "8": {"datetime_param": "103, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "et hundrede og tre" },
       "9": {"datetime_param": "1000, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "et tusind" },
       "10": {"datetime_param": "2000, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "to tusind" },
       "11": {"datetime_param": "99, 1, 31, 13, 22, 3", "bc": "True", "assertEqual": "ni og halvfems f.kr." },
       "12": {"datetime_param": "5, 1, 31, 13, 22, 3", "bc": "True", "assertEqual": "fem f.kr." },
-      "13": {"datetime_param": "3120, 1, 31, 13, 22, 3", "bc": "True", "assertEqual": "tre tusind et hundred og tyve f.kr." },
-      "14": {"datetime_param": "3241, 1, 31, 13, 22, 3", "bc": "True", "assertEqual": "tre tusind to hundred og en og fyrre f.kr." }
+      "13": {"datetime_param": "3120, 1, 31, 13, 22, 3", "bc": "True", "assertEqual": "tre tusind et hundrede og tyve f.kr." },
+      "14": {"datetime_param": "3241, 1, 31, 13, 22, 3", "bc": "True", "assertEqual": "tre tusind to hundrede og en og fyrre f.kr." }
   },
   "test_nice_date": {
       "1": {"datetime_param": "2017, 1, 31, 0, 2, 3", "now": "None", "assertEqual": "tirsdag, den en og tredivte januar, to tusind og sytten"},

--- a/test/format_tests/test_format_da.py
+++ b/test/format_tests/test_format_da.py
@@ -170,10 +170,10 @@ class TestNiceDateFormat_da(unittest.TestCase):
         self.assertEqual(nice_time(dt, lang="da-dk"), "et femogfyrre")
 
         dt = datetime.datetime(2017, 1, 31, 4, 50, 00, tzinfo=default_timezone())
-        self.assertEqual(nice_time(dt, lang="da-dk"), "fire halvtres")
+        self.assertEqual(nice_time(dt, lang="da-dk"), "fire halvtreds")
 
         dt = datetime.datetime(2017, 1, 31, 5, 55, 00, tzinfo=default_timezone())
-        self.assertEqual(nice_time(dt, lang="da-dk"), "fem femoghalvtres")
+        self.assertEqual(nice_time(dt, lang="da-dk"), "fem femoghalvtreds")
 
         dt = datetime.datetime(2017, 1, 31, 5, 30, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="da-dk", use_ampm=True),


### PR DESCRIPTION
Fixes two spelling bugs in the Danish (da) locale data:

- "et hundred" -> "et hundrede" in hundreds_format/thousand_format. The base number dict already had "100": "hundrede" correctly spelled elsewhere in the same file, so this was an internal inconsistency.
- "60": "treds" -> "tres". Cross-checked against ovos-number-parser, which has the audited/complete Danish implementation and uses 60: tres.
- Updated date_time_test.json fixtures to match the corrected spelling.
- Fixed two pre-existing incorrect test assertions in test_format_da.py ("halvtres" -> "halvtreds" at :50 and :55), consistent with the already-correct "halvtreds" spelling used elsewhere in the same file.

All Danish tests plus the cross-language parity/invariant test suites pass locally.

Fixes #4, Fixes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Danish number and date/time wording, including “hundrede,” “tres,” and “halvtreds.”
  * Improved spoken year and time formatting for Danish locales.

* **Tests**
  * Updated Danish date and time formatting expectations to reflect the corrected wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->