### PR TITLE
fix: parse case-inflected Basque month, day and year forms

### DIFF
--- a/ovos_date_parser/dates_eu.py
+++ b/ovos_date_parser/dates_eu.py
@@ -236,9 +236,9 @@ def extract_datetime_eu(input_str, anchorDate=None, default_time=None):
         anchorDate = datetime.now()
 
     def is_numeric_day(tok):
-        # a bare day number ("25"), not a clock ("15:00") or a
-        # case-inflected number ("3etan")
-        return bool(tok) and tok.isdigit()
+        # a bare day number ("25"), not a clock ("15:00"), a
+        # case-inflected number ("3etan") or a 4 digit year
+        return bool(tok) and tok.isdigit() and 1 <= len(tok) <= 2
 
     def is_numeric_year(tok):
         # only a 4 digit token is treated as a year, so a trailing
@@ -281,6 +281,45 @@ def extract_datetime_eu(input_str, anchorDate=None, default_time=None):
     thises = ["hau"]
     froms += thises
     lists = nxts + prevs + froms + time_indicators
+
+    # --- normalize Basque case-inflected date tokens to their bare forms ---
+    # Basque marks the date word, not a preposition: months take the
+    # genitive ("ekainaren 5a" = the 5th of June) or, with a day, the
+    # absolutive/inessive; the day carries the inessive ("5ean" = on the
+    # 5th); years take the relational -ko ("2027ko ekaina").  The scanner
+    # below only knows the bare stems, so fold the natural suffixed forms
+    # back onto them first.  See Euskaltzaindia EGLU-I declension tables
+    # and the Hiztegia month entries (papers/linguistics/eu/).
+    def _stem(base):
+        return base[:-1] if base.endswith("a") else base
+
+    _month_infl = {}
+    for _m in months:
+        _s = _stem(_m)
+        for _v in (_m + "k", _m + "ren", _s + "ean", _s + "an", _s + "ko"):
+            _month_infl.setdefault(_v, _m)
+    _day_infl = {}
+    for _d in days:
+        _s = _stem(_d)
+        for _v in (_s + "ean", _s + "an", _d + "ren", _s + "ko"):
+            _day_infl.setdefault(_v, _d)
+
+    for _i, _w in enumerate(words):
+        if not _w:
+            continue
+        if _w in months or _w in days:
+            continue
+        if _w in _month_infl:
+            words[_i] = _month_infl[_w]
+        elif _w in _day_infl:
+            words[_i] = _day_infl[_w]
+        elif re.match(r"^\d{4}ko$", _w):
+            # year with the relational suffix: "2027ko" -> "2027"
+            words[_i] = _w[:-2]
+        elif re.match(r"^\d{1,2}(?:an|ean|garren|garrena|garrenean)$", _w):
+            # day in the inessive: "5ean" -> "5", "20an" -> "20"
+            words[_i] = re.match(r"^(\d{1,2})", _w).group(1)
+
     for idx, word in enumerate(words):
         if word == "":
             continue
@@ -431,11 +470,13 @@ def extract_datetime_eu(input_str, anchorDate=None, default_time=None):
             used = 1
             if dayOffset < 0:
                 dayOffset += 7
-            if wordPrev == "hurrengo":
+            if wordPrev in nexts:
+                # "datorren / hurrengo / ondorengo ostirala" = next Friday
                 dayOffset += 7
                 used += 1
                 start -= 1
-            elif wordPrev == "aurreko":
+            elif wordPrev in prevs:
+                # "aurreko / duela ... ostirala" = last Friday
                 dayOffset -= 7
                 used += 1
                 start -= 1
@@ -452,53 +493,46 @@ def extract_datetime_eu(input_str, anchorDate=None, default_time=None):
             except ValueError:
                 m = monthsShort.index(word)
             used += 1
-            datestr = months[m]
+            month_name = months[m]
+            day_tok = ""
+            year_tok = ""
+            # a day sits right before or after the month:
+            # "ekainaren 5a" / "5 ekaina" / "ekaina 5"
             if is_numeric_day(wordPrev):
-                # 13 mayo
-                datestr += " " + wordPrev
+                day_tok = wordPrev
                 start -= 1
                 used += 1
-                if is_numeric_year(wordNext):
-                    datestr += " " + wordNext
-                    used += 1
-                    hasYear = True
-                else:
-                    hasYear = False
-
             elif is_numeric_day(wordNext):
-                # mayo 13
-                datestr += " " + wordNext
+                day_tok = wordNext
                 used += 1
-                if is_numeric_year(wordNextNext):
-                    datestr += " " + wordNextNext
-                    used += 1
+            # a 4 digit year can flank the month on either side; the
+            # natural Basque order is "<year> <month> <day>"
+            # ("2027ko ekainaren 5ean" -> "2027 ekaina 5")
+            if is_numeric_year(wordPrev) and wordPrev != day_tok:
+                year_tok = wordPrev
+                start -= 1
+                used += 1
+            elif is_numeric_year(wordNext) and wordNext != day_tok:
+                year_tok = wordNext
+                used += 1
+            elif is_numeric_year(wordNextNext) and day_tok == wordNext:
+                year_tok = wordNextNext
+                used += 1
+
+            if day_tok:
+                datestr = month_name + " " + day_tok
+                if year_tok:
+                    datestr += " " + year_tok
                     hasYear = True
                 else:
                     hasYear = False
-
-            elif is_numeric_day(wordPrevPrev):
-                # 13 dia mayo
-                datestr += " " + wordPrevPrev
-
-                start -= 2
-                used += 2
-                if is_numeric_year(wordNext):
-                    datestr += " " + wordNext
-                    used += 1
-                    hasYear = True
-                else:
-                    hasYear = False
-
-            elif is_numeric_day(wordNextNext):
-                # mayo dia 13
-                datestr += " " + wordNextNext
-                used += 2
-                if is_numeric_year(wordNextNextNext):
-                    datestr += " " + wordNextNextNext
-                    used += 1
-                    hasYear = True
-                else:
-                    hasYear = False
+            elif year_tok:
+                # month + year with no day ("2027ko ekainean"): the
+                # first of the month stands in for the missing day
+                datestr = month_name + " 1 " + year_tok
+                hasYear = True
+            else:
+                datestr = month_name
 
             if datestr in months:
                 datestr = ""

--- a/test/test_dates_eu_calendar.py
+++ b/test/test_dates_eu_calendar.py
@@ -1,0 +1,142 @@
+"""Basque calendar-date extraction: case-inflected month/day/year forms.
+
+Basque marks the date word, not a preposition. The canonical, recommended
+composition (Euskaltzaindia Araua 37 "Data nola adierazi", approved
+Donostia 1995-07-28) is "1983ko martxoaren 7an":
+
+    * year  -> relational suffix -ko   ("2027ko")
+    * month -> genitive suffix   -aren ("ekainaren")
+    * day   -> inessive suffix   -an/-ean ("7an", "5ean")
+
+The bare apposition "urtarrilak 20" is licensed only where no case suffix
+is required. Weekdays take the inessive too ("datorren ostegunean").
+
+Source (downloaded, text-verified):
+    papers/linguistics/eu/INDEX.md ->
+    papers/iberian/euskaltzaindia_araua37_data_nola_adierazi.pdf
+    https://www.euskaltzaindia.eus/dok/arauak/Araua_0037.pdf
+
+The anchor is a Tuesday (2017-06-27) so weekday and year-rollover maths
+are unambiguous.
+"""
+import unittest
+from datetime import datetime
+
+from ovos_config.locale import get_default_tz as default_timezone
+
+import ovos_date_parser as _odp
+
+ANCHOR = datetime(2017, 6, 27, 13, 4, 0)  # a Tuesday
+TZ = default_timezone()
+
+
+def extract(text, lang="eu", anchor=ANCHOR):
+    res = _odp.extract_datetime(text, lang=lang, anchorDate=anchor)
+    if res is not None and res[0] is not None and res[0].tzinfo is None:
+        res = [res[0].replace(tzinfo=TZ), res[1]]
+    return res
+
+
+def dt(y, mo, d, h=0, mi=0, s=0):
+    return datetime(y, mo, d, h, mi, s, tzinfo=TZ)
+
+
+class TestMonthDayInessive(unittest.TestCase):
+    """"ekainaren 5ean" = the 5th of June (month genitive + day inessive)."""
+
+    def test_month_genitive_day_inessive(self):
+        # June 5 is already past the June 27 anchor, so it rolls to next year
+        res = extract("ekainaren 5ean")
+        self.assertEqual(res[0], dt(2018, 6, 5, 0, 0))
+        self.assertEqual(res[1], "")
+
+    def test_july_20_inessive(self):
+        res = extract("uztailaren 20an")
+        self.assertEqual(res[0], dt(2017, 7, 20, 0, 0))
+        self.assertEqual(res[1], "")
+
+    def test_february_18_rolls_forward(self):
+        res = extract("otsailaren 18an")
+        self.assertEqual(res[0], dt(2018, 2, 18, 0, 0))
+        self.assertEqual(res[1], "")
+
+    def test_bare_apposition_form(self):
+        # "urtarrilak 20" apposition form (Araua 37) still resolves
+        self.assertEqual(extract("urtarrilak 20")[0], dt(2018, 1, 20, 0, 0))
+
+    def test_inside_a_sentence_leaves_remainder(self):
+        res = extract("bilera ekainaren 5ean izango da")
+        self.assertEqual(res[0], dt(2018, 6, 5, 0, 0))
+        self.assertEqual(res[1], "bilera izango da")
+
+
+class TestMonthDayYear(unittest.TestCase):
+    """"2027ko ekainaren 5ean" = year -ko + month genitive + day inessive."""
+
+    def test_full_natural_date(self):
+        res = extract("2027ko ekainaren 5ean")
+        self.assertEqual(res[0], dt(2027, 6, 5, 0, 0))
+        self.assertEqual(res[1], "")
+
+    def test_bare_year_after(self):
+        self.assertEqual(extract("ekaina 5 2027")[0], dt(2027, 6, 5, 0, 0))
+
+    def test_year_is_not_taken_as_day(self):
+        # the 4-digit year must never be parsed as the day of the month
+        res = extract("2027ko ekainaren 5ean")
+        self.assertEqual(res[0].year, 2027)
+        self.assertEqual(res[0].day, 5)
+
+
+class TestMonthYearOnly(unittest.TestCase):
+    """"2027ko ekainean" = a month + year with no day -> defaults to the 1st."""
+
+    def test_year_ko_month_inessive(self):
+        res = extract("2027ko ekainean")
+        self.assertEqual(res[0], dt(2027, 6, 1, 0, 0))
+        self.assertEqual(res[1], "")
+
+    def test_bare_month_year(self):
+        self.assertEqual(extract("ekaina 2027")[0], dt(2027, 6, 1, 0, 0))
+
+
+class TestInflectedWeekday(unittest.TestCase):
+    """"datorren ostiralean" = next Friday (weekday inessive + next marker)."""
+
+    def test_next_friday(self):
+        # anchor is Tuesday 2017-06-27; the coming Friday marker adds a week
+        self.assertEqual(extract("datorren ostiralean")[0], dt(2017, 7, 7, 0, 0))
+
+    def test_last_friday(self):
+        self.assertEqual(extract("aurreko ostiralean")[0], dt(2017, 6, 23, 0, 0))
+
+    def test_ondorengo_thursday(self):
+        # osteguna = Thursday; this-week Thursday is the 29th, next is +7
+        self.assertEqual(extract("ondorengo ostegunean")[0], dt(2017, 7, 6, 0, 0))
+
+
+class TestAdversarialNonMatches(unittest.TestCase):
+    """Inflection must not turn impossible or non-date input into a date."""
+
+    def test_impossible_inflected_days_return_none(self):
+        for phrase in ("otsailaren 30ean", "urtarrilaren 45ean",
+                       "otsailak 30", "maiatza 32"):
+            with self.subTest(phrase=phrase):
+                self.assertIsNone(extract(phrase))
+
+    def test_oclock_is_not_a_day(self):
+        # "5ak" is o'clock (plural), NOT the inessive day "5ean"
+        self.assertEqual(extract("arratsaldeko 5ak")[0], dt(2017, 6, 27, 17, 0))
+
+    def test_locative_hour_is_not_a_day(self):
+        # "3etan" = at 3 o'clock, a clock time not the 3rd of the month
+        res = extract("3etan")
+        self.assertEqual(res[0].hour, 3)
+        self.assertEqual(res[0].month, 6)  # not day-3 of some other month
+
+    def test_non_date_returns_none(self):
+        self.assertIsNone(extract("kaixo zer moduz"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`extract_datetime_eu` only recognised bare month stems (`ekaina`) and bare digit days, but natural Basque inflects the date words themselves (Euskaltzaindia Araua 37: year `-ko`, month genitive `-aren`, day inessive `-an/-ean`). The naturally-phrased forms didn't just fail — they produced **wrong values**: `ekainaren 5ean` was swallowed by the clock parser as 05:00 on the wrong day, `2027ko ekainean` read the year as an hour, and inflected weekdays returned None.

| phrase | before | after |
|---|---|---|
| `2027ko ekainaren 5ean` | 06-28 05:00 (garbage) | 2027-06-05 |
| `ekainaren 5ean` | 06-28 05:00 | 2018-06-05 |
| `2027ko ekainean` | 06-27 20:00 | 2027-06-01 |
| `uztailaren 20an` | 06-27 20:00 | 2017-07-20 |
| `datorren ostiralean` / `aurreko ostiralean` | None | next/last Friday |
| `bilera ekainaren 5ean izango da` | None | 2018-06-05, remainder kept |

Fix: a normalisation pass folds the inflected surface forms onto bare stems before scanning; numeric days restricted to 1–2 digits so 4-digit years are never eaten as days; the month block accepts the natural `year month day` order and month+year without a day; the weekday block honours all next/last markers. Clock guards intact: `arratsaldeko 5ak` still parses as 17:00 and impossible dates (`otsailaren 30ean`) return None.

Cited to Euskaltzaindia Araua 37 ("Data nola adierazi", 1995) from the papers library; `dateparser` has no Basque support so expected values are derived from the norm.

17 new tests in `test/test_dates_eu_calendar.py`. Full suite: 1941 passed, 2 skipped; zero existing assertions changed.