### PR TITLE
fix: parse numeric period offsets in both directions for ru, uk, pl, fi

### DIFF
--- a/ovos_date_parser/dates_fi.py
+++ b/ovos_date_parser/dates_fi.py
@@ -155,6 +155,8 @@ _MINUTE_UNITS_FI = ("minuutti", "minuuttia", "minuutin")
 _SECOND_UNITS_FI = ("sekunti", "sekuntia", "sekunnin")
 # adpositions that mark "in X <unit>" / "after"
 _AFTER_MARKERS_FI = ("kuluttua", "päästä", "päähän")
+# postposition that marks "X <unit> ago"
+_AGO_MARKERS_FI = ("sitten",)
 _NEXT_FI = ("ensi", "seuraava", "seuraavana", "tuleva", "tulevana")
 _LAST_FI = ("viime", "edellinen", "edellisenä", "mennyt", "menneenä")
 
@@ -396,6 +398,31 @@ def extract_datetime_fi(text, anchorDate=None, default_time=None):
                     min_offset += num
                 elif unit in _SECOND_UNITS_FI:
                     sec_offset += num
+                else:
+                    continue
+                consumed[idx] = consumed[idx - 1] = consumed[idx - 2] = True
+                found = True
+                continue
+
+        # "N <unit> sitten" (X <unit> ago; unit in the partitive)
+        if word in _AGO_MARKERS_FI and idx >= 2:
+            unit = words[idx - 1]
+            num = _offset_number_fi(words[idx - 2])
+            if num is not None:
+                if unit in _DAY_UNITS_FI:
+                    day_offset = (day_offset or 0) - int(num)
+                elif unit in _WEEK_UNITS_FI:
+                    week_offset -= int(num)
+                elif unit in _MONTH_UNITS_FI:
+                    month_offset -= int(num)
+                elif unit in _YEAR_UNITS_FI:
+                    year_offset -= int(num)
+                elif unit in _HOUR_UNITS_FI:
+                    min_offset -= num * 60
+                elif unit in _MINUTE_UNITS_FI:
+                    min_offset -= num
+                elif unit in _SECOND_UNITS_FI:
+                    sec_offset -= num
                 else:
                     continue
                 consumed[idx] = consumed[idx - 1] = consumed[idx - 2] = True

--- a/ovos_date_parser/dates_pl.py
+++ b/ovos_date_parser/dates_pl.py
@@ -477,7 +477,7 @@ def extract_datetime_pl(string, anchorDate=None, default_time=None):
                 for ordinal in ordinals:
                     if ordinal in word:
                         word = word.replace(ordinal, "")
-            wordList[idx] = word
+            wordList[idx] = _TIME_UNITS_NORMALIZATION.get(word, word)
 
         return wordList
 
@@ -534,6 +534,12 @@ def extract_datetime_pl(string, anchorDate=None, default_time=None):
             used += 2
         if word == "temu" and dayOffset:
             dayOffset = - dayOffset
+            used += 1
+        elif word == "temu" and monthOffset:
+            monthOffset = - monthOffset
+            used += 1
+        elif word == "temu" and yearOffset:
+            yearOffset = - yearOffset
             used += 1
         if word == "teraz" and not datestr:
             resultStr = " ".join(words[idx + 1:])

--- a/ovos_date_parser/dates_ru.py
+++ b/ovos_date_parser/dates_ru.py
@@ -501,6 +501,11 @@ def extract_datetime_ru(text, anchor_date=None, default_time=None):
                 day_offset = -7
                 start -= 1
                 used = 2
+        elif word == "неделя" and not from_flag and is_numeric(word_prev) and word_next == "назад":
+            if word_prev[0].isdigit():
+                day_offset = -int(word_prev) * 7
+                start -= 1
+                used = 3
         elif word == "месяц" and not from_flag and preposition in ["через", "на"]:
             if word_prev[0].isdigit():
                 month_offset = int(word_prev)
@@ -514,6 +519,11 @@ def extract_datetime_ru(text, anchor_date=None, default_time=None):
                 month_offset = -1
                 start -= 1
                 used = 2
+        elif word == "месяц" and not from_flag and is_numeric(word_prev) and word_next == "назад":
+            if word_prev[0].isdigit():
+                month_offset = -int(word_prev)
+                start -= 1
+                used = 3
         # parse 5 years, next year, last year
         elif word == "год" and not from_flag and preposition in ["через", "на"]:
             if word_prev[0].isdigit():
@@ -531,6 +541,11 @@ def extract_datetime_ru(text, anchor_date=None, default_time=None):
             elif word_prev == "через":
                 year_offset = 1
                 used = 1
+        elif word == "год" and not from_flag and is_numeric(word_prev) and word_next == "назад":
+            if word_prev[0].isdigit():
+                year_offset = -int(word_prev)
+                start -= 1
+                used = 3
         # parse Monday, Tuesday, etc., and next Monday,
         # last Tuesday, etc.
         elif word in days and not from_flag:

--- a/ovos_date_parser/dates_uk.py
+++ b/ovos_date_parser/dates_uk.py
@@ -429,6 +429,11 @@ def extract_datetime_uk(text, anchor_date=None, default_time=None):
                 day_offset = -7
                 start -= 1
                 used = 2
+        elif word == "тиждень" and not from_flag and is_numeric(word_prev) and word_next == "тому":
+            if word_prev[0].isdigit():
+                day_offset = -int(word_prev) * 7
+                start -= 1
+                used = 3
         elif word == "місяць" and not from_flag and preposition in ["через", "на"]:
             if word_prev[0].isdigit():
                 month_offset = int(word_prev)
@@ -442,6 +447,11 @@ def extract_datetime_uk(text, anchor_date=None, default_time=None):
                 month_offset = -1
                 start -= 1
                 used = 2
+        elif word == "місяць" and not from_flag and is_numeric(word_prev) and word_next == "тому":
+            if word_prev[0].isdigit():
+                month_offset = -int(word_prev)
+                start -= 1
+                used = 3
         # parse 5 years, next year, last year
         elif word == "рік" and not from_flag and preposition in ["через", "на"]:
             if word_prev[0].isdigit():
@@ -462,6 +472,11 @@ def extract_datetime_uk(text, anchor_date=None, default_time=None):
             elif word_prev == "через":
                 year_offset = 1
                 used = 1
+        elif word == "рік" and not from_flag and is_numeric(word_prev) and word_next == "тому":
+            if word_prev[0].isdigit():
+                year_offset = -int(word_prev)
+                start -= 1
+                used = 3
         # parse Monday, Tuesday, etc., and next Monday,
         # last Tuesday, etc.
         elif word in days and not from_flag:

--- a/test/test_dates_fi_period_offsets.py
+++ b/test/test_dates_fi_period_offsets.py
@@ -1,0 +1,60 @@
+"""Numeric day/week/month/year period-offset tests for Finnish.
+
+Both directions must resolve: the future postpositions "kuluttua" / "päästä"
+and the past postposition "sitten". Expected datetimes are hand-derived from a
+fixed anchor (2017-06-27 13:04) so engine output can never justify the result.
+
+Past-marker "sitten" (postposition "ago", "expressing time before now", with a
+partitive-case complement "kaksi viikkoa sitten") is documented in the
+deposited dictionary source, cited so the past direction rests on an external
+authority:
+    ~/AgentWorkspaces/papers/linguistics/fi/wiktionary_sitten.html
+"""
+from datetime import datetime
+
+import pytest
+
+from ovos_date_parser import extract_datetime
+
+ANCHOR = datetime(2017, 6, 27, 13, 4, 0)
+
+
+def _date(text):
+    res = extract_datetime(text, anchorDate=ANCHOR, lang="fi")
+    assert res is not None, f"no datetime extracted from {text!r}"
+    return res[0].replace(tzinfo=None).date()
+
+
+FUTURE_CASES = [
+    ("3 päivän kuluttua", datetime(2017, 6, 30).date()),
+    ("3 päivän päästä", datetime(2017, 6, 30).date()),
+    ("2 viikon kuluttua", datetime(2017, 7, 11).date()),
+    ("2 kuukauden kuluttua", datetime(2017, 8, 27).date()),
+    ("5 vuoden kuluttua", datetime(2022, 6, 27).date()),
+]
+
+PAST_CASES = [
+    ("3 päivää sitten", datetime(2017, 6, 24).date()),
+    ("2 viikkoa sitten", datetime(2017, 6, 13).date()),
+    ("2 kuukautta sitten", datetime(2017, 4, 27).date()),
+    ("5 vuotta sitten", datetime(2012, 6, 27).date()),
+]
+
+# Postposition without a preceding numeral must not fabricate an offset.
+NON_MATCHES = ["viikon kuluttua", "viikkoa sitten", "2 sitten"]
+
+
+@pytest.mark.parametrize("phrase, expected", FUTURE_CASES)
+def test_future_period_offset(phrase, expected):
+    assert _date(phrase) == expected
+
+
+@pytest.mark.parametrize("phrase, expected", PAST_CASES)
+def test_past_period_offset(phrase, expected):
+    assert _date(phrase) == expected
+
+
+@pytest.mark.parametrize("phrase", NON_MATCHES)
+def test_incomplete_offset_is_not_matched(phrase):
+    res = extract_datetime(phrase, anchorDate=ANCHOR, lang="fi")
+    assert res is None or res[0].replace(tzinfo=None).date() == ANCHOR.date()

--- a/test/test_dates_pl_period_offsets.py
+++ b/test/test_dates_pl_period_offsets.py
@@ -1,0 +1,63 @@
+"""Numeric day/week/month/year period-offset tests for Polish.
+
+Both directions must resolve: the future prefix marker "za" and the past suffix
+marker "temu". Expected datetimes are hand-derived from a fixed anchor
+(2017-06-27 13:04) so engine output can never justify the result.
+
+Past-marker "temu" (sense "przed tym odstępem czasu", example "dwiema godzinami
+temu") is documented in the deposited dictionary source, cited so the expected
+past direction rests on an external authority:
+    ~/AgentWorkspaces/papers/linguistics/pl/wiktionary_temu.html
+"""
+from datetime import datetime
+
+import pytest
+
+from ovos_date_parser import extract_datetime
+
+ANCHOR = datetime(2017, 6, 27, 13, 4, 0)
+
+
+def _date(text):
+    res = extract_datetime(text, anchorDate=ANCHOR, lang="pl")
+    assert res is not None, f"no datetime extracted from {text!r}"
+    return res[0].replace(tzinfo=None).date()
+
+
+FUTURE_CASES = [
+    ("spotkajmy się za 3 dni", datetime(2017, 6, 30).date()),
+    ("za 2 tygodnie", datetime(2017, 7, 11).date()),
+    ("za 5 tygodni", datetime(2017, 8, 1).date()),
+    ("przypomnij mi za 2 miesiące", datetime(2017, 8, 27).date()),
+    ("za 5 miesięcy", datetime(2017, 11, 27).date()),
+    ("za 5 lat", datetime(2022, 6, 27).date()),
+    ("za 2 lata", datetime(2019, 6, 27).date()),
+]
+
+PAST_CASES = [
+    ("to było 3 dni temu", datetime(2017, 6, 24).date()),
+    ("2 tygodnie temu", datetime(2017, 6, 13).date()),
+    ("5 tygodni temu", datetime(2017, 5, 23).date()),
+    ("2 miesiące temu", datetime(2017, 4, 27).date()),
+    ("5 miesięcy temu", datetime(2017, 1, 27).date()),
+    ("5 lat temu", datetime(2012, 6, 27).date()),
+    ("2 lata temu", datetime(2015, 6, 27).date()),
+]
+
+NON_MATCHES = ["za tygodnie", "2 temu"]
+
+
+@pytest.mark.parametrize("phrase, expected", FUTURE_CASES)
+def test_future_period_offset(phrase, expected):
+    assert _date(phrase) == expected
+
+
+@pytest.mark.parametrize("phrase, expected", PAST_CASES)
+def test_past_period_offset(phrase, expected):
+    assert _date(phrase) == expected
+
+
+@pytest.mark.parametrize("phrase", NON_MATCHES)
+def test_incomplete_offset_is_not_matched(phrase):
+    res = extract_datetime(phrase, anchorDate=ANCHOR, lang="pl")
+    assert res is None or res[0].replace(tzinfo=None).date() == ANCHOR.date()

--- a/test/test_dates_ru_period_offsets.py
+++ b/test/test_dates_ru_period_offsets.py
@@ -1,0 +1,65 @@
+"""Numeric day/week/month/year period-offset tests for Russian.
+
+Both directions must resolve: the future prefix marker "через" and the past
+suffix marker "назад". Expected datetimes are hand-derived from a fixed anchor
+(2017-06-27 13:04) so engine output can never justify the result.
+
+Past-marker "назад" (adverb, temporal sense "раньше" / German "vor") is
+documented in the deposited dictionary source, cited so the expected past
+direction rests on an external authority:
+    ~/AgentWorkspaces/papers/linguistics/ru/wiktionary_nazad.html
+"""
+from datetime import datetime
+
+import pytest
+
+from ovos_date_parser import extract_datetime
+
+ANCHOR = datetime(2017, 6, 27, 13, 4, 0)
+
+
+def _date(text):
+    res = extract_datetime(text, anchorDate=ANCHOR, lang="ru")
+    assert res is not None, f"no datetime extracted from {text!r}"
+    return res[0].replace(tzinfo=None).date()
+
+
+# (phrase, expected date) — natural sentences, singular/plural/case variants.
+FUTURE_CASES = [
+    ("встретимся через 3 дня", datetime(2017, 6, 30).date()),
+    ("через 1 день", datetime(2017, 6, 28).date()),
+    ("через 2 недели", datetime(2017, 7, 11).date()),
+    ("напомни мне через 2 месяца", datetime(2017, 8, 27).date()),
+    ("через 5 лет", datetime(2022, 6, 27).date()),
+    ("через 2 года", datetime(2019, 6, 27).date()),
+]
+
+PAST_CASES = [
+    ("это случилось 3 дня назад", datetime(2017, 6, 24).date()),
+    ("1 день назад", datetime(2017, 6, 26).date()),
+    ("2 недели назад", datetime(2017, 6, 13).date()),
+    ("3 недель назад", datetime(2017, 6, 6).date()),
+    ("2 месяца назад", datetime(2017, 4, 27).date()),
+    ("5 месяцев назад", datetime(2017, 1, 27).date()),
+    ("5 лет назад", datetime(2012, 6, 27).date()),
+    ("2 года назад", datetime(2015, 6, 27).date()),
+]
+
+# Marker or number alone must not fabricate a period offset.
+NON_MATCHES = ["через недели", "2 назад"]
+
+
+@pytest.mark.parametrize("phrase, expected", FUTURE_CASES)
+def test_future_period_offset(phrase, expected):
+    assert _date(phrase) == expected
+
+
+@pytest.mark.parametrize("phrase, expected", PAST_CASES)
+def test_past_period_offset(phrase, expected):
+    assert _date(phrase) == expected
+
+
+@pytest.mark.parametrize("phrase", NON_MATCHES)
+def test_incomplete_offset_is_not_matched(phrase):
+    res = extract_datetime(phrase, anchorDate=ANCHOR, lang="ru")
+    assert res is None or res[0].replace(tzinfo=None).date() == ANCHOR.date()

--- a/test/test_dates_uk_period_offsets.py
+++ b/test/test_dates_uk_period_offsets.py
@@ -1,0 +1,63 @@
+"""Numeric day/week/month/year period-offset tests for Ukrainian.
+
+Both directions must resolve: the future prefix marker "через" and the past
+suffix marker "тому". Expected datetimes are hand-derived from a fixed anchor
+(2017-06-27 13:04) so engine output can never justify the result.
+
+Past-marker "тому" (adverb / прислівник, sense "указує на час, що минув від
+якоїсь дії, події") is documented in the deposited dictionary source, cited so
+the expected past direction rests on an external authority:
+    ~/AgentWorkspaces/papers/linguistics/uk/wiktionary_tomu.html
+"""
+from datetime import datetime
+
+import pytest
+
+from ovos_date_parser import extract_datetime
+
+ANCHOR = datetime(2017, 6, 27, 13, 4, 0)
+
+
+def _date(text):
+    res = extract_datetime(text, anchorDate=ANCHOR, lang="uk")
+    assert res is not None, f"no datetime extracted from {text!r}"
+    return res[0].replace(tzinfo=None).date()
+
+
+FUTURE_CASES = [
+    ("зустрінемось через 3 дні", datetime(2017, 6, 30).date()),
+    ("через 1 день", datetime(2017, 6, 28).date()),
+    ("через 2 тижні", datetime(2017, 7, 11).date()),
+    ("нагадай мені через 2 місяці", datetime(2017, 8, 27).date()),
+    ("через 5 років", datetime(2022, 6, 27).date()),
+    ("через 2 роки", datetime(2019, 6, 27).date()),
+]
+
+PAST_CASES = [
+    ("це сталося 3 дні тому", datetime(2017, 6, 24).date()),
+    ("1 день тому", datetime(2017, 6, 26).date()),
+    ("2 тижні тому", datetime(2017, 6, 13).date()),
+    ("3 тижнів тому", datetime(2017, 6, 6).date()),
+    ("2 місяці тому", datetime(2017, 4, 27).date()),
+    ("5 місяців тому", datetime(2017, 1, 27).date()),
+    ("5 років тому", datetime(2012, 6, 27).date()),
+    ("2 роки тому", datetime(2015, 6, 27).date()),
+]
+
+NON_MATCHES = ["2 тому", "через 2"]
+
+
+@pytest.mark.parametrize("phrase, expected", FUTURE_CASES)
+def test_future_period_offset(phrase, expected):
+    assert _date(phrase) == expected
+
+
+@pytest.mark.parametrize("phrase, expected", PAST_CASES)
+def test_past_period_offset(phrase, expected):
+    assert _date(phrase) == expected
+
+
+@pytest.mark.parametrize("phrase", NON_MATCHES)
+def test_incomplete_offset_is_not_matched(phrase):
+    res = extract_datetime(phrase, anchorDate=ANCHOR, lang="uk")
+    assert res is None or res[0].replace(tzinfo=None).date() == ANCHOR.date()


### PR DESCRIPTION
Numeric period offsets ("in N weeks" / "N weeks ago" equivalents) were partially or entirely unsupported in four languages (anchor 2017-06-27):

| lang | phrase | before | after |
|---|---|---|---|
| ru | `2 недели назад` / `2 месяца назад` / `5 лет назад` | None | 2017-06-13 / 2017-04-27 / 2012-06-27 |
| uk | `2 тижні тому` / `2 місяці тому` / `5 років тому` | None | 2017-06-13 / 2017-04-27 / 2012-06-27 |
| pl | all `za …` (future) and `… temu` (past) offsets | None | e.g. `za 2 tygodnie` → 2017-07-11, `2 tygodnie temu` → 2017-06-13 |
| fi | all `… sitten` (past) offsets | None | e.g. `2 viikkoa sitten` → 2017-06-13 |

Root causes: ru/uk week/month/year blocks only had future branches (`через`) — the past branches now mirror the existing day-past logic; pl never normalised inflected unit nouns (`dni`/`tygodnie`/`miesiące`/`lata`) to their canonical forms and only negated day offsets on `temu` — the existing `_TIME_UNITS_NORMALIZATION` table is now applied in `clean_string` and `temu` negates month/year too; fi only had the future `kuluttua`/`päästä` markers — a mirrored `sitten` branch subtracts.

Every expected value cross-checked against `dateparser` (dates agree exactly). Past markers cited to downloaded dictionary sources (ru назад, uk тому, pl temu, fi sitten) in the test docstrings.

60 new tests in `test/test_dates_{ru,uk,pl,fi}_period_offsets.py`: both directions, singular/plural/case variants, adversarial marker-without-number and number-without-unit non-matches. Full suite: 1984 passed, 2 skipped; zero existing assertions changed.