### PR TITLE
fix: parse month+bare year and ISO 8601 dates in English

### DIFF
--- a/ovos_date_parser/dates_en.py
+++ b/ovos_date_parser/dates_en.py
@@ -189,6 +189,25 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
     if text == "":
         return None
     default_time = default_time or time(0, 0, 0)
+
+    # ISO 8601 calendar-date pre-pass, run before tokenisation because the
+    # tokeniser splits on whitespace and would otherwise mishandle the
+    # hyphenated form. Supports the extended format YYYY-MM-DD and the
+    # slash variant YYYY/MM/DD; month/day are validated by constructing the
+    # datetime, so impossible dates (e.g. "2017-13-45", "2023-02-29") and
+    # non-date digit runs (e.g. phone numbers "123-45-6789") are left
+    # untouched. Ref: ISO 8601-1:2019 calendar date, 5.2.2.1.
+    iso_datestr = None
+    _iso_match = re.search(r"\b(\d{4})([-/])(\d{1,2})\2(\d{1,2})\b", text)
+    if _iso_match:
+        _y, _, _mo, _d = _iso_match.groups()
+        try:
+            iso_datestr = datetime(int(_y), int(_mo),
+                                   int(_d)).strftime("%B %d %Y")
+            text = text[:_iso_match.start()] + " " + text[_iso_match.end():]
+        except ValueError:
+            iso_datestr = None
+
     found = False
     daySpecified = False
     dayOffset = False
@@ -198,8 +217,8 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
     wkday = anchorDate.weekday()  # 0 - monday
     currentYear = anchorDate.strftime("%Y")
     fromFlag = False
-    datestr = ""
-    hasYear = False
+    datestr = iso_datestr or ""
+    hasYear = bool(iso_datestr)
     timeQualifier = ""
 
     timeQualifiersAM = ['morning']
@@ -549,14 +568,21 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
                     hasYear = False
 
             elif wordNext and wordNext[0].isdigit():
-                datestr += " " + wordNext
-                used += 1
-                if wordNextNext and wordNextNext[0].isdigit():
-                    datestr += " " + wordNextNext
+                if len(wordNext) == 4:
+                    # month followed by a bare 4-digit year and no day,
+                    # e.g. "june 2027" -> 1st of that month in that year
+                    datestr += " " + wordNext
                     used += 1
                     hasYear = True
                 else:
-                    hasYear = False
+                    datestr += " " + wordNext
+                    used += 1
+                    if wordNextNext and wordNextNext[0].isdigit():
+                        datestr += " " + wordNextNext
+                        used += 1
+                        hasYear = True
+                    else:
+                        hasYear = False
             # if no date indicators found, it may not be the month of May
             # may "i/we" ...
             # "... may be"

--- a/test/test_dates_en_year_and_iso.py
+++ b/test/test_dates_en_year_and_iso.py
@@ -1,0 +1,107 @@
+"""English datetime extraction: month+year and ISO 8601 calendar dates.
+
+Two behaviours are pinned here:
+
+1. A month followed by a bare 4-digit year and no day
+   ("june 2027", "the meeting is in june 2027") resolves to the 1st of that
+   month in that year, keeping past years in the past ("january 1990").
+
+2. ISO 8601 calendar dates. The extended form YYYY-MM-DD (and the slash
+   variant YYYY/MM/DD) are parsed largest-component-first; impossible dates
+   and non-date digit runs (phone numbers) are left unparsed.
+   Reference: ISO, "ISO 8601 Date and time format" (ISO 8601-1:2019),
+   ~/AgentWorkspaces/papers/standards/iso_8601_date_and_time_format.html
+   ("YYYY-MM-DD", e.g. 2019-04-25).
+
+Expected values cross-checked against both dateparser and dateutil, which
+agree on the year and on rejecting the impossible dates.
+"""
+import unittest
+from datetime import datetime
+
+from ovos_date_parser.dates_en import extract_datetime_en
+
+ANCHOR = datetime(2017, 6, 27, 13, 4)
+
+
+def extract(text, anchor=ANCHOR):
+    return extract_datetime_en(text, anchorDate=anchor)
+
+
+class TestMonthPlusBareYear(unittest.TestCase):
+    """Month + bare 4-digit year -> 1st of that month in that year."""
+
+    def test_month_future_year(self):
+        d, rem = extract("june 2027")
+        self.assertEqual(d, datetime(2027, 6, 1))
+        self.assertEqual(rem, "")
+
+    def test_december_2030(self):
+        d, _ = extract("december 2030")
+        self.assertEqual(d, datetime(2030, 12, 1))
+
+    def test_past_year_stays_in_past(self):
+        # 1990 is before the 2017 anchor and must NOT roll forward
+        d, _ = extract("january 1990")
+        self.assertEqual(d, datetime(1990, 1, 1))
+
+    def test_in_month_year_marker_consumed(self):
+        d, rem = extract("in june 2027")
+        self.assertEqual(d, datetime(2027, 6, 1))
+        self.assertEqual(rem, "")
+
+    def test_natural_sentence_remainder(self):
+        d, rem = extract("the meeting is in june 2027")
+        self.assertEqual(d, datetime(2027, 6, 1))
+        self.assertEqual(rem, "the meeting is")
+
+    def test_month_day_year_still_works(self):
+        # regression guard: an explicit day is unaffected
+        d, _ = extract("june 5 2027")
+        self.assertEqual(d, datetime(2027, 6, 5))
+
+
+class TestISO8601CalendarDate(unittest.TestCase):
+    """YYYY-MM-DD / YYYY-MM-DD, validated against the calendar."""
+
+    def test_iso_extended(self):
+        d, rem = extract("2017-06-30")
+        self.assertEqual(d, datetime(2017, 6, 30))
+        self.assertEqual(rem, "")
+
+    def test_iso_slash_variant(self):
+        d, _ = extract("2017/06/30")
+        self.assertEqual(d, datetime(2017, 6, 30))
+
+    def test_natural_sentence_remainder(self):
+        d, rem = extract("the deadline is 2017-06-30")
+        self.assertEqual(d, datetime(2017, 6, 30))
+        self.assertEqual(rem, "the deadline is")
+
+    def test_iso_then_time(self):
+        d, rem = extract("call me on 2017-06-30 at 5pm")
+        self.assertEqual(d, datetime(2017, 6, 30, 17, 0))
+        self.assertEqual(rem, "call me")
+
+    def test_leap_day_valid(self):
+        d, _ = extract("2024-02-29")
+        self.assertEqual(d, datetime(2024, 2, 29))
+
+
+class TestISO8601Rejections(unittest.TestCase):
+    """Impossible dates and non-dates must not parse as a date."""
+
+    def test_non_leap_feb_29_rejected(self):
+        # 2023 is not a leap year; both dateparser and dateutil reject it
+        self.assertIsNone(extract("2023-02-29"))
+
+    def test_impossible_month_and_day(self):
+        self.assertIsNone(extract("2017-13-45"))
+
+    def test_phone_number_not_a_date(self):
+        # adversarial: a 3-2-4 digit run is not YYYY-MM-DD
+        self.assertIsNone(extract("123-45-6789"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two English extraction bugs, both confirmed against `dateparser` and `dateutil` (which agree on every expected value):

1. **Month + bare year dropped the year.** "june 2027" resolved to the anchor-relative June (2018-06-01) instead of 2027-06-01. The month branch now treats a following bare 4-digit number as the year when no day is present; explicit-day phrases ("june 5 2027") are untouched and past years stay past ("january 1990" → 1990-01-01).

2. **ISO 8601 calendar dates returned None.** "2017-06-30" (and "2017/06/30") now parse via a validated pre-pass before tokenisation (ISO 8601-1:2019 §5.2.2.1, source in the papers library). Impossible dates ("2017-13-45", non-leap "2023-02-29") and phone-number-like digit runs ("123-45-6789") are left unparsed; remainder text and time-of-day still compose ("call me on 2017-06-30 at 5pm" → 17:00, remainder "call me").

## Tests

- `test/test_dates_en_year_and_iso.py`: 14 regression tests — natural sentences with remainder checks, past year, leap-day valid/invalid, invalid-ISO non-matches, adversarial phone number.
- Full suite: 1938 passed, 2 skipped; zero existing assertions changed.