### PR TITLE
fix: French and German yesterday words were not recognised

### DIFF
--- a/ovos_date_parser/dates_de.py
+++ b/ovos_date_parser/dates_de.py
@@ -192,6 +192,15 @@ def extract_datetime_de(text, anchorDate=None, default_time=None):
         if word in timeQualifiersList:
             timeQualifier = word
             # parse today, tomorrow, day after tomorrow
+        # "gestern": an dem Tag, der dem heutigen unmittelbar
+        # vorausgegangen ist (Duden,
+        # papers/linguistics/german/duden_gestern.html)
+        elif word == "vorgestern" and not fromFlag:
+            dayOffset = -2
+            used += 1
+        elif word == "gestern" and not fromFlag:
+            dayOffset = -1
+            used += 1
         elif word == "heute" and not fromFlag:
             dayOffset = 0
             used += 1

--- a/ovos_date_parser/dates_fr.py
+++ b/ovos_date_parser/dates_fr.py
@@ -192,7 +192,15 @@ def extract_datetime_fr(text, anchorDate=None, default_time=None):
             if wordPrev in ["ce", "cet", "cette"]:
                 used = 2
                 start -= 1
-        # parse aujourd'hui, demain, après-demain
+        # parse avant-hier, hier, aujourd'hui, demain, après-demain
+        # "hier": jour qui précède immédiatement celui où l'on est
+        # (Larousse, papers/linguistics/french/larousse_hier.html)
+        elif word == "avant-hier" and not fromFlag:
+            dayOffset = -2
+            used += 1
+        elif word == "hier" and not fromFlag:
+            dayOffset = -1
+            used += 1
         elif word == "aujourd'hui" and not fromFlag:
             dayOffset = 0
             used += 1

--- a/test/test_dates_de_sentences.py
+++ b/test/test_dates_de_sentences.py
@@ -172,5 +172,37 @@ class TestLeapDate(unittest.TestCase):
         self.assertEqual(extract("am 29. februar 2024")[0], dt(2024, 2, 29))
 
 
+class TestYesterdayWords(unittest.TestCase):
+    """"gestern": an dem Tag, der dem heutigen unmittelbar vorausgegangen
+    ist (Duden, papers/linguistics/german/duden_gestern.html).  Regression
+    for the three-way differential lead: "gestern"/"vorgestern" returned
+    None while today/tomorrow worked."""
+
+    def test_gestern(self):
+        self.assertEqual(extract("gestern")[0], dt(2117, 9, 2))
+        self.assertEqual(extract("vorgestern")[0], dt(2117, 9, 1))
+
+    def test_in_sentences(self):
+        self.assertEqual(extract("was ist gestern passiert")[0],
+                         dt(2117, 9, 2))
+        self.assertEqual(extract("das spiel von vorgestern")[0],
+                         dt(2117, 9, 1))
+
+    def test_gestern_with_time(self):
+        self.assertEqual(extract("gestern um 17 uhr")[0],
+                         dt(2117, 9, 2, 17, 0))
+
+    def test_morgen_still_tomorrow_and_morning(self):
+        # "morgen" (tomorrow) and "am morgen" (in the morning) untouched;
+        # 8:00 has already passed at the 13:30 anchor, so "am morgen"
+        # rolls to the next morning (legacy roll-forward behaviour)
+        self.assertEqual(extract("morgen")[0], dt(2117, 9, 4))
+        self.assertEqual(extract("am morgen")[0], dt(2117, 9, 4, 8, 0))
+
+    def test_symmetry(self):
+        self.assertEqual((extract("morgen")[0] - extract("gestern")[0]).days,
+                         2)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_dates_fr.py
+++ b/test/test_dates_fr.py
@@ -101,5 +101,30 @@ class TestAdversarial(unittest.TestCase):
         self.assertEqual(extract("15 juillet 2020")[0], dt(2020, 7, 15))
 
 
+class TestYesterdayWords(unittest.TestCase):
+    """"hier": le jour qui précède immédiatement celui où l'on est
+    (Larousse, papers/linguistics/french/larousse_hier.html).  Regression
+    for the three-way differential lead: "hier"/"avant-hier" returned
+    None while "ontem"/"ayer" worked in the sibling languages."""
+
+    def test_hier(self):
+        self.assertEqual(extract("hier")[0], dt(2117, 9, 2))
+        self.assertEqual(extract("avant-hier")[0], dt(2117, 9, 1))
+
+    def test_in_sentences(self):
+        res = extract("que s'est-il passé hier")
+        self.assertEqual(res[0], dt(2117, 9, 2))
+        res = extract("le match d'avant-hier")
+        self.assertEqual(res[0], dt(2117, 9, 1))
+
+    def test_hier_with_time(self):
+        self.assertEqual(extract("hier à 17 heures")[0],
+                         dt(2117, 9, 2, 17, 0))
+
+    def test_symmetry_with_demain(self):
+        # demain/hier must be symmetric around the anchor day
+        self.assertEqual((extract("demain")[0] - extract("hier")[0]).days, 2)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`extract_datetime("hier", "fr")` and `extract_datetime("gestern", "de")` returned `None` — the scanners had today/tomorrow/day-after branches but no negative day offsets, while pt/es resolve "ontem"/"ayer" fine. Adds `avant-hier`/`hier` and `vorgestern`/`gestern` with definitions cited from Larousse and Duden (saved to the papers library), plus regression tests including sentence context, time combination ("hier à 17 heures", "gestern um 17 uhr"), the German "morgen"/"am morgen" tomorrow-vs-morning disambiguation, and demain/hier symmetry.

Found by the new three-way differential harness (ours vs dateparser vs dateutil). Full suite: 1933 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * German date parsing now recognizes “gestern” and “vorgestern.”
  * French date parsing now recognizes “hier” and “avant-hier.”
  * Relative-day phrases work in sentences and with specified times.

* **Tests**
  * Added coverage confirming correct offsets, sentence parsing, time combinations, and existing “tomorrow” behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->