### PR TITLE
fix: match plural period-offset unit nouns in nl, sv, da, cs

### DIFF
--- a/ovos_date_parser/dates_cs.py
+++ b/ovos_date_parser/dates_cs.py
@@ -1092,6 +1092,8 @@ def _text_cs_inflection_normalize(word, arg):
             word = "den"
         if word == "dny":
             word = "den"
+        if word == "dnech":
+            word = "den"
         if word == "týdny":
             word = "týden"
         if word == "týdnů":
@@ -1107,6 +1109,8 @@ def _text_cs_inflection_normalize(word, arg):
         if word == "roků":
             word = "rok"
         if word == "let":
+            word = "rok"
+        if word == "lety":
             word = "rok"
         if word == "včerejšku":
             word = "včera"

--- a/ovos_date_parser/dates_da.py
+++ b/ovos_date_parser/dates_da.py
@@ -256,7 +256,7 @@ def extract_datetime_da(text, anchorDate=None, default_time=None):
                 start -= 1
                 used = 2
                 # parse 10 months, next month, last month
-        elif word == "måned" and not fromFlag:
+        elif (word == "måned" or word == "måneder") and not fromFlag:
             if wordPrev[0].isdigit():
                 monthOffset = int(wordPrev)
                 start -= 1

--- a/ovos_date_parser/dates_nl.py
+++ b/ovos_date_parser/dates_nl.py
@@ -214,7 +214,7 @@ def extract_datetime_nl(text, anchorDate=None, default_time=None):
                 start -= 1
                 used = 2
                 # parse 10 months, next month, last month
-        elif word == "maand" and not fromFlag:
+        elif (word == "maand" or word == "maanden") and not fromFlag:
             if wordPrev[0].isdigit():
                 monthOffset = int(wordPrev)
                 start -= 1
@@ -228,7 +228,7 @@ def extract_datetime_nl(text, anchorDate=None, default_time=None):
                 start -= 1
                 used = 2
         # parse 5 years, next year, last year
-        elif word == "jaar" and not fromFlag:
+        elif (word == "jaar" or word == "jaren") and not fromFlag:
             if wordPrev[0].isdigit():
                 yearOffset = int(wordPrev)
                 start -= 1

--- a/ovos_date_parser/dates_sv.py
+++ b/ovos_date_parser/dates_sv.py
@@ -231,7 +231,7 @@ def extract_datetime_sv(text, anchorDate=None, default_time=None):
                 start -= 1
                 used = 2
                 # parse 10 months, next month, last month
-        elif word == "månad" and not fromFlag:
+        elif (word == "månad" or word == "månader") and not fromFlag:
             if wordPrev and wordPrev[0].isdigit():
                 monthOffset = int(wordPrev)
                 start -= 1

--- a/test/test_dates_cs_period_offsets.py
+++ b/test/test_dates_cs_period_offsets.py
@@ -1,0 +1,83 @@
+"""Czech period-offset units: inflected noun forms not yet normalised.
+
+Czech "rok" (year) and "den" (day) take heavy case inflection depending on
+the preposition used, and the parser normalises inflected forms to their
+dictionary singular before matching. Two forms were missing: the
+instrumental plural "lety" (used after "před", as in "před 2 lety" -
+"2 years ago") and the locative plural "dnech" (used after "před"/"po", as
+in "před 2 dnech" - "2 days ago"). Without normalisation those tokens never
+matched the "rok"/"den" branches at all, so the phrases returned no
+datetime.
+
+This branch does not include the (separately tracked, unmerged) past-marker
+direction fix, so "před" ("ago") phrases currently resolve forward from the
+anchor instead of backward - the same pre-existing behavior already shown
+by the already-working "před 2 měsíci"/"před 2 týdny" phrases on this
+branch. The tests below only assert that the magnitude of the offset is
+applied (parsing no longer fails outright) and record the current direction,
+without re-asserting a specific past/future outcome that the past-marker fix
+will change.
+
+Instrumental/locative declension confirmed against the Internetová jazyková
+příručka (ÚJČ AV ČR) entries for "rok" and "den", downloaded to
+~/AgentWorkspaces/papers/linguistics/cs/prirucka_rok.html and
+prirucka_den.html.
+"""
+import unittest
+from datetime import datetime
+
+from ovos_config.locale import get_default_tz as default_timezone
+
+import ovos_date_parser as _odp
+
+ANCHOR = datetime(2017, 6, 27, 13, 4)
+TZ = default_timezone()
+
+
+def extract(text, anchor=ANCHOR):
+    res = _odp.extract_datetime(text, lang="cs", anchorDate=anchor)
+    if res is not None and res[0] is not None and res[0].tzinfo is None:
+        res = [res[0].replace(tzinfo=TZ), res[1]]
+    return res
+
+
+def dt(y, mo, d, h=0, mi=0, s=0):
+    return datetime(y, mo, d, h, mi, s, tzinfo=TZ)
+
+
+class TestPeriodOffsetInflections(unittest.TestCase):
+    def test_year_future_already_worked(self):
+        self.assertEqual(extract("za 2 roky")[0], dt(2019, 6, 27))
+
+    def test_year_instrumental_plural_lety_now_matches(self):
+        result = extract("viděli jsme se před 2 lety")
+        self.assertIsNotNone(result)
+        # Direction depends on the unmerged past-marker fix; only the
+        # 2-year magnitude is asserted here.
+        self.assertIn(result[0].year, (2015, 2019))
+
+    def test_day_plural_dny_already_worked(self):
+        self.assertEqual(extract("za 2 dny")[0], dt(2017, 6, 29))
+
+    def test_day_locative_plural_dnech_now_matches(self):
+        result = extract("potkali jsme se před 2 dnech")
+        self.assertIsNotNone(result)
+        self.assertIn(result[0].date(), (dt(2017, 6, 25).date(), dt(2017, 6, 29).date()))
+
+    def test_week_plural_tydny_already_worked(self):
+        self.assertEqual(extract("za 2 týdny")[0], dt(2017, 7, 11))
+
+    def test_month_locative_plural_mesici_already_worked(self):
+        result = extract("za 2 měsíce")
+        self.assertEqual(result[0], dt(2017, 8, 27))
+
+    def test_adversarial_letos_does_not_match_lety(self):
+        # "letos" ("this year") is a different word entirely; normalisation
+        # must not fold it into "rok" via a loose prefix match.
+        result = extract("letos jedeme na dovolenou")
+        self.assertNotEqual(result[0].year if result else None, 2019)
+        self.assertNotEqual(result[0].year if result else None, 2015)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_dates_da_period_offsets.py
+++ b/test/test_dates_da_period_offsets.py
@@ -1,0 +1,56 @@
+"""Danish period-offset units: singular and plural noun matching.
+
+Danish pluralizes "måned" (month) as "måneder"; "uge"/"uger" and "dag"/"dage"
+already covered both forms, and "år" (year) is invariant between singular
+and plural.
+
+Plural confirmed against the Den Danske Ordbog "måned" entry (Wayback
+snapshot, since the live ordnet.dk site returns an AWS WAF challenge to
+non-browser clients), downloaded to
+~/AgentWorkspaces/papers/linguistics/da/wayback_ddo_maaned.html.
+"""
+import unittest
+from datetime import datetime
+
+from ovos_config.locale import get_default_tz as default_timezone
+
+import ovos_date_parser as _odp
+
+ANCHOR = datetime(2017, 6, 27, 13, 4)
+TZ = default_timezone()
+
+
+def extract(text, anchor=ANCHOR):
+    res = _odp.extract_datetime(text, lang="da", anchorDate=anchor)
+    if res is not None and res[0] is not None and res[0].tzinfo is None:
+        res = [res[0].replace(tzinfo=TZ), res[1]]
+    return res
+
+
+def dt(y, mo, d, h=0, mi=0, s=0):
+    return datetime(y, mo, d, h, mi, s, tzinfo=TZ)
+
+
+class TestPeriodOffsetPlurals(unittest.TestCase):
+    def test_month_singular(self):
+        self.assertEqual(extract("om 1 måned")[0], dt(2017, 7, 27))
+
+    def test_month_plural(self):
+        self.assertEqual(extract("vi ses om 2 måneder")[0], dt(2017, 8, 27))
+
+    def test_week_plural_already_worked(self):
+        self.assertEqual(extract("om 2 uger")[0], dt(2017, 7, 11))
+
+    def test_day_plural_already_worked(self):
+        self.assertEqual(extract("om 2 dage")[0], dt(2017, 6, 29))
+
+    def test_year_invariant_plural(self):
+        self.assertEqual(extract("om 2 år")[0], dt(2019, 6, 27))
+
+    def test_adversarial_maanedlig_does_not_match(self):
+        # "månedlig" (monthly, adjective) must not fire the month-offset match.
+        self.assertIsNone(extract("huslejen er månedlig"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_dates_nl_period_offsets.py
+++ b/test/test_dates_nl_period_offsets.py
@@ -1,0 +1,66 @@
+"""Dutch period-offset units: singular and plural noun matching.
+
+Dutch pluralizes "maand" (month) as "maanden" and "jaar" (year) as "jaren";
+those plurals go through irregular/en-suffixed forms rather than a simple
+"-en" strip, so the parser must list them explicitly alongside the singular.
+"week"/"weken" and "dag"/"dagen" already covered both forms.
+
+Plurals confirmed against Woordenlijst.org headword entries, downloaded to
+~/AgentWorkspaces/papers/linguistics/nl/woorden_maanden.html and
+woorden_jaren.html.
+"""
+import unittest
+from datetime import datetime
+
+from ovos_config.locale import get_default_tz as default_timezone
+
+import ovos_date_parser as _odp
+
+ANCHOR = datetime(2017, 6, 27, 13, 4)
+TZ = default_timezone()
+
+
+def extract(text, anchor=ANCHOR):
+    res = _odp.extract_datetime(text, lang="nl", anchorDate=anchor)
+    if res is not None and res[0] is not None and res[0].tzinfo is None:
+        res = [res[0].replace(tzinfo=TZ), res[1]]
+    return res
+
+
+def dt(y, mo, d, h=0, mi=0, s=0):
+    return datetime(y, mo, d, h, mi, s, tzinfo=TZ)
+
+
+class TestPeriodOffsetPlurals(unittest.TestCase):
+    def test_month_singular(self):
+        self.assertEqual(extract("over 1 maand")[0], dt(2017, 7, 27))
+
+    def test_month_plural(self):
+        self.assertEqual(extract("ik zie je over 2 maanden")[0], dt(2017, 8, 27))
+
+    def test_year_singular(self):
+        self.assertEqual(extract("over 1 jaar")[0], dt(2018, 6, 27))
+
+    def test_year_plural(self):
+        self.assertEqual(extract("we spreken af over 2 jaren")[0], dt(2019, 6, 27))
+
+    def test_week_plural_already_worked(self):
+        self.assertEqual(extract("over 2 weken")[0], dt(2017, 7, 11))
+
+    def test_day_plural_already_worked(self):
+        self.assertEqual(extract("over 2 dagen")[0], dt(2017, 6, 29))
+
+    def test_adversarial_maanden_as_substring_does_not_match(self):
+        # "maandenlang" is a different word (adjective "months-long"); the
+        # exact-token match must not fire on it.
+        self.assertIsNone(extract("dit duurt maandenlang"))
+
+    def test_adversarial_bare_number_without_unit_does_not_offset(self):
+        # No unit noun at all -> no month/year offset should be inferred.
+        res = extract("2")
+        self.assertNotEqual(res[0] if res else None, dt(2019, 6, 27))
+        self.assertNotEqual(res[0] if res else None, dt(2017, 8, 27))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_dates_sv_period_offsets.py
+++ b/test/test_dates_sv_period_offsets.py
@@ -1,0 +1,54 @@
+"""Swedish period-offset units: singular and plural noun matching.
+
+Swedish pluralizes "månad" (month) as "månader"; "vecka"/"veckor" and
+"dag"/"dagar" already covered both forms, and "år" (year) is invariant
+between singular and plural.
+
+Plural confirmed against the Wiktionary "månader" entry, downloaded to
+~/AgentWorkspaces/papers/linguistics/sv/wiktionary_manader.html.
+"""
+import unittest
+from datetime import datetime
+
+from ovos_config.locale import get_default_tz as default_timezone
+
+import ovos_date_parser as _odp
+
+ANCHOR = datetime(2017, 6, 27, 13, 4)
+TZ = default_timezone()
+
+
+def extract(text, anchor=ANCHOR):
+    res = _odp.extract_datetime(text, lang="sv", anchorDate=anchor)
+    if res is not None and res[0] is not None and res[0].tzinfo is None:
+        res = [res[0].replace(tzinfo=TZ), res[1]]
+    return res
+
+
+def dt(y, mo, d, h=0, mi=0, s=0):
+    return datetime(y, mo, d, h, mi, s, tzinfo=TZ)
+
+
+class TestPeriodOffsetPlurals(unittest.TestCase):
+    def test_month_singular(self):
+        self.assertEqual(extract("om 1 månad")[0], dt(2017, 7, 27))
+
+    def test_month_plural(self):
+        self.assertEqual(extract("vi ses om 2 månader")[0], dt(2017, 8, 27))
+
+    def test_week_plural_already_worked(self):
+        self.assertEqual(extract("om 2 veckor")[0], dt(2017, 7, 11))
+
+    def test_day_plural_already_worked(self):
+        self.assertEqual(extract("om 2 dagar")[0], dt(2017, 6, 29))
+
+    def test_year_invariant_plural(self):
+        self.assertEqual(extract("om 2 år")[0], dt(2019, 6, 27))
+
+    def test_adversarial_manadsvis_does_not_match(self):
+        # "månadsvis" (monthly, adverb) must not fire the month-offset match.
+        self.assertIsNone(extract("hon betalar hyran månadsvis"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Period-offset unit nouns only matched in singular in four languages, so plural offsets silently failed:

| lang | phrase | before | after |
|---|---|---|---|
| nl | `over 2 maanden` / `over 2 jaren` | None | 2017-08-27 / 2019-06-27 |
| sv | `om 2 månader` | None | 2017-08-27 |
| da | `om 2 måneder` | unmatched leftover | 2017-08-27 |
| cs | `před 2 lety` / `před 2 dnech` | None | resolves (instrumental forms normalised to rok/den) |

nl `weken`/`dagen`, sv `veckor`/`dagar`/`år`, da `uger`/`dage`/`år`, cs `roky`/`dny`/`týdny`/`měsíce` were already handled and are covered by regression tests; nb/nn/de were swept and have no gaps of this class.

Expected values cross-checked against `dateparser` (nl/sv/da); plural forms cited to downloaded dictionary sources (Woordenlijst/woorden.org, SAOL via Wiktionary, DDO, Internetová jazyková příručka) in the test docstrings.

27 new tests in `test/test_dates_{nl,sv,da,cs}_period_offsets.py` (singular + plural + adversarial non-matches). Full suite: 1951 passed, 2 skipped; zero existing assertions changed.