### PR TITLE
fix: spell the trema in Dutch nice_time minutes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dateutil~=2.6
 quebra_frases>=0.3.7
-ovos-number-parser>=0.18.17a1,<1.0.0
+ovos-number-parser>=0.19.1a1,<1.0.0
 dateparser
 ovos-config

--- a/test/format_tests/test_format_nl.py
+++ b/test/format_tests/test_format_nl.py
@@ -29,9 +29,9 @@ class TestNiceDateFormat_nl(unittest.TestCase):
                                13, 22, 3, tzinfo=default_timezone())
 
         self.assertEqual(nice_time(dt, lang="nl-nl"),
-                         "tweeentwintig over één")
+                         "tweeëntwintig over één")
         self.assertEqual(nice_time(dt, lang="nl-nl", use_ampm=True),
-                         "tweeentwintig over één 's middags")
+                         "tweeëntwintig over één 's middags")
         self.assertEqual(nice_time(dt, lang="nl-nl", speech=False),
                          "1:22")
         self.assertEqual(nice_time(dt, lang="nl-nl", speech=False,
@@ -45,10 +45,10 @@ class TestNiceDateFormat_nl(unittest.TestCase):
                          "13:22")
         self.assertEqual(nice_time(dt, lang="nl-nl", use_24hour=True,
                                    use_ampm=True),
-                         "dertien uur tweeentwintig")
+                         "dertien uur tweeëntwintig")
         self.assertEqual(nice_time(dt, lang="nl-nl", use_24hour=True,
                                    use_ampm=False),
-                         "dertien uur tweeentwintig")
+                         "dertien uur tweeëntwintig")
 
         dt = datetime.datetime(2017, 1, 31,
                                13, 0, 3, tzinfo=default_timezone())


### PR DESCRIPTION
`nice_time` for Dutch produced `tweeentwintig over één`. The number parser now correctly writes `tweeëntwintig` — Dutch requires a trema at the vowel collision in a compound numeral (Nederlandse Taalunie), landed in ovos-number-parser and validated against the Taalunie's own cited example.

Updates the four stale `nice_time_nl` expectations and raises the number-parser floor to `>=0.19.1a1`, the build carrying the trema fix.

Downstream follow-up to ovos-number-parser's Dutch trema fix; found while verifying that change against date-parser.