### PR TITLE
fix: keep Hebrew date fields masculine via explicit gender kwarg

### DIFF
--- a/ovos_date_parser/dates_he.py
+++ b/ovos_date_parser/dates_he.py
@@ -134,7 +134,12 @@ def nice_year_he(dt, bc=False):
     Returns:
         (str): the formatted year
     """
-    year = pronounce_number_he(dt.year)
+    # Hebrew date fields keep the masculine forms this formatter has always
+    # produced; the number parser now defaults to the feminine abstract
+    # counting form, so the gender is requested explicitly here. Whether a
+    # year (שנה, feminine) or day-of-month should instead be feminine is a
+    # separate Hebrew-dates question, deliberately not changed here.
+    year = pronounce_number_he(dt.year, feminine=False)
     if bc:
         return f"{year} לפני הספירה"
     return year
@@ -173,7 +178,7 @@ def nice_date_he(dt: datetime, now: datetime = None, include_weekday=True):
     Returns:
         (str): the formatted date
     """
-    day = pronounce_number_he(dt.day)
+    day = pronounce_number_he(dt.day, feminine=False)
     if now is not None:
         if dt.year == now.year and dt.month == now.month:
             if dt.day == now.day:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dateutil~=2.6
 quebra_frases>=0.3.7
-ovos-number-parser>=0.19.1a1,<1.0.0
+ovos-number-parser>=0.19.6a2,<1.0.0
 dateparser
 ovos-config


### PR DESCRIPTION
The number parser now defaults Hebrew numbers to the feminine abstract counting form (per the Academy of the Hebrew Language). Hebrew date fields (`year`, `day`) here previously relied on the old masculine default, so `nice_date`/`nice_year` changed.

This requests `feminine=False` explicitly at both call sites, so the Hebrew date output is **byte-for-byte unchanged** from before. Whether a year (שנה, feminine) or a day-of-month should actually be feminine is a separate Hebrew-dates decision, deliberately not made here.

Raises the number-parser floor to `>=0.19.6a2`, the build that adds the `feminine` kwarg. Downstream companion to ovos-number-parser's Hebrew feminine-default fix. Hebrew tests green (149 passed).