### PR TITLE
fix: correct Danish spelling of eleven, raise number-parser floor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dateutil~=2.6
 quebra_frases>=0.3.7
-ovos-number-parser>=0.15.0a1,<1.0.0
+ovos-number-parser>=0.18.17a1,<1.0.0
 dateparser
 ovos-config

--- a/test/format_tests/test_format_da.py
+++ b/test/format_tests/test_format_da.py
@@ -78,7 +78,9 @@ class TestNiceDateFormat_da(unittest.TestCase):
         self.assertEqual(
             nice_time(datetime.datetime(2017, 1, 31, 23, 45), lang="da",
                       use_ampm=True),
-            "elve femogfyrre om natten")
+            # Danish 11 is "elleve"; "elve" is not a standard spelling and
+            # was corrected in the number parser
+            "elleve femogfyrre om natten")
     def test_nice_date_ordinal_days_da(self):
         # issue #4/#9 follow-up (flagged by review on #257): the
         # day-of-month ordinal table is separate from the year/hundreds


### PR DESCRIPTION
`test_nice_time_da_comprehensive` asserted `'elve femogfyrre om natten'`. Danish 11 is **elleve** — `elve` is not a standard spelling, and the number parser was corrected accordingly. The stale expectation was pinning the old, wrong output.

Also raises the number-parser floor from `>=0.15.0a1` to `>=0.18.17a1`. The old floor could resolve to a build lacking both the `elleve` correction and the Romance joiner-direction fix — the latter is what makes the Spanish `TestQuarterAndHalf` and `TestNiceTimeRoundTrip` tests pass, since `las tres y veinte` used to parse as 23 and lose the minutes.

Suite green against number-parser dev: 1930 passed.