### PR TITLE
feat(da): explicit AD/CE year notation (e.Kr.)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -137,10 +137,13 @@ Date and time combined ("tuesday, june fifth at half past one"). `now`,
 Day number, optionally with the month, ordered by `date_format` (`'DMY'`,
 `'MDY'` or `'YMD'`).
 
-### `nice_weekday(dt, lang)` / `nice_month(dt, lang, date_format='MDY')` / `nice_year(dt, lang, bc=False)`
+### `nice_weekday(dt, lang)` / `nice_month(dt, lang, date_format='MDY')` / `nice_year(dt, lang, bc=False, ad=False)`
 
 Individual components in speakable form. `nice_year` appends a B.C. marker when
-`bc=True` (Python `datetime` cannot itself represent B.C. years).
+`bc=True` (Python `datetime` cannot itself represent B.C. years). Some locales
+(currently Danish) also support an explicit A.D./C.E. marker via `ad=True`;
+`bc` takes precedence if both are set. `ad` is a no-op for locales that don't
+define one.
 
 ```python
 >>> nice_year(datetime(1984, 1, 1), "en")

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -93,6 +93,16 @@ plural declension may be imperfect (e.g. Slovenian dual forms).
 - Spoken numbers are understood in dates, times and durations
   ("peste trei zile", "douăzeci de minute").
 
+## Danish (da)
+
+- `nice_year` supports an explicit AD/CE marker via `nice_year(dt, "da",
+  ad=True)`, appending "e.Kr." the same way `bc=True` appends "f.Kr.". The two
+  are mutually exclusive; if both are passed, `bc` wins. Years are implicitly
+  AD when neither flag is set, as before.
+- The `ad` parameter is part of the generic `year_format` engine and is a
+  no-op for any locale that does not define an `"ad"` key in its
+  `year_format` resource, so it does not affect other languages.
+
 ## Known gaps
 
 - Relative *past* wording ("anoche", "bart", "last night") is not handled in

--- a/ovos_date_parser/__init__.py
+++ b/ovos_date_parser/__init__.py
@@ -643,7 +643,7 @@ class DateTimeFormat:
         return self.lang_config[lang]['date_time_format']['date_time'].format(
             formatted_date=date_str, formatted_time=time_str)
 
-    def year_format(self, dt, lang, bc):
+    def year_format(self, dt, lang, bc, ad=False):
         lang = lang.split("-")[0]
         number_tuple = self._number_strings(dt.year, lang)
         formatted_bc = (
@@ -656,7 +656,7 @@ class DateTimeFormat:
             dt.year, number_tuple, lang, formatted_decade, formatted_hundreds)
 
         s = self._format_string(dt.year, 'year_format', lang)
-        return re.sub(' +', ' ',
+        result = re.sub(' +', ' ',
                       s.format(
                           year=str(dt.year),
                           century=str(int(dt.year / 100)),
@@ -665,6 +665,15 @@ class DateTimeFormat:
                           formatted_decade=formatted_decade,
                           formatted_thousand=formatted_thousand,
                           bc=formatted_bc)).strip()
+        # explicit AD/CE marker, mutually exclusive with bc.
+        # only applied for locales that define an "ad" suffix in their
+        # year_format resource (e.g. "e.Kr." in Danish); a no-op elsewhere
+        # so existing languages/callers are unaffected.
+        if ad and not bc:
+            formatted_ad = self.lang_config[lang]['year_format'].get('ad', '')
+            if formatted_ad:
+                result = f"{result} {formatted_ad}"
+        return result
 
 
 date_time_format = DateTimeFormat(os.path.join(os.path.dirname(__file__), 'res'))
@@ -854,7 +863,7 @@ def nice_month(dt, lang, date_format='MDY'):
     return month.capitalize()
 
 
-def nice_year(dt, lang, bc=False):
+def nice_year(dt, lang, bc=False, ad=False):
     """
         Format a datetime to a pronounceable year
 
@@ -866,6 +875,10 @@ def nice_year(dt, lang, bc=False):
                                   the default language will be used.
             bc (bool) pust B.C. after the year (python does not support dates
                 B.C. in datetime)
+            ad (bool) append an explicit AD/CE marker after the year (e.g.
+                "e.Kr." in Danish). Mutually exclusive with bc. Only has an
+                effect for locales that define an "ad" suffix in their
+                year_format resource; a no-op otherwise.
         Returns:
             (str): The formatted year string
     """
@@ -895,7 +908,7 @@ def nice_year(dt, lang, bc=False):
     if lang.startswith("et"):
         return nice_year_et(dt, bc)
     date_time_format.cache(lang)
-    return date_time_format.year_format(dt, lang, bc)
+    return date_time_format.year_format(dt, lang, bc, ad)
 
 
 def get_date_strings(dt, lang, date_format=None, time_format="full"):

--- a/ovos_date_parser/res/da/date_time.json
+++ b/ovos_date_parser/res/da/date_time.json
@@ -26,7 +26,8 @@
     "5": {"match": "^(1\\d{3})|(\\d0\\d{2})$", "format": "{formatted_thousand} og {formatted_decade} {bc}"},
     "6": {"match": "^\\d{4}$", "format": "{formatted_thousand} {formatted_hundreds} og {formatted_decade} {bc}"},
     "default": "{year} {bc}",
-    "bc": "f.kr."
+    "bc": "f.kr.",
+    "ad": "e.kr."
   },
   "date_format": {
     "date_full": "{weekday}, den {day} {month}, {formatted_year}",

--- a/ovos_date_parser/res/da/date_time.json
+++ b/ovos_date_parser/res/da/date_time.json
@@ -8,12 +8,12 @@
     "default": "{number}"
   },
   "hundreds_format": {
-    "1": {"match": "^1\\d{2}$", "format": "et hundred"},
-    "2": {"match": "^\\d{3}$", "format": "{x_in_x00} hundred"},
+    "1": {"match": "^1\\d{2}$", "format": "et hundrede"},
+    "2": {"match": "^\\d{3}$", "format": "{x_in_x00} hundrede"},
     "default": "{number}"
   },
   "thousand_format": {
-    "1": {"match": "^1[1-9]\\d{2}$", "format": "{xx_in_xx00} hundred"},
+    "1": {"match": "^1[1-9]\\d{2}$", "format": "{xx_in_xx00} hundrede"},
     "2": {"match": "^1\\d{3}$", "format": "et tusind"},
     "3": {"match": "^\\d{4}$", "format": "{x_in_x000} tusind"},
     "default": "{number}"
@@ -120,7 +120,7 @@
     "30": "tredive",
     "40": "fyrre",
     "50": "halvtreds",
-    "60": "treds",
+    "60": "tres",
     "70": "halvfjerds",
     "80": "firs",
     "90": "halvfems",

--- a/ovos_date_parser/res/da/date_time_test.json
+++ b/ovos_date_parser/res/da/date_time_test.json
@@ -1,19 +1,19 @@
 {
   "test_nice_year": {
       "1": {"datetime_param": "2017, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "to tusind og sytten"},
-      "2": {"datetime_param": "1984, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "nitten hundred og fire og firs"},
-      "3": {"datetime_param": "1906, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "nitten hundred og seks"},
-      "4": {"datetime_param": "1802, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "atten hundred og to" },
-      "5": {"datetime_param": "806, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "otte hundred og seks" },
-      "6": {"datetime_param": "1800, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "atten hundred" },
+      "2": {"datetime_param": "1984, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "nitten hundrede og fire og firs"},
+      "3": {"datetime_param": "1906, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "nitten hundrede og seks"},
+      "4": {"datetime_param": "1802, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "atten hundrede og to" },
+      "5": {"datetime_param": "806, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "otte hundrede og seks" },
+      "6": {"datetime_param": "1800, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "atten hundrede" },
       "7": {"datetime_param": "1, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "et" },
-      "8": {"datetime_param": "103, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "et hundred og tre" },
+      "8": {"datetime_param": "103, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "et hundrede og tre" },
       "9": {"datetime_param": "1000, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "et tusind" },
       "10": {"datetime_param": "2000, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "to tusind" },
       "11": {"datetime_param": "99, 1, 31, 13, 22, 3", "bc": "True", "assertEqual": "ni og halvfems f.kr." },
       "12": {"datetime_param": "5, 1, 31, 13, 22, 3", "bc": "True", "assertEqual": "fem f.kr." },
-      "13": {"datetime_param": "3120, 1, 31, 13, 22, 3", "bc": "True", "assertEqual": "tre tusind et hundred og tyve f.kr." },
-      "14": {"datetime_param": "3241, 1, 31, 13, 22, 3", "bc": "True", "assertEqual": "tre tusind to hundred og en og fyrre f.kr." }
+      "13": {"datetime_param": "3120, 1, 31, 13, 22, 3", "bc": "True", "assertEqual": "tre tusind et hundrede og tyve f.kr." },
+      "14": {"datetime_param": "3241, 1, 31, 13, 22, 3", "bc": "True", "assertEqual": "tre tusind to hundrede og en og fyrre f.kr." }
   },
   "test_nice_date": {
       "1": {"datetime_param": "2017, 1, 31, 0, 2, 3", "now": "None", "assertEqual": "tirsdag, den en og tredivte januar, to tusind og sytten"},

--- a/test/format_tests/test_format_da.py
+++ b/test/format_tests/test_format_da.py
@@ -170,10 +170,10 @@ class TestNiceDateFormat_da(unittest.TestCase):
         self.assertEqual(nice_time(dt, lang="da-dk"), "et femogfyrre")
 
         dt = datetime.datetime(2017, 1, 31, 4, 50, 00, tzinfo=default_timezone())
-        self.assertEqual(nice_time(dt, lang="da-dk"), "fire halvtres")
+        self.assertEqual(nice_time(dt, lang="da-dk"), "fire halvtreds")
 
         dt = datetime.datetime(2017, 1, 31, 5, 55, 00, tzinfo=default_timezone())
-        self.assertEqual(nice_time(dt, lang="da-dk"), "fem femoghalvtres")
+        self.assertEqual(nice_time(dt, lang="da-dk"), "fem femoghalvtreds")
 
         dt = datetime.datetime(2017, 1, 31, 5, 30, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="da-dk", use_ampm=True),

--- a/test/format_tests/test_format_da.py
+++ b/test/format_tests/test_format_da.py
@@ -19,10 +19,62 @@ import unittest
 from ovos_config.locale import get_default_tz as default_timezone
 
 from ovos_date_parser import (
-    nice_time
+    nice_time, nice_year
 )
 
 class TestNiceDateFormat_da(unittest.TestCase):
+    def test_nice_year_da(self):
+        # ported from the previously-unused res/da/date_time_test.json
+        # fixtures (issue #7: missing Danish nice_year test coverage)
+        self.assertEqual(nice_year(datetime.datetime(2017, 1, 31), "da"),
+                         "to tusind og sytten")
+        self.assertEqual(nice_year(datetime.datetime(1984, 1, 31), "da"),
+                         "nitten hundrede og fire og firs")
+        self.assertEqual(nice_year(datetime.datetime(1906, 1, 31), "da"),
+                         "nitten hundrede og seks")
+        self.assertEqual(nice_year(datetime.datetime(1802, 1, 31), "da"),
+                         "atten hundrede og to")
+        self.assertEqual(nice_year(datetime.datetime(806, 1, 31), "da"),
+                         "otte hundrede og seks")
+        self.assertEqual(nice_year(datetime.datetime(1800, 1, 31), "da"),
+                         "atten hundrede")
+        self.assertEqual(nice_year(datetime.datetime(103, 1, 31), "da"),
+                         "et hundrede og tre")
+        self.assertEqual(nice_year(datetime.datetime(1000, 1, 31), "da"),
+                         "et tusind")
+        self.assertEqual(nice_year(datetime.datetime(2000, 1, 31), "da"),
+                         "to tusind")
+        self.assertEqual(
+            nice_year(datetime.datetime(99, 1, 31), "da", bc=True),
+            "ni og halvfems f.kr.")
+        self.assertEqual(
+            nice_year(datetime.datetime(5, 1, 31), "da", bc=True),
+            "fem f.kr.")
+        self.assertEqual(
+            nice_year(datetime.datetime(3120, 1, 31), "da", bc=True),
+            "tre tusind et hundrede og tyve f.kr.")
+
+    def test_nice_year_da_ad(self):
+        # issue #11: explicit AD/CE year notation for Danish
+        self.assertEqual(
+            nice_year(datetime.datetime(103, 1, 31), "da", ad=True),
+            "et hundrede og tre e.kr.")
+        self.assertEqual(
+            nice_year(datetime.datetime(806, 1, 31), "da", ad=True),
+            "otte hundrede og seks e.kr.")
+        # bc takes precedence if both are somehow passed together
+        self.assertEqual(
+            nice_year(datetime.datetime(103, 1, 31), "da", bc=True, ad=True),
+            "et hundrede og tre f.kr.")
+        # no explicit marker by default (implicit AD, as before)
+        self.assertEqual(
+            nice_year(datetime.datetime(1984, 1, 31), "da"),
+            "nitten hundrede og fire og firs")
+        # ad has no effect on locales without an "ad" resource key
+        self.assertEqual(
+            nice_year(datetime.datetime(103, 1, 31), "en", ad=True),
+            "one hundred three")
+
     def test_convert_times_da(self):
         dt = datetime.datetime(2017, 1, 31, 13, 22, 3, tzinfo=default_timezone())
 


### PR DESCRIPTION
Adds support for an explicit AD/CE year marker in Danish, mirroring the existing B.C. handling.

```python
nice_year(dt, "da", ad=True)   # -> "...e.Kr."
nice_year(dt, "da", bc=True)   # -> "...f.Kr." (existing, unchanged)
```

## Implementation

- Added an optional `ad` parameter to the generic `year_format()` engine and to the public `nice_year()` function.
- Opt-in per locale via an `"ad"` key in a language's `year_format` resource. Danish now defines `"ad": "e.kr."`. Every other language has no such key, so `ad=True` is a silent no-op for them - fully backward compatible, no behavior change for existing callers.
- `bc` takes precedence if both flags are passed together.
- Documented in docs/api.md and docs/languages.md.

## Tests

- Added `test_nice_year_da`: general nice_year coverage for da (bc + no-marker cases), which had no test coverage at all before this - partial progress on #7.
- Added `test_nice_year_da_ad`: covers the new ad feature, the bc/ad precedence rule, and the no-op fallback for a language without an "ad" key (en).

All Danish + cross-language parity/invariant tests pass locally.

## Note on branch base

This is stacked on #257 (the hundrede/tres spelling fix) - the ported nice_year test assertions use the corrected "hundrede" spelling, so this branch builds on that one rather than duplicating/contradicting it. Diff will shrink to just this feature once #257 merges.

Fixes #11