### PR TITLE
fix(sv): correct fyrtio spelling (was förtio)

### DIFF
--- a/ovos_date_parser/res/sv/date_time.json
+++ b/ovos_date_parser/res/sv/date_time.json
@@ -119,7 +119,7 @@
     "19": "nitton",
     "20": "tjugo",
     "30": "trettio",
-    "40": "förtio",
+    "40": "fyrtio",
     "50": "femtio",
     "60": "sextio",
     "70": "sjuttio",

--- a/ovos_date_parser/res/sv/date_time_test.json
+++ b/ovos_date_parser/res/sv/date_time_test.json
@@ -8,7 +8,7 @@
     "6": {"datetime_param": "454, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "fyra hundra femtio fyra" },
     "7": {"datetime_param": "1005, 1, 31, 13, 22, 3", "bc": "False", "assertEqual": "ett tusen fem" },
     "8": {"datetime_param": "1012, 1, 31, 13, 22, 3", "bc": "False", "assertEqual": "tio tolv" },
-    "9": {"datetime_param": "1046, 1, 31, 13, 22, 3", "bc": "False", "assertEqual": "tio förtio sex" },
+    "9": {"datetime_param": "1046, 1, 31, 13, 22, 3", "bc": "False", "assertEqual": "tio fyrtio sex" },
     "10": {"datetime_param": "1807, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "arton noll sju" },
     "11": {"datetime_param": "1717, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "sjutton sjutton" },
     "12": {"datetime_param": "1988, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "nitton åttio åtta"},
@@ -20,7 +20,7 @@
     "18": {"datetime_param": "1000, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "ett tusen" },
     "19": {"datetime_param": "2000, 1, 31, 13, 22, 3", "bc": "None", "assertEqual": "två tusen" },
     "20": {"datetime_param": "3120, 1, 31, 13, 22, 3", "bc": "True", "assertEqual": "trettio ett tjugo före kristus" },
-    "21": {"datetime_param": "3241, 1, 31, 13, 22, 3", "bc": "True", "assertEqual": "trettio två förtio ett före kristus" },
+    "21": {"datetime_param": "3241, 1, 31, 13, 22, 3", "bc": "True", "assertEqual": "trettio två fyrtio ett före kristus" },
     "22": {"datetime_param": "5200, 1, 31, 13, 22, 3", "bc": "False", "assertEqual": "femtio två hundra" },
     "23": {"datetime_param": "1100, 1, 31, 13, 22, 3", "bc": "False", "assertEqual": "elva hundra" },
     "24": {"datetime_param": "2100, 1, 31, 13, 22, 3", "bc": "False", "assertEqual": "tjugo ett hundra" }


### PR DESCRIPTION
"förtio" is not a Swedish word; the correct spelling for 40 is "fyrtio". Cross-checked against 'ovos-number-parser', which uses "fyrtio" consistently for both the cardinal (40) and ordinal (40th) forms.

Reproduces for any year containing a 4x decade:
```python
nice_year(datetime(1946, 1, 1), "sv")  # -> "nitton förtio sex", should be "...fyrtio sex"
```

Not caught by any currently-active test - `nice_time` reaches :40 via an idiomatic "X minutes to the next hour" phrasing that never spells the word out directly, so the bug only surfaces through `nice_year`/date formatting, which had no test coverage at all before this (see #36).

Also validated all 24 nice_year + 9 nice_date + 2 nice_date_time fixtures in res/sv/date_time_test.json against the actual implementation - this was the only mismatch found.

Fixes #8