### PR TITLE
feat: split extract_datetime_en into extract_date_en and extract_time_en

### DIFF
--- a/ovos_date_parser/__init__.py
+++ b/ovos_date_parser/__init__.py
@@ -72,7 +72,8 @@ from ovos_date_parser.dates_nn import (
     extract_datetime_nn, extract_duration_nn, nice_time_nn,
 )
 from ovos_date_parser.dates_en import (
-    extract_datetime_en, extract_duration_en, nice_time_en
+    extract_datetime_en, extract_date_en, extract_time_en,
+    extract_duration_en, nice_time_en
 )
 from ovos_date_parser.dates_es import (
     extract_datetime_es, extract_duration_es, nice_time_es, nice_date_time_es, nice_date_es,

--- a/ovos_date_parser/dates_en.py
+++ b/ovos_date_parser/dates_en.py
@@ -1,5 +1,5 @@
 import re
-from datetime import datetime, timedelta, time
+from datetime import datetime, timedelta, time, date
 
 from dateutil.relativedelta import relativedelta
 from ovos_number_parser.numbers_en import extract_number_en, numbers_to_digits_en, pronounce_number_en
@@ -116,79 +116,32 @@ def extract_duration_en(text, resolution=DurationResolution.TIMEDELTA,
                                     resolution, replace_token)
 
 
-def extract_datetime_en(text, anchorDate=None, default_time=None):
-    """ Convert a human date reference into an exact datetime
+def _scan_date_en(words, anchorDate):
+    """Scan the (in-place mutated) ``words`` list for date-side information.
 
-    Convert things like
-        "today"
-        "tomorrow afternoon"
-        "next Tuesday at 4pm"
-        "August 3rd"
-    into a datetime.  If a reference date is not provided, the current
-    local time is used.  Also consumes the words used to define the date
-    returning the remaining string.  For example, the string
-       "what is Tuesday's weather forecast"
-    returns the date for the forthcoming Tuesday relative to the reference
-    date and the remainder string
-       "what is weather forecast".
+    This is the first half of the original ``extract_datetime_en`` monolith,
+    lifted verbatim: the word loop that recognises weekdays ("on/next/last/this
+    monday"), relative day/week/month/year offsets ("in 3 days", "2 weeks
+    ago"), "couple of" multiples, and ordinal + month-name dates ("june 5th",
+    "the 3rd of july").  It also enforces the inherited quirk that the "next"
+    instance of a weekday or weekend is never earlier than 48 hours away.
 
-    The "next" instance of a day or weekend is considered to be no earlier than
-    48 hours in the future. On Friday, "next Monday" would be in 3 days.
-    On Saturday, "next Monday" would be in 9 days.
+    Consumed tokens are blanked out in ``words`` in place -- the caller shares
+    the very same list with :func:`_scan_time_en`, so time scanning sees the
+    already-consumed date words as empty strings.
 
     Args:
-        text (str): string containing date words
-        anchorDate (datetime): A reference date/time for "tommorrow", etc
-        default_time (time): Time to set if no time was found in the string
+        words (list): tokenised, number-normalised utterance (mutated in place)
+        anchorDate (datetime): reference date/time for "tomorrow", "next" etc.
 
     Returns:
-        [datetime, str]: An array containing the datetime and the remaining
-                         text not consumed in the parsing, or None if no
-                         date or time related text was found.
+        dict: the date-side scanner state -- ``found``, ``datestr``,
+        ``hasYear``, ``dayOffset``, ``monthOffset``, ``yearOffset``,
+        ``daySpecified``, ``timeQualifier``, ``fromFlag``, ``currentYear`` and
+        the mutated ``words``.  ``now_return`` holds a ready ``[datetime, str]``
+        pair when the utterance was a bare "now" (the caller returns it
+        verbatim and skips time scanning), otherwise ``None``.
     """
-
-    def clean_string(s):
-        # normalize and lowercase utt  (replaces words with numbers)
-        s = numbers_to_digits_en(s, ordinals=None)
-        # clean unneeded punctuation and capitalization among other things.
-        s = s.lower().replace('?', '').replace(',', '') \
-            .replace(' the ', ' ').replace(' a ', ' ').replace(' an ', ' ') \
-            .replace("o' clock", "o'clock").replace("o clock", "o'clock") \
-            .replace("o ' clock", "o'clock").replace("o 'clock", "o'clock") \
-            .replace("oclock", "o'clock").replace("couple", "2") \
-            .replace("centuries", "century").replace("decades", "decade") \
-            .replace("millenniums", "millennium")
-
-        wordList = s.split()
-        for idx, word in enumerate(wordList):
-            word = word.replace("'s", "")
-
-            ordinals = ["rd", "st", "nd", "th"]
-            if word[0].isdigit():
-                for ordinal in ordinals:
-                    # "second" is the only case we should not do this
-                    if ordinal in word and "second" not in word:
-                        word = word.replace(ordinal, "")
-            wordList[idx] = word
-
-        return wordList
-
-    def date_found():
-        return found or \
-            (
-                    datestr != "" or
-                    yearOffset != 0 or monthOffset != 0 or
-                    dayOffset is True or hrOffset != 0 or
-                    hrAbs or minOffset != 0 or
-                    minAbs or secOffset != 0
-            )
-
-    if not anchorDate:
-        anchorDate = now_local()
-
-    if text == "":
-        return None
-    default_time = default_time or time(0, 0, 0)
     found = False
     daySpecified = False
     dayOffset = False
@@ -225,8 +178,6 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
     day_multiples = ["weeks", "months", "years"]
     past_markers = ["was", "last", "past"]
 
-    words = clean_string(text)
-
     for idx, word in enumerate(words):
         if word == "":
             continue
@@ -247,7 +198,7 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
             resultStr = " ".join(words[idx + 1:])
             resultStr = ' '.join(resultStr.split())
             extractedDate = anchorDate.replace(microsecond=0)
-            return [extractedDate, resultStr]
+            return {"now_return": [extractedDate, resultStr]}
         elif wordNext in year_multiples:
             multiplier = None
             if is_numeric(word):
@@ -628,7 +579,79 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
             found = True
             daySpecified = True
 
-    # parse time
+    return {
+        "found": found,
+        "daySpecified": daySpecified,
+        "dayOffset": dayOffset,
+        "monthOffset": monthOffset,
+        "yearOffset": yearOffset,
+        "currentYear": currentYear,
+        "fromFlag": fromFlag,
+        "datestr": datestr,
+        "hasYear": hasYear,
+        "timeQualifier": timeQualifier,
+        "words": words,
+        "now_return": None,
+    }
+
+
+def _scan_time_en(words, anchorDate, date_state):
+    """Scan the (in-place mutated) ``words`` list for clock-time information.
+
+    Second half of the original monolith, lifted verbatim: noon/midnight and
+    morning/afternoon/evening qualifiers, "in/last N hours|minutes|seconds",
+    "half past 8", "quarter past 10", "20 to 5 pm", colon clock forms ("7:30"),
+    bare "at 7", am/pm and military ("0800 hours") times.  It reads the
+    date-side state from :func:`_scan_date_en` (``found``, ``daySpecified``,
+    ``dayOffset``, ``timeQualifier``) because an already-passed bare clock time
+    rolls the day forward to the next morning.
+
+    Args:
+        words (list): tokenised utterance, already date-scanned (mutated)
+        anchorDate (datetime): reference date/time
+        date_state (dict): the mapping returned by :func:`_scan_date_en`
+
+    Returns:
+        dict: the merged state after time scanning -- the time-side ``hrAbs``,
+        ``minAbs``, ``hrOffset``, ``minOffset``, ``secOffset`` and ``military``
+        plus the possibly-updated ``found``, ``daySpecified`` and ``dayOffset``
+        and the mutated ``words``.
+    """
+    found = date_state["found"]
+    daySpecified = date_state["daySpecified"]
+    dayOffset = date_state["dayOffset"]
+    timeQualifier = date_state["timeQualifier"]
+
+    # ``start`` is a stale carry-over from the date loop in the original
+    # monolith: the time loop only ever decrements it and never reads it back,
+    # so its value cannot affect the result.  It is seeded here purely so the
+    # extracted function does not raise NameError now that the two loops live
+    # in separate scopes.
+    start = 0
+
+    timeQualifiersAM = ['morning']
+    timeQualifiersPM = ['afternoon', 'evening', 'night', 'tonight']
+    timeQualifiersList = set(timeQualifiersAM + timeQualifiersPM)
+    year_markers = ['in', 'on', 'of']
+    past_markers = ["last", "past"]
+    earlier_markers = ["ago", "earlier"]
+    later_markers = ["after", "later"]
+    future_markers = ["in", "within"]  # in a month -> + 1 month timedelta
+    future_1st_markers = ["next"]  # next month -> day 1 of next month
+    markers = year_markers + ['at', 'by', 'this', 'around', 'for', "within"]
+    days = ['monday', 'tuesday', 'wednesday',
+            'thursday', 'friday', 'saturday', 'sunday']
+    months = ['january', 'february', 'march', 'april', 'may', 'june',
+              'july', 'august', 'september', 'october', 'november',
+              'december']
+    recur_markers = days + [d + 's' for d in days] + ['weekend', 'weekday',
+                                                      'weekends', 'weekdays']
+    monthsShort = ['jan', 'feb', 'mar', 'apr', 'may', 'june', 'july', 'aug',
+                   'sept', 'oct', 'nov', 'dec']
+    year_multiples = ["decade", "century", "millennium"]
+    day_multiples = ["weeks", "months", "years"]
+    past_markers = ["was", "last", "past"]
+
     hrOffset = 0
     minOffset = 0
     secOffset = 0
@@ -1040,9 +1063,144 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
             idx += used - 1
             found = True
 
+    return {
+        "found": found,
+        "daySpecified": daySpecified,
+        "dayOffset": dayOffset,
+        "hrOffset": hrOffset,
+        "minOffset": minOffset,
+        "secOffset": secOffset,
+        "hrAbs": hrAbs,
+        "minAbs": minAbs,
+        "military": military,
+        "words": words,
+    }
+
+
+def _extract_datetime_en(text, anchorDate=None, default_time=None):
+    """ Convert a human date reference into an exact datetime
+
+    Convert things like
+        "today"
+        "tomorrow afternoon"
+        "next Tuesday at 4pm"
+        "August 3rd"
+    into a datetime.  If a reference date is not provided, the current
+    local time is used.  Also consumes the words used to define the date
+    returning the remaining string.  For example, the string
+       "what is Tuesday's weather forecast"
+    returns the date for the forthcoming Tuesday relative to the reference
+    date and the remainder string
+       "what is weather forecast".
+
+    The "next" instance of a day or weekend is considered to be no earlier than
+    48 hours in the future. On Friday, "next Monday" would be in 3 days.
+    On Saturday, "next Monday" would be in 9 days.
+
+    Args:
+        text (str): string containing date words
+        anchorDate (datetime): A reference date/time for "tommorrow", etc
+        default_time (time): Time to set if no time was found in the string
+
+    Returns:
+        tuple: ``(result, has_date, has_time)`` where ``result`` is the
+            ``[datetime, str]`` pair (datetime + unconsumed remainder) or
+            ``None`` when nothing date/time related was found, ``has_date`` is
+            True when a calendar-date component matched (weekday, month-name
+            date or a day/month/year offset -- not a bare clock time) and
+            ``has_time`` is True when a clock-time component matched (absolute
+            hour/minute or an hour/minute/second offset).  The public
+            :func:`extract_datetime_en` returns only ``result``; the
+            :func:`extract_date_en` / :func:`extract_time_en` wrappers use the
+            flags to enforce their date-only / time-only contracts.
+    """
+
+    def clean_string(s):
+        # normalize and lowercase utt  (replaces words with numbers)
+        s = numbers_to_digits_en(s, ordinals=None)
+        # clean unneeded punctuation and capitalization among other things.
+        s = s.lower().replace('?', '').replace(',', '') \
+            .replace(' the ', ' ').replace(' a ', ' ').replace(' an ', ' ') \
+            .replace("o' clock", "o'clock").replace("o clock", "o'clock") \
+            .replace("o ' clock", "o'clock").replace("o 'clock", "o'clock") \
+            .replace("oclock", "o'clock").replace("couple", "2") \
+            .replace("centuries", "century").replace("decades", "decade") \
+            .replace("millenniums", "millennium")
+
+        wordList = s.split()
+        for idx, word in enumerate(wordList):
+            word = word.replace("'s", "")
+
+            ordinals = ["rd", "st", "nd", "th"]
+            if word[0].isdigit():
+                for ordinal in ordinals:
+                    # "second" is the only case we should not do this
+                    if ordinal in word and "second" not in word:
+                        word = word.replace(ordinal, "")
+            wordList[idx] = word
+
+        return wordList
+
+    if not anchorDate:
+        anchorDate = now_local()
+
+    if text == "":
+        return None, False, False
+    default_time = default_time or time(0, 0, 0)
+
+    words = clean_string(text)
+
+    date_state = _scan_date_en(words, anchorDate)
+    if date_state["now_return"] is not None:
+        # a bare "now": the current moment carries both a date and a time
+        return date_state["now_return"], True, True
+    time_state = _scan_time_en(words, anchorDate, date_state)
+
+    # merge the two scanner states back into the flat locals the original
+    # assembly step operates on
+    found = time_state["found"]
+    daySpecified = time_state["daySpecified"]
+    dayOffset = time_state["dayOffset"]
+    monthOffset = date_state["monthOffset"]
+    yearOffset = date_state["yearOffset"]
+    currentYear = date_state["currentYear"]
+    datestr = date_state["datestr"]
+    hasYear = date_state["hasYear"]
+    hrOffset = time_state["hrOffset"]
+    minOffset = time_state["minOffset"]
+    secOffset = time_state["secOffset"]
+    hrAbs = time_state["hrAbs"]
+    minAbs = time_state["minAbs"]
+
+    # a DATE component is one the *date* scanner recognised (weekday match,
+    # month-name date, or a day/month/year offset).  The date scanner's own
+    # dayOffset is read here rather than the merged one, because a bare clock
+    # time that has already passed nudges dayOffset forward by a day during
+    # time scanning -- that roll is a time effect and must not count as a date.
+    _has_date = (date_state["datestr"] != "" or date_state["found"]
+                 or (date_state["dayOffset"] is not False
+                     and date_state["dayOffset"] != 0)
+                 or date_state["monthOffset"] != 0
+                 or date_state["yearOffset"] != 0)
+    # a TIME component is an absolute hour/minute or a nonzero h/m/s offset.
+    # the -1 sentinel hrAbs/minAbs (set by "half past", "in 3 hours" etc.)
+    # still counts as a time match.
+    _has_time = (hrAbs is not None or minAbs is not None
+                 or hrOffset != 0 or minOffset != 0 or secOffset != 0)
+
+    def date_found():
+        return found or \
+            (
+                    datestr != "" or
+                    yearOffset != 0 or monthOffset != 0 or
+                    dayOffset is True or hrOffset != 0 or
+                    hrAbs or minOffset != 0 or
+                    minAbs or secOffset != 0
+            )
+
     # check that we found a date
     if not date_found():
-        return None
+        return None, False, False
 
     if dayOffset is False:
         dayOffset = 0
@@ -1065,7 +1223,7 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
     if datestr != "" and temp is None:
         # an explicit date was spoken but it does not exist on the calendar
         # (e.g. "february 29 2019"); report nothing rather than a wrong guess
-        return None
+        return None, False, False
     if temp is not None:
         extractedDate = extractedDate.replace(hour=0, minute=0, second=0)
         if not hasYear:
@@ -1112,7 +1270,7 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
     except (OverflowError, ValueError):
         # a relative offset so large it cannot be represented as a datetime
         # (e.g. "999999999999 hours"); report nothing rather than a wrong guess
-        return None
+        return None, False, False
 
     if hrAbs != -1 and minAbs != -1 and not hrOffset and not minOffset and not secOffset:
         # If no time was supplied in the string set the time to default
@@ -1129,7 +1287,7 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
         except ValueError:
             # an out-of-range clock value such as "2400" or "24:00" that maps
             # to hour 24 or beyond; report nothing rather than a wrong guess
-            return None
+            return None, False, False
 
         if (hrAbs != 0 or minAbs != 0) and datestr == "":
             if not daySpecified and anchorDate > extractedDate:
@@ -1142,4 +1300,125 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
 
     resultStr = " ".join(words)
     resultStr = ' '.join(resultStr.split())
-    return [extractedDate, resultStr]
+    return [extractedDate, resultStr], _has_date, _has_time
+
+
+def extract_datetime_en(text, anchorDate=None, default_time=None):
+    """ Convert a human date reference into an exact datetime
+
+    Convert things like
+        "today"
+        "tomorrow afternoon"
+        "next Tuesday at 4pm"
+        "August 3rd"
+    into a datetime.  If a reference date is not provided, the current
+    local time is used.  Also consumes the words used to define the date
+    returning the remaining string.  For example, the string
+       "what is Tuesday's weather forecast"
+    returns the date for the forthcoming Tuesday relative to the reference
+    date and the remainder string
+       "what is weather forecast".
+
+    The "next" instance of a day or weekend is considered to be no earlier than
+    48 hours in the future. On Friday, "next Monday" would be in 3 days.
+    On Saturday, "next Monday" would be in 9 days.
+
+    Args:
+        text (str): string containing date words
+        anchorDate (datetime): A reference date/time for "tommorrow", etc
+        default_time (time): Time to set if no time was found in the string
+
+    Returns:
+        [datetime, str]: An array containing the datetime and the remaining
+                         text not consumed in the parsing, or None if no
+                         date or time related text was found.
+    """
+    return _extract_datetime_en(text, anchorDate, default_time)[0]
+
+
+def extract_date_en(text, ref_date=None):
+    """Extract only the DATE component of a natural-language phrase.
+
+    Runs the exact same clean -> date-scan -> time-scan -> assembly pipeline as
+    :func:`extract_datetime_en`, but only returns a result when a calendar-date
+    component was actually recognised: a weekday ("next friday"), a month-name
+    date ("march 5th", "the 3rd of july", "june 2027") or a relative day/week/
+    month/year offset ("in 3 days", "2 weeks ago", "tomorrow").  A phrase that
+    is only a bare clock time returns ``None`` -- e.g. "at 5 pm" -> ``None``,
+    while "tomorrow at 5pm" -> ``(date, remainder)``.
+
+    Any time words present are still consumed from the returned remainder (they
+    just do not, on their own, produce a date), so "tomorrow at 5pm" yields the
+    tomorrow date with both "tomorrow" and "at 5pm" stripped from the remainder.
+
+    The "next X is at least 48 hours away" rule is inherited unchanged from the
+    underlying scanner: on a Friday, "next monday" is 3 days out; on a Saturday
+    it is 9 days out.
+
+    Args:
+        text (str): phrase possibly containing a date reference.
+        ref_date (datetime | date): reference point for relative dates such as
+            "tomorrow".  A bare ``date`` is coerced to midnight of that day; if
+            omitted the current local time is used.
+
+    Returns:
+        tuple[datetime.date, str] | None: ``(date, remainder)`` when a date
+        component matched, otherwise ``None``.  Never raises on garbage input.
+    """
+    anchorDate = _coerce_anchor(ref_date)
+    try:
+        result, has_date, _has_time = _extract_datetime_en(text, anchorDate)
+    except Exception:
+        return None
+    if result is None or not has_date:
+        return None
+    return result[0].date(), result[1]
+
+
+def extract_time_en(text, ref_time=None):
+    """Extract only the TIME component of a natural-language phrase.
+
+    Runs the exact same clean -> date-scan -> time-scan -> assembly pipeline as
+    :func:`extract_datetime_en`, but only returns a result when a clock-time
+    component was actually recognised: an absolute hour/minute ("at 7:30",
+    "quarter past 10", "20 to 5 pm", "at noon", "at midnight", "half past 8")
+    or a relative hour/minute/second offset ("in a couple of hours",
+    "in 5 minutes").  A phrase that is only a date returns ``None`` -- e.g.
+    "tomorrow" -> ``None``, while "at 5 pm" -> ``(time(17, 0), remainder)``.
+
+    The reference is only used to resolve the ambiguous "has this clock time
+    already passed today?" roll inside the scanner; the returned value is a
+    plain :class:`datetime.time`, so the date the scanner rolled to is dropped.
+
+    Args:
+        text (str): phrase possibly containing a time reference.
+        ref_time (datetime | date): reference point.  A bare ``date`` is coerced
+            to midnight; if omitted the current local time is used.
+
+    Returns:
+        tuple[datetime.time, str] | None: ``(time, remainder)`` when a time
+        component matched, otherwise ``None``.  Never raises on garbage input.
+    """
+    anchorDate = _coerce_anchor(ref_time)
+    try:
+        result, _has_date, has_time = _extract_datetime_en(text, anchorDate)
+    except Exception:
+        return None
+    if result is None or not has_time:
+        return None
+    return result[0].time(), result[1]
+
+
+def _coerce_anchor(ref):
+    """Normalise a date/datetime reference to a datetime (or None).
+
+    ``datetime`` is passed through, a bare ``date`` becomes midnight of that
+    day, and ``None`` is left as-is so the scanner falls back to ``now_local``.
+    """
+    if ref is None:
+        return None
+    if isinstance(ref, datetime):
+        return ref
+    if isinstance(ref, date):
+        return datetime(ref.year, ref.month, ref.day)
+    return ref

--- a/test/test_extract_date_time_en.py
+++ b/test/test_extract_date_time_en.py
@@ -1,0 +1,369 @@
+"""Behaviour tests for extract_date_en / extract_time_en.
+
+These exercise the date-only / time-only public wrappers around the shared
+English datetime scanner.  The anchor is a fixed Tuesday, ``2017-06-27 13:04``,
+so every expected ``date(...)`` / ``time(...)`` value below is deterministic and
+was worked out by hand from that anchor (weekday offsets, the "next X is at
+least 48h away" rule, month-name resolution, relative offsets and the handful
+of inherited scanner quirks that are called out in comments).
+
+Both wrappers must never raise on garbage input -- they return ``None`` instead.
+"""
+import unittest
+from datetime import datetime, date, time
+
+from ovos_date_parser import extract_date_en, extract_time_en
+
+# a plain Tuesday afternoon
+ANCHOR = datetime(2017, 6, 27, 13, 4)
+
+
+class TestExtractDateWeekdays(unittest.TestCase):
+    """`on/next/last/this X` weekday phrases resolve against the Tuesday anchor."""
+
+    def test_on_each_weekday(self):
+        # "on X" is the coming X, today counts as itself (tuesday -> today)
+        self.assertEqual(extract_date_en("on monday", ANCHOR),
+                         (date(2017, 7, 3), ""))
+        self.assertEqual(extract_date_en("on tuesday", ANCHOR),
+                         (date(2017, 6, 27), ""))
+        self.assertEqual(extract_date_en("on wednesday", ANCHOR),
+                         (date(2017, 6, 28), ""))
+        self.assertEqual(extract_date_en("on thursday", ANCHOR),
+                         (date(2017, 6, 29), ""))
+        self.assertEqual(extract_date_en("on friday", ANCHOR),
+                         (date(2017, 6, 30), ""))
+        self.assertEqual(extract_date_en("on saturday", ANCHOR),
+                         (date(2017, 7, 1), ""))
+        self.assertEqual(extract_date_en("on sunday", ANCHOR),
+                         (date(2017, 7, 2), ""))
+
+    def test_next_weekday_is_at_least_48h_out(self):
+        # the inherited "next" rule: on Tuesday, "next monday" is <=2 days so
+        # it rolls a week, but "next friday" (3 days) does not
+        self.assertEqual(extract_date_en("next monday", ANCHOR),
+                         (date(2017, 7, 3), ""))
+        self.assertEqual(extract_date_en("next tuesday", ANCHOR),
+                         (date(2017, 7, 4), ""))
+        self.assertEqual(extract_date_en("next friday", ANCHOR),
+                         (date(2017, 6, 30), ""))
+        self.assertEqual(extract_date_en("next sunday", ANCHOR),
+                         (date(2017, 7, 2), ""))
+
+    def test_last_weekday(self):
+        self.assertEqual(extract_date_en("last monday", ANCHOR),
+                         (date(2017, 6, 26), ""))
+        self.assertEqual(extract_date_en("last friday", ANCHOR),
+                         (date(2017, 6, 23), ""))
+        self.assertEqual(extract_date_en("last tuesday", ANCHOR),
+                         (date(2017, 6, 20), ""))
+
+    def test_this_weekday(self):
+        self.assertEqual(extract_date_en("this wednesday", ANCHOR),
+                         (date(2017, 6, 28), ""))
+        self.assertEqual(extract_date_en("this friday", ANCHOR),
+                         (date(2017, 6, 30), ""))
+
+
+class TestExtractDateMonthNames(unittest.TestCase):
+    """Month-name dates, ordinals and explicit years."""
+
+    def test_bare_month_day(self):
+        # no year given and the date has already passed this year -> next year
+        self.assertEqual(extract_date_en("march 5th", ANCHOR),
+                         (date(2018, 3, 5), ""))
+        # still ahead this year -> this year
+        self.assertEqual(extract_date_en("december 25th", ANCHOR),
+                         (date(2017, 12, 25), ""))
+
+    def test_ordinal_of_month(self):
+        # "the" survives in the remainder (only "of july" is consumed)
+        self.assertEqual(extract_date_en("the 3rd of july", ANCHOR),
+                         (date(2017, 7, 3), "the"))
+        self.assertEqual(extract_date_en("the 1st of january", ANCHOR),
+                         (date(2018, 1, 1), "the"))
+
+    def test_explicit_year(self):
+        self.assertEqual(extract_date_en("5 december 2030", ANCHOR),
+                         (date(2030, 12, 5), ""))
+        self.assertEqual(extract_date_en("5 june 2030", ANCHOR),
+                         (date(2030, 6, 5), ""))
+        self.assertEqual(extract_date_en("february 29 2024", ANCHOR),
+                         (date(2024, 2, 29), ""))
+
+    def test_month_and_year_quirk(self):
+        # QUIRK: "june 2027" is parsed as month+day-less "%B %Y" but hasYear is
+        # False (only one trailing number), so the year is discarded and the
+        # next-occurrence rule fires -> june of the following year, day 1
+        self.assertEqual(extract_date_en("june 2027", ANCHOR),
+                         (date(2018, 6, 1), ""))
+
+    def test_worded_ordinal_quirk(self):
+        # QUIRK: "the fifth of november 1955" -> only "of november" parses; the
+        # spelled ordinal and year are left in the remainder, day defaults to 1
+        self.assertEqual(extract_date_en("the fifth of november 1955", ANCHOR),
+                         (date(2017, 11, 1), "the fifth"))
+
+
+class TestExtractDateRelative(unittest.TestCase):
+    """Relative day/week/month/year offsets."""
+
+    def test_relative_today_tomorrow_yesterday(self):
+        self.assertEqual(extract_date_en("today", ANCHOR),
+                         (date(2017, 6, 27), ""))
+        self.assertEqual(extract_date_en("tomorrow", ANCHOR),
+                         (date(2017, 6, 28), ""))
+        self.assertEqual(extract_date_en("yesterday", ANCHOR),
+                         (date(2017, 6, 26), ""))
+        self.assertEqual(extract_date_en("day after tomorrow", ANCHOR),
+                         (date(2017, 6, 29), ""))
+        self.assertEqual(extract_date_en("day before yesterday", ANCHOR),
+                         (date(2017, 6, 25), ""))
+
+    def test_relative_days(self):
+        self.assertEqual(extract_date_en("in 1 day", ANCHOR),
+                         (date(2017, 6, 28), ""))
+        self.assertEqual(extract_date_en("in 3 days", ANCHOR),
+                         (date(2017, 6, 30), ""))
+        self.assertEqual(extract_date_en("in 100 days", ANCHOR),
+                         (date(2017, 10, 5), ""))
+
+    def test_relative_weeks(self):
+        self.assertEqual(extract_date_en("in 2 weeks", ANCHOR),
+                         (date(2017, 7, 11), ""))
+        self.assertEqual(extract_date_en("2 weeks ago", ANCHOR),
+                         (date(2017, 6, 13), ""))
+        # "next week" -> next monday
+        self.assertEqual(extract_date_en("next week", ANCHOR),
+                         (date(2017, 7, 3), ""))
+        self.assertEqual(extract_date_en("last week", ANCHOR),
+                         (date(2017, 6, 20), ""))
+
+    def test_relative_months(self):
+        # "next month" -> day 1 of next month
+        self.assertEqual(extract_date_en("next month", ANCHOR),
+                         (date(2017, 7, 1), ""))
+        # "last month" keeps the day-of-month
+        self.assertEqual(extract_date_en("last month", ANCHOR),
+                         (date(2017, 5, 27), ""))
+        self.assertEqual(extract_date_en("in 5 months", ANCHOR),
+                         (date(2017, 11, 27), ""))
+
+    def test_relative_years(self):
+        # "next year" -> jan 1
+        self.assertEqual(extract_date_en("next year", ANCHOR),
+                         (date(2018, 1, 1), ""))
+        self.assertEqual(extract_date_en("last year", ANCHOR),
+                         (date(2016, 6, 27), ""))
+        self.assertEqual(extract_date_en("3 years ago", ANCHOR),
+                         (date(2014, 6, 27), ""))
+
+
+class TestExtractDateWithTimeConsumed(unittest.TestCase):
+    """A time in the phrase is still consumed, but only the date is returned."""
+
+    def test_date_plus_time(self):
+        self.assertEqual(extract_date_en("tomorrow at 5pm", ANCHOR),
+                         (date(2017, 6, 28), ""))
+        self.assertEqual(extract_date_en("next friday at 8 am", ANCHOR),
+                         (date(2017, 6, 30), ""))
+        self.assertEqual(
+            extract_date_en("december 25th at 9 in the morning", ANCHOR),
+            (date(2017, 12, 25), ""))
+
+
+class TestExtractDateNone(unittest.TestCase):
+    """Time-only, empty and nonsensical inputs yield no date."""
+
+    def test_bare_time_is_not_a_date(self):
+        self.assertIsNone(extract_date_en("at 5 pm", ANCHOR))
+        self.assertIsNone(extract_date_en("at noon", ANCHOR))
+        self.assertIsNone(extract_date_en("at midnight", ANCHOR))
+        self.assertIsNone(extract_date_en("in 5 minutes", ANCHOR))
+        self.assertIsNone(extract_date_en("half past 8", ANCHOR))
+
+    def test_non_dates(self):
+        self.assertIsNone(extract_date_en("no date here", ANCHOR))
+        self.assertIsNone(extract_date_en("", ANCHOR))
+        self.assertIsNone(extract_date_en("the the the", ANCHOR))
+        self.assertIsNone(extract_date_en("12345", ANCHOR))
+
+    def test_impossible_calendar_date(self):
+        # "february 30" does not exist -> None rather than a wrong guess
+        self.assertIsNone(extract_date_en("february 30", ANCHOR))
+        self.assertIsNone(extract_date_en("february 29 2019", ANCHOR))
+
+
+class TestExtractTimeClockForms(unittest.TestCase):
+    """Absolute clock forms and am/pm."""
+
+    def test_colon_and_ampm(self):
+        # "at 7:30" with no am/pm and afternoon anchor -> 19:30 (assumed pm)
+        self.assertEqual(extract_time_en("at 7:30", ANCHOR),
+                         (time(19, 30), ""))
+        self.assertEqual(extract_time_en("at 7 am", ANCHOR), (time(7, 0), ""))
+        self.assertEqual(extract_time_en("at 7 pm", ANCHOR), (time(19, 0), ""))
+        self.assertEqual(extract_time_en("at 5 pm", ANCHOR), (time(17, 0), ""))
+        self.assertEqual(extract_time_en("at 23:00", ANCHOR), (time(23, 0), ""))
+        self.assertEqual(extract_time_en("at 9 in the morning", ANCHOR),
+                         (time(9, 0), ""))
+
+    def test_noon_and_midnight(self):
+        self.assertEqual(extract_time_en("at noon", ANCHOR), (time(12, 0), ""))
+        self.assertEqual(extract_time_en("at midnight", ANCHOR),
+                         (time(0, 0), ""))
+
+    def test_remainder_preserved(self):
+        self.assertEqual(extract_time_en("wake me at 8:15 pm", ANCHOR),
+                         (time(20, 15), "wake me"))
+
+    def test_twelve_oclock_colon_quirk(self):
+        # QUIRK: "at 12:00" (no am/pm) rolls to hour 24, an invalid clock value,
+        # so the whole extraction bails out -> None
+        self.assertIsNone(extract_time_en("at 12:00", ANCHOR))
+
+
+class TestExtractTimePastToForms(unittest.TestCase):
+    """`half/quarter past`, `X to`, `X past` phrasings (with their quirks)."""
+
+    def test_half_and_quarter_past_quirks(self):
+        # QUIRK: the scanner does not truly compute "half/quarter past N"; it
+        # reads N as the hour and assumes pm.  Values asserted as produced.
+        self.assertEqual(extract_time_en("half past 8", ANCHOR),
+                         (time(20, 0), "half past"))
+        self.assertEqual(extract_time_en("quarter past 10", ANCHOR),
+                         (time(22, 0), "quarter past"))
+        self.assertEqual(extract_time_en("quarter to 9", ANCHOR),
+                         (time(21, 0), "quarter to"))
+        self.assertEqual(extract_time_en("20 to 5 pm", ANCHOR),
+                         (time(17, 0), "20 to"))
+        self.assertEqual(extract_time_en("10 past 4", ANCHOR),
+                         (time(16, 0), "10 past"))
+
+
+class TestExtractTimeRelative(unittest.TestCase):
+    """Relative hour/minute/second offsets applied to 13:04."""
+
+    def test_couple_of_hours(self):
+        # "couple" normalises to 2 -> 13:04 + 2h = 15:04
+        self.assertEqual(extract_time_en("in a couple of hours", ANCHOR),
+                         (time(15, 4), ""))
+
+    def test_minute_and_hour_and_second_offsets(self):
+        self.assertEqual(extract_time_en("in 5 minutes", ANCHOR),
+                         (time(13, 9), ""))
+        self.assertEqual(extract_time_en("in 3 hours", ANCHOR),
+                         (time(16, 4), ""))
+        self.assertEqual(extract_time_en("in 30 seconds", ANCHOR),
+                         (time(13, 4, 30), ""))
+
+    def test_hours_ago_quirk(self):
+        # QUIRK: in the time scanner "N hours ago" is not treated as past; the
+        # offset stays positive -> 13:04 + 2h = 15:04, "ago" left over
+        self.assertEqual(extract_time_en("2 hours ago", ANCHOR),
+                         (time(15, 4), "ago"))
+
+
+class TestExtractTimeFromCombined(unittest.TestCase):
+    """A date+time phrase yields the time half from extract_time_en."""
+
+    def test_combined(self):
+        self.assertEqual(extract_time_en("tomorrow at 5pm", ANCHOR),
+                         (time(17, 0), ""))
+        self.assertEqual(extract_time_en("next friday at 8 am", ANCHOR),
+                         (time(8, 0), ""))
+
+
+class TestExtractTimeNone(unittest.TestCase):
+    """Date-only, empty and nonsensical inputs yield no time."""
+
+    def test_bare_date_is_not_a_time(self):
+        self.assertIsNone(extract_time_en("tomorrow", ANCHOR))
+        self.assertIsNone(extract_time_en("next friday", ANCHOR))
+        self.assertIsNone(extract_time_en("march 5th", ANCHOR))
+        self.assertIsNone(extract_time_en("in 3 days", ANCHOR))
+        self.assertIsNone(extract_time_en("yesterday", ANCHOR))
+
+    def test_non_times(self):
+        self.assertIsNone(extract_time_en("no date here", ANCHOR))
+        self.assertIsNone(extract_time_en("", ANCHOR))
+        self.assertIsNone(extract_time_en("february 30", ANCHOR))
+
+
+class TestCombinedContract(unittest.TestCase):
+    """The classic "next friday at 8 am" split: date AND time each returned."""
+
+    def test_split(self):
+        d = extract_date_en("next friday at 8 am", ANCHOR)
+        t = extract_time_en("next friday at 8 am", ANCHOR)
+        self.assertEqual(d, (date(2017, 6, 30), ""))
+        self.assertEqual(t, (time(8, 0), ""))
+
+
+class TestReferenceCoercion(unittest.TestCase):
+    """ref_date/ref_time accept datetime or bare date; None uses now_local."""
+
+    def test_bare_date_coerced_to_midnight(self):
+        self.assertEqual(extract_date_en("tomorrow", date(2017, 6, 27)),
+                         (date(2017, 6, 28), ""))
+
+    def test_datetime_passthrough(self):
+        self.assertEqual(extract_date_en("tomorrow", ANCHOR),
+                         (date(2017, 6, 28), ""))
+
+    def test_time_ref_as_bare_date(self):
+        # midnight anchor: "in 3 hours" -> 03:00
+        self.assertEqual(extract_time_en("in 3 hours", date(2017, 6, 27)),
+                         (time(3, 0), ""))
+
+    def test_none_ref_does_not_raise(self):
+        # falls back to now_local(); we only assert it runs and stays typed
+        r = extract_date_en("tomorrow")
+        self.assertIsInstance(r, tuple)
+        self.assertIsInstance(r[0], date)
+
+
+class TestNeverRaises(unittest.TestCase):
+    """Garbage input must return None (or a valid tuple), never raise."""
+
+    GARBAGE = [
+        "", " ", "?", "!!!", "the the the", "12345", "0", "-1",
+        "at 25 o'clock", "february 30", "february 29 2019", "99:99",
+        "2400", "24:00", "999999999999 hours", "in -5 minutes",
+        "june 31st", "the 3rd of blursday", "at o'clock", ":::",
+        "aaaa bbbb cccc", "5 5 5 5 5", "next next next", "of of of",
+    ]
+
+    def test_extract_date_never_raises(self):
+        for text in self.GARBAGE:
+            try:
+                res = extract_date_en(text, ANCHOR)
+            except Exception as exc:  # pragma: no cover - failure path
+                self.fail(f"extract_date_en raised on {text!r}: {exc!r}")
+            self.assertTrue(res is None or isinstance(res, tuple))
+
+    def test_extract_time_never_raises(self):
+        for text in self.GARBAGE:
+            try:
+                res = extract_time_en(text, ANCHOR)
+            except Exception as exc:  # pragma: no cover - failure path
+                self.fail(f"extract_time_en raised on {text!r}: {exc!r}")
+            self.assertTrue(res is None or isinstance(res, tuple))
+
+    def test_adversarial_out_of_range_clock_none(self):
+        self.assertIsNone(extract_time_en("at 25 o'clock", ANCHOR))
+        self.assertIsNone(extract_time_en("2400", ANCHOR))
+        self.assertIsNone(extract_time_en("24:00", ANCHOR))
+
+    def test_bare_numbers_are_neither_here(self):
+        # a lone small number is read as a bare clock hour, not a date; the
+        # afternoon anchor pushes the ambiguous "7" to 19:00
+        self.assertIsNone(extract_date_en("7", ANCHOR))
+        self.assertEqual(extract_time_en("7", ANCHOR), (time(19, 0), ""))
+        # oversized offset cannot be represented -> both None
+        self.assertIsNone(extract_date_en("999999999999 hours", ANCHOR))
+        self.assertIsNone(extract_time_en("999999999999 hours", ANCHOR))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Phase 3 of the named-epochs design (#270), stacked on #272.

Splits the ~1030-line `extract_datetime_en` monolith into `_scan_date_en` / `_scan_time_en` internal helpers (code moved verbatim, no logic rewrites) plus assembly, and exposes two new public functions:

- **`extract_date_en(text, ref_date)`** → `(datetime.date, remainder)` only when a calendar-date component matched — "at 5 pm" → `None`, "tomorrow at 5pm" → tomorrow's date with both parts consumed from the remainder.
- **`extract_time_en(text, ref_time)`** → `(datetime.time, remainder)` only when a clock-time component matched — "tomorrow" → `None`, "at 5 pm" → `time(17, 0)`.

**Gate:** `extract_datetime_en` is byte-identical against the 1112-case frozen natural-language oracle (`benchmarks/en_datetime_oracle.py`): 1112/1112, 0 diffs. Full suite: 1994 passed, 2 skipped.

New `test/test_extract_date_time_en.py`: 38 test methods / 150+ assertions of natural-language sentences with exact expected dates, times and remainders (weekdays, month-name dates, relative offsets, clock forms, combined phrases, adversarial garbage that must return None and never raise).

Several legacy scanner quirks are deliberately preserved and asserted as-produced rather than fixed (the oracle pins them): "2 hours ago" resolves forward, "june 2027" discards a bare trailing year, "quarter past 10" assumes PM. These are recorded as future bug-fix leads to be addressed behind their own tests, separately from this behaviour-preserving refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)