### PR TITLE
fix(no): complete the no->nb alias for year/date formatting; document nb/nn

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,9 @@ generic word-table.
 | hu Hungarian    | 🚧 | ✅ |
 | it Italian      | ✅ | ✅ |
 | kab Kabyle      | ✅ | ✅ |
+| nb Norwegian Bokmål | ✅ | ✅ |
 | nl Dutch        | ✅ | ✅ |
+| nn Norwegian Nynorsk | ✅ | ✅ |
 | oc Occitan      | ✅ | ✅ |
 | pl Polish       | ✅ | ✅ |
 | pt Portuguese   | ✅ | ✅ |
@@ -202,7 +204,9 @@ generic word-table.
 | hu Hungarian    | ✅ | ✅ | ✅ | 🚧 |
 | it Italian      | ✅ | ✅ | ✅ | 🚧 |
 | kab Kabyle      | 🚧 | ✅ | ✅ | 🚧 |
+| nb Norwegian Bokmål | ✅ | ✅ | ✅ | 🚧 |
 | nl Dutch        | ✅ | ✅ | ✅ | 🚧 |
+| nn Norwegian Nynorsk | ✅ | ✅ | ✅ | 🚧 |
 | oc Occitan      | ✅ | ✅ | ✅ | 🚧 |
 | pl Polish       | ✅ | ✅ | ✅ | 🚧 |
 | pt Portuguese   | ✅ | ✅ | ✅ | 🚧 |

--- a/ovos_date_parser/__init__.py
+++ b/ovos_date_parser/__init__.py
@@ -484,14 +484,19 @@ class DateTimeFormat:
 
     def cache(self, lang):
         lang = lang.split("-")[0]
+        # "no" is a common alias for Norwegian Bokmål (nb); the dedicated
+        # nice_time/extract_datetime/extract_duration functions already
+        # special-case it, but this generic JSON-driven engine (used by
+        # nice_year/nice_date/nice_date_time) didn't have its own resource
+        # directory for it - load Bokmål's data under the "no" key instead.
+        resource_lang = "nb" if lang == "no" else lang
         # TODO - find closest lang code
         if lang not in self.lang_config:
-            path = self.config_path + '/' + lang + '/date_time.json'
+            path = self.config_path + '/' + resource_lang + '/date_time.json'
             if not os.path.isfile(path):
                 LOG.warning(f"could not find '{path}'")
                 return
-            with open(self.config_path + '/' + lang + '/date_time.json',
-                      'r', encoding='utf8') as lang_config_file:
+            with open(path, 'r', encoding='utf8') as lang_config_file:
                 self.lang_config[lang] = json.loads(
                     lang_config_file.read())
 

--- a/test/test_dates_nb.py
+++ b/test/test_dates_nb.py
@@ -45,6 +45,16 @@ class TestNiceTimeNb(unittest.TestCase):
         self.assertEqual(nice_time(ANCHOR, "no", use_24hour=True),
                          "tretten null fire")
 
+    def test_no_alias_year_and_date(self):
+        # regression test: nice_year/nice_date/nice_date_time go through a
+        # separate generic JSON-driven engine from nice_time/extract_*, and
+        # previously had no "no" resource directory at all, raising a
+        # KeyError instead of falling back to Bokmål like the docs promise
+        self.assertEqual(nice_year(datetime(1984, 1, 1), "no"),
+                         nice_year(datetime(1984, 1, 1), "nb"))
+        self.assertEqual(nice_date(ANCHOR, "no"),
+                         nice_date(ANCHOR, "nb"))
+
 
 class TestNiceDateNb(unittest.TestCase):
     def test_weekday(self):


### PR DESCRIPTION
Two related fixes for Norwegian, found while doing a general nb/nn health check (no existing issue - this repo currently has no nb/nn/no labels at all).

## Bug: incomplete "no" alias

The docs and existing tests already claim "no" is an alias for Bokmål (nb), which works for `nice_time`/`extract_datetime`/`extract_duration` (dedicated per-language dispatch special-cases it). But `nice_year`/`nice_date`/`nice_date_time` go through a separate generic JSON-driven engine (`DateTimeFormat`) that had no `res/no/` directory, so:

```python
nice_year(dt, "no")  # KeyError: 'no'
```

`DateTimeFormat.cache()` now loads Bokmål's resource file for the "no" key too. Verified `nice_year`/`nice_date`/`nice_date_time(dt, "no")` now produce output identical to `(dt, "nb")`. Added a regression test.
## Docs: nb/nn missing from README tables entirely

Both `nb` and `nn` are fully implemented - dedicated `nice_time`/`extract_datetime`/`extract_duration`, full generic-engine coverage for year/date, and 114 existing tests all passing - but neither appears anywhere in the README language support tables, so they look unsupported at a glance. Added both rows (same status as sv: checkmarks across the board except the shared `nice_relative_time`).

## Validation done

For context on how these were found: I cross-checked the nb/nn number-word tables in `ovos_date_parser` against the independently-maintained `ovos-number-parser`, spot-checked `nice_year` output across ~18 years spanning multiple centuries for both nb and nn, and confirmed the existing 114 nb/nn tests all pass. No other discrepancies turned up - the nb/nn implementations are in noticeably better shape than da/sv were before #257/#260, likely thanks to more recent contribution history there.
