### PR TITLE
fix: return list not tuple from extract_datetime_{tr,ar,fa,id,ms,kab}

### DIFF
--- a/ovos_date_parser/dates_ar.py
+++ b/ovos_date_parser/dates_ar.py
@@ -695,7 +695,7 @@ def extract_datetime_ar(text, anchorDate=None, default_time=None):
                                           minute=default_time.minute,
                                           second=default_time.second)
 
-    return result_date, " ".join(remainder).strip()
+    return [result_date, " ".join(remainder).strip()]
 
 
 def _parse_duration_span(tokens, i):

--- a/ovos_date_parser/dates_fa.py
+++ b/ovos_date_parser/dates_fa.py
@@ -214,7 +214,7 @@ def extract_datetime_fa(text, anchorDate=None, default_time=None):
         result = anchorDate + delta_seen
     if result is None:
         return None
-    return (result, " ".join(remainder))
+    return [result, " ".join(remainder)]
 
 
 def nice_time_fa(dt, speech=True, use_24hour=False, use_ampm=False):

--- a/ovos_date_parser/dates_id.py
+++ b/ovos_date_parser/dates_id.py
@@ -247,7 +247,7 @@ def extract_datetime_id(text, anchorDate=None, default_time=None):
             result = result.replace(hour=0, minute=0, second=0, microsecond=0)
     remainder = " ".join(t for idx, t in enumerate(tokens)
                          if idx not in consumed)
-    return result, remainder.strip()
+    return [result, remainder.strip()]
 
 
 def _period_id(hour):

--- a/ovos_date_parser/dates_kab.py
+++ b/ovos_date_parser/dates_kab.py
@@ -214,4 +214,4 @@ def extract_datetime_kab(text: str, anchorDate: Optional[datetime] = None,
                                     microsecond=0)
     remainder = " ".join(t for idx, t in enumerate(tokens)
                          if idx not in consumed)
-    return result, remainder.strip()
+    return [result, remainder.strip()]

--- a/ovos_date_parser/dates_ms.py
+++ b/ovos_date_parser/dates_ms.py
@@ -247,7 +247,7 @@ def extract_datetime_ms(text, anchorDate=None, default_time=None):
             result = result.replace(hour=0, minute=0, second=0, microsecond=0)
     remainder = " ".join(t for idx, t in enumerate(tokens)
                          if idx not in consumed)
-    return result, remainder.strip()
+    return [result, remainder.strip()]
 
 
 def _period_ms(hour):

--- a/ovos_date_parser/dates_tr.py
+++ b/ovos_date_parser/dates_tr.py
@@ -247,7 +247,7 @@ def extract_datetime_tr(text, anchorDate=None, default_time=None):
             result = result.replace(hour=0, minute=0, second=0, microsecond=0)
     remainder = " ".join(t for idx, t in enumerate(tokens)
                          if idx not in consumed)
-    return result, remainder.strip()
+    return [result, remainder.strip()]
 
 
 def _period_tr(hour):

--- a/test/test_dates_id.py
+++ b/test/test_dates_id.py
@@ -178,7 +178,7 @@ class TestRealSentencesId(unittest.TestCase):
 
     def test_relative_day_sentences(self):
         self.assertEqual(self._dt("Meeting besok jam 10 pagi."),
-                         (datetime(2026, 7, 16, 10, 0), "meeting pagi"))
+                         [datetime(2026, 7, 16, 10, 0), "meeting pagi"])
         self.assertEqual(self._dt("Hari ini saya libur.")[0],
                          datetime(2026, 7, 15, 0, 0))
         self.assertEqual(self._dt("Kemarin hujan.")[0],
@@ -190,7 +190,7 @@ class TestRealSentencesId(unittest.TestCase):
 
     def test_offset_sentences(self):
         self.assertEqual(self._dt("Ingatkan saya dua jam lagi."),
-                         (datetime(2026, 7, 15, 14, 0), "ingatkan saya"))
+                         [datetime(2026, 7, 15, 14, 0), "ingatkan saya"])
         self.assertEqual(self._dt("Tiga hari yang lalu dia pergi.")[0],
                          datetime(2026, 7, 12, 0, 0))
         self.assertEqual(
@@ -199,13 +199,13 @@ class TestRealSentencesId(unittest.TestCase):
 
     def test_weekday_sentences(self):
         self.assertEqual(self._dt("Ada acara Selasa depan."),
-                         (datetime(2026, 7, 21, 0, 0), "ada acara"))
+                         [datetime(2026, 7, 21, 0, 0), "ada acara"])
         self.assertEqual(self._dt("Jumat lalu kami bertemu.")[0],
                          datetime(2026, 7, 10, 0, 0))
 
     def test_period_sentences(self):
         self.assertEqual(self._dt("Minggu depan libur."),
-                         (datetime(2026, 7, 22, 0, 0), "libur"))
+                         [datetime(2026, 7, 22, 0, 0), "libur"])
         self.assertEqual(self._dt("Bulan depan gajian.")[0],
                          datetime(2026, 8, 15, 0, 0))
         self.assertEqual(self._dt("Tahun lalu kami menikah.")[0],
@@ -221,7 +221,7 @@ class TestRealSentencesId(unittest.TestCase):
 
     def test_month_date_sentences(self):
         self.assertEqual(self._dt("Ulang tahun 17 Agustus 2026!"),
-                         (datetime(2026, 8, 17, 0, 0), "ulang tahun"))
+                         [datetime(2026, 8, 17, 0, 0), "ulang tahun"])
 
     def test_combined_date_and_time(self):
         self.assertEqual(self._dt("Besok pukul 8 ada kelas.")[0],

--- a/test/test_dates_ms.py
+++ b/test/test_dates_ms.py
@@ -114,7 +114,7 @@ class TestRealSentencesMs(unittest.TestCase):
 
     def test_relative_day_sentences(self):
         self.assertEqual(self._dt("Jumpa esok pukul 9 pagi."),
-                         (datetime(2026, 7, 16, 9, 0), "jumpa pagi"))
+                         [datetime(2026, 7, 16, 9, 0), "jumpa pagi"])
         self.assertEqual(self._dt("Hari ini saya cuti.")[0],
                          datetime(2026, 7, 15, 0, 0))
         self.assertEqual(self._dt("Semalam hujan.")[0],
@@ -124,7 +124,7 @@ class TestRealSentencesMs(unittest.TestCase):
 
     def test_offset_sentences(self):
         self.assertEqual(self._dt("Ingatkan saya dua jam lagi."),
-                         (datetime(2026, 7, 15, 14, 0), "ingatkan saya"))
+                         [datetime(2026, 7, 15, 14, 0), "ingatkan saya"])
         self.assertEqual(self._dt("Lima hari lepas dia pergi.")[0],
                          datetime(2026, 7, 10, 0, 0))
         self.assertEqual(
@@ -133,7 +133,7 @@ class TestRealSentencesMs(unittest.TestCase):
 
     def test_weekday_sentences(self):
         self.assertEqual(self._dt("Mesyuarat Selasa depan."),
-                         (datetime(2026, 7, 21, 0, 0), "mesyuarat"))
+                         [datetime(2026, 7, 21, 0, 0), "mesyuarat"])
         self.assertEqual(self._dt("Jumaat lepas kami berjumpa.")[0],
                          datetime(2026, 7, 10, 0, 0))
         # "Ahad ini" resolves to the coming Sunday
@@ -142,7 +142,7 @@ class TestRealSentencesMs(unittest.TestCase):
 
     def test_period_sentences(self):
         self.assertEqual(self._dt("Minggu depan cuti."),
-                         (datetime(2026, 7, 22, 0, 0), "cuti"))
+                         [datetime(2026, 7, 22, 0, 0), "cuti"])
         self.assertEqual(self._dt("Bulan lepas kami berpindah.")[0],
                          datetime(2026, 6, 15, 0, 0))
         self.assertEqual(self._dt("Tahun depan saya bergraduasi.")[0],
@@ -156,7 +156,7 @@ class TestRealSentencesMs(unittest.TestCase):
 
     def test_month_date_sentences(self):
         self.assertEqual(self._dt("Hari lahir 17 Julai 2026."),
-                         (datetime(2026, 7, 17, 0, 0), "hari lahir"))
+                         [datetime(2026, 7, 17, 0, 0), "hari lahir"])
         # Malay month name "Mac" (March), distinct from Indonesian "Maret"
         self.assertEqual(self._dt("3 Mac 2027")[0],
                          datetime(2027, 3, 3, 0, 0))

--- a/test/test_dates_tr.py
+++ b/test/test_dates_tr.py
@@ -194,7 +194,7 @@ class TestRealSentencesTr(unittest.TestCase):
 
     def test_relative_day_sentences(self):
         self.assertEqual(self._dt("Toplantı yarın."),
-                         (datetime(2026, 7, 16, 0, 0), "toplantı"))
+                         [datetime(2026, 7, 16, 0, 0), "toplantı"])
         self.assertEqual(self._dt("Dün akşam geldim.")[0],
                          datetime(2026, 7, 14, 0, 0))
         self.assertEqual(self._dt("Öbür gün tatil.")[0],
@@ -206,9 +206,9 @@ class TestRealSentencesTr(unittest.TestCase):
 
     def test_offset_sentences(self):
         self.assertEqual(self._dt("Beni iki saat sonra uyandır."),
-                         (datetime(2026, 7, 15, 14, 0), "beni uyandır"))
+                         [datetime(2026, 7, 15, 14, 0), "beni uyandır"])
         self.assertEqual(self._dt("Üç gün önce geldi."),
-                         (datetime(2026, 7, 12, 0, 0), "geldi"))
+                         [datetime(2026, 7, 12, 0, 0), "geldi"])
         self.assertEqual(self._dt("On beş dakika sonra çıkıyoruz.")[0],
                          datetime(2026, 7, 15, 12, 15))
         # a whole-day-or-larger offset resolves to midnight of that day
@@ -217,17 +217,17 @@ class TestRealSentencesTr(unittest.TestCase):
 
     def test_weekday_sentences(self):
         self.assertEqual(self._dt("Gelecek salı görüşürüz."),
-                         (datetime(2026, 7, 21, 0, 0), "görüşürüz"))
+                         [datetime(2026, 7, 21, 0, 0), "görüşürüz"])
         self.assertEqual(self._dt("Geçen cuma oradaydım."),
-                         (datetime(2026, 7, 10, 0, 0), "oradaydım"))
+                         [datetime(2026, 7, 10, 0, 0), "oradaydım"])
         self.assertEqual(self._dt("Geçen pazartesi başladı.")[0],
                          datetime(2026, 7, 13, 0, 0))
         self.assertEqual(self._dt("Pazartesi spora gidiyorum."),
-                         (datetime(2026, 7, 20, 0, 0), "spora gidiyorum"))
+                         [datetime(2026, 7, 20, 0, 0), "spora gidiyorum"])
 
     def test_period_sentences(self):
         self.assertEqual(self._dt("Gelecek hafta tatildeyim."),
-                         (datetime(2026, 7, 22, 0, 0), "tatildeyim"))
+                         [datetime(2026, 7, 22, 0, 0), "tatildeyim"])
         self.assertEqual(self._dt("Geçen ay taşındık.")[0],
                          datetime(2026, 6, 15, 0, 0))
         self.assertEqual(self._dt("Gelecek yıl mezun oluyorum.")[0],
@@ -236,9 +236,9 @@ class TestRealSentencesTr(unittest.TestCase):
     def test_clock_sentences(self):
         # Turkish written locative suffix on the hour
         self.assertEqual(self._dt("Alarmı saat 7'ye kur."),
-                         (datetime(2026, 7, 15, 7, 0), "alarmı kur"))
+                         [datetime(2026, 7, 15, 7, 0), "alarmı kur"])
         self.assertEqual(self._dt("Randevu 15:30'da."),
-                         (datetime(2026, 7, 15, 15, 30), "randevu"))
+                         [datetime(2026, 7, 15, 15, 30), "randevu"])
         self.assertEqual(self._dt("Bugün saat 23:59")[0],
                          datetime(2026, 7, 15, 23, 59))
         # spelled-out clock hour
@@ -247,7 +247,7 @@ class TestRealSentencesTr(unittest.TestCase):
 
     def test_month_date_sentences(self):
         self.assertEqual(self._dt("Doğum günüm 26 Temmuz 2026."),
-                         (datetime(2026, 7, 26, 0, 0), "doğum günüm"))
+                         [datetime(2026, 7, 26, 0, 0), "doğum günüm"])
         # a past month rolls to next year
         self.assertEqual(self._dt("5 Nisan")[0], datetime(2027, 4, 5, 0, 0))
 

--- a/test/test_extract_datetime_return_shape.py
+++ b/test/test_extract_datetime_return_shape.py
@@ -1,0 +1,98 @@
+"""API-shape parity: extract_datetime must always return a list.
+
+Regression coverage for extract_datetime_tr, extract_datetime_ar,
+extract_datetime_fa, extract_datetime_id, extract_datetime_ms and
+extract_datetime_kab, which used to return a bare tuple ``(dt, leftover)``
+instead of the ``[dt, leftover]`` list every other supported language
+returns. Callers that rely on the documented list shape (mutation,
+``+`` concatenation with lists, ``isinstance(x, list)`` checks) broke for
+these languages.
+
+Phrases below are reused verbatim from the existing per-language test
+suites (test_multilang_invariants.py, test_lang_parity.py, and the
+individual test_dates_*.py files) so no new linguistic claims are made
+here - this is an API-shape check, not a behavioural one.
+"""
+import unittest
+from datetime import datetime
+
+from ovos_date_parser import extract_datetime
+
+ANCHOR = datetime(2018, 6, 1, 0, 0, 0)  # a Friday, midnight
+
+# One trivially-parseable phrase per supported language, reused from the
+# existing test suite (test_multilang_invariants.TOMORROW,
+# test_lang_parity._TOMORROW, and per-language test_dates_*.py files).
+PHRASE_PER_LANG = {
+    "ar": "غداً",
+    "ast": "mañana",
+    "az": "sabah",
+    "bg": "в петък",
+    "ca": "demà",
+    "cs": "zítra",
+    "da": "i morgen",
+    "de": "morgen",
+    "el": "σήμερα",
+    "en": "tomorrow",
+    "es": "mañana",
+    "et": "homme",
+    "eu": "bihar",
+    "fa": "فردا",
+    "fi": "huomenna",
+    "fr": "demain",
+    "gl": "mañá",
+    "he": "מחר",
+    "hr": "u petak",
+    "hu": "holnap",
+    "id": "besok",
+    "it": "domani",
+    "kab": "azekka",
+    "ms": "esok",
+    "nb": "i morgen",
+    "nl": "morgen",
+    "nn": "i morgon",
+    "oc": "deman",
+    "pl": "jutro",
+    "pt": "amanhã",
+    "ro": "mâine",
+    "ru": "завтра",
+    "sk": "zajtra",
+    "sl": "jutri",
+    "sv": "imorgon",
+    "tr": "yarın",
+    "uk": "завтра",
+}
+
+# Languages fixed by this change - must return None (not a tuple/falsy
+# object other than None) when no date/time is found.
+FIXED_LANGS_NO_MATCH = {
+    "tr": "merhaba dünya",
+    "ar": "مرحبا كيف حالك",
+    "fa": "سلام چطوری",
+    "id": "halo dunia",
+    "ms": "helo dunia",
+    "kab": "azul fell-awen amek tellam",
+}
+
+
+class TestExtractDatetimeReturnsListForEveryLanguage(unittest.TestCase):
+    def test_every_supported_language_returns_a_list(self):
+        for lang, phrase in PHRASE_PER_LANG.items():
+            with self.subTest(lang=lang):
+                result = extract_datetime(phrase, lang, anchorDate=ANCHOR)
+                self.assertIsNotNone(result, f"{lang}: {phrase!r} did not parse")
+                self.assertIsInstance(result, list, f"{lang} returned {type(result)}")
+                self.assertEqual(len(result), 2, f"{lang} returned {result!r}")
+                self.assertIsInstance(result[0], datetime, f"{lang} result[0] wrong type")
+
+
+class TestFixedLanguagesReturnNoneOnNoMatch(unittest.TestCase):
+    def test_no_match_returns_none(self):
+        for lang, phrase in FIXED_LANGS_NO_MATCH.items():
+            with self.subTest(lang=lang):
+                result = extract_datetime(phrase, lang, anchorDate=ANCHOR)
+                self.assertIsNone(result, f"{lang}: {phrase!r} should not parse")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Six languages returned a tuple `(datetime, remainder)` from their `extract_datetime_xx` while every other language returns a list `[datetime, remainder]` — callers relying on the documented list shape (mutation, list concatenation, type checks) broke for tr, ar, fa, id, ms, and kab (the sixth was found by sweeping every `dates_*.py` return statement, not just the reported five).

No-match behaviour was already `None` everywhere, so only the match-shape changed. Twenty existing assertions in `test_dates_{tr,id,ms}.py` were pinning the tuple shape and are updated to the list convention they were locking out.

New `test/test_extract_datetime_return_shape.py` enumerates all 37 dispatched languages and asserts the `[datetime, str]` shape for each using phrases already proven in the suite (no languages skipped), plus `None` on no-match for the six fixed ones — so a future language can't reintroduce the inconsistency.

Full suite: 1926 passed, 2 skipped.