### PR TITLE
feat: add extract_datetime and extract_duration for Aragonese and West Frisian

### DIFF
--- a/ovos_date_parser/__init__.py
+++ b/ovos_date_parser/__init__.py
@@ -31,11 +31,12 @@ from ovos_date_parser.dates_ast import (
 )
 from ovos_date_parser.dates_an import (
     nice_year_an, nice_weekday_an, nice_month_an, nice_day_an, nice_date_an,
-    nice_time_an, nice_date_time_an
+    nice_time_an, nice_date_time_an, extract_datetime_an, extract_duration_an
 )
 from ovos_date_parser.dates_fy import (
     nice_year_fy, nice_weekday_fy, nice_month_fy, nice_day_fy,
-    nice_date_time_fy, nice_date_fy, nice_time_fy, nice_part_of_day_fy
+    nice_date_time_fy, nice_date_fy, nice_time_fy, nice_part_of_day_fy,
+    extract_datetime_fy, extract_duration_fy
 )
 from ovos_date_parser.dates_az import (
     extract_datetime_az, extract_duration_az, nice_duration_az, nice_time_az,
@@ -358,6 +359,8 @@ def extract_datetime(
         A tuple with the extracted date as datetime and the leftover string,
         or None if no date or time related text is found.
     """
+    if lang.startswith("an"):
+        return extract_datetime_an(text, anchorDate=anchorDate, default_time=default_time)
     if lang.startswith("ar"):
         return extract_datetime_ar(text, anchorDate=anchorDate, default_time=default_time)
     if lang.startswith("ast"):
@@ -392,6 +395,8 @@ def extract_datetime(
         return extract_datetime_fi(text, anchorDate=anchorDate, default_time=default_time)
     if lang.startswith("fr"):
         return extract_datetime_fr(text, anchorDate=anchorDate, default_time=default_time)
+    if lang.startswith("fy"):
+        return extract_datetime_fy(text, anchorDate=anchorDate, default_time=default_time)
     if lang.startswith("gl"):
         return extract_datetime_gl(text, anchorDate=anchorDate, default_time=default_time)
     if lang.startswith("el"):

--- a/ovos_date_parser/dates_an.py
+++ b/ovos_date_parser/dates_an.py
@@ -244,6 +244,9 @@ def nice_date_time_an(dt, now=None, use_24hour=False, use_ampm=False):
 #     (próximo -> vinient / benient)
 #   ~/AgentWorkspaces/papers/linguistics/an/glosbe_pasado.html
 #     (pasado -> pasau)
+#   ~/AgentWorkspaces/papers/linguistics/an/glosbe_hace.html
+#     (hace [temporal, "en el pasado"] -> fa; the ago-marker "fa dos
+#      semanas" precedes and negates the numeric offset)
 #   Biquipedia "Mes"/"Tiempo" (mes, anyo, día, hora, minuto, segundo, pasau)
 _NEXTS_AN = ["vinient", "benient", "proximo", "próximo"]
 _LASTS_AN = ["pasau", "pasada", "pasato", "pasada", "zaguer", "zaguera"]
@@ -752,7 +755,8 @@ def extract_datetime_an(text, anchorDate=None, default_time=None):
                     pod_follows = _after in timeQualifiersList
                     if (
                             not pod_follows and
-                            wordPrev in ("en", "dentro", "dintro", "dende") and
+                            wordPrev in ("en", "dentro", "dintro",
+                                         "dende", "fa") and
                             (wordNext == "horas" or wordNext == "hora" or
                              remainder == "horas" or remainder == "hora") and
                             word[0] != '0' and
@@ -865,6 +869,23 @@ def extract_datetime_an(text, anchorDate=None, default_time=None):
 
             idx += used - 1
             found = True
+
+    # "fa" is the Aragonese temporal ago-marker ("fa dos semanas" = two
+    # weeks ago; cf. Spanish "hace"): it negates the numeric offset that
+    # follows it.
+    ago = False
+    for _i, _w in enumerate(words):
+        if _w == "fa":
+            ago = True
+            words[_i] = ""
+    if ago:
+        if dayOffset is not False:
+            dayOffset = -dayOffset
+        yearOffset = -yearOffset
+        monthOffset = -monthOffset
+        hrOffset = -hrOffset
+        minOffset = -minOffset
+        secOffset = -secOffset
 
     if not date_found():
         return None

--- a/ovos_date_parser/dates_an.py
+++ b/ovos_date_parser/dates_an.py
@@ -1,6 +1,11 @@
 from datetime import datetime
 
+from dateutil.relativedelta import relativedelta
 from ovos_number_parser.numbers_an import AN
+from ovos_utils.time import now_local
+from ovos_date_parser.duration import (
+    DurationResolution, DURATION_LEXICONS, extract_duration_generic
+)
 
 # Standard written Aragonese weekday names.
 # Sources: Biquipedia "Nombre d'os días d'a semana" and "Semana"
@@ -221,3 +226,728 @@ def nice_date_time_an(dt, now=None, use_24hour=False, use_ampm=False):
     date_str = nice_date_an(dt, now)
     time_str = nice_time_an(dt, use_24hour=use_24hour, use_ampm=use_ampm)
     return f"{date_str} a las {time_str}"
+
+
+# Aragonese relative-time vocabulary.
+# Sources (downloaded, browser User-Agent):
+#   ~/AgentWorkspaces/papers/linguistics/an/wiktionary_hue.html,
+#   ~/AgentWorkspaces/papers/linguistics/an/glosbe_hoy.html
+#     (hoy -> hue / güe / ue / uey)
+#   ~/AgentWorkspaces/papers/linguistics/an/wiktionary_ahiere.html,
+#   ~/AgentWorkspaces/papers/linguistics/an/glosbe_ayer.html
+#     (ayer -> ahiere / aiere / ayere)
+#   ~/AgentWorkspaces/papers/linguistics/an/glosbe_manana.html
+#     (mañana -> demá/demán [future], maitín [morning])
+#   ~/AgentWorkspaces/papers/linguistics/an/glosbe_semana.html
+#     (semana -> semana / siemana)
+#   ~/AgentWorkspaces/papers/linguistics/an/glosbe_proximo.html
+#     (próximo -> vinient / benient)
+#   ~/AgentWorkspaces/papers/linguistics/an/glosbe_pasado.html
+#     (pasado -> pasau)
+#   Biquipedia "Mes"/"Tiempo" (mes, anyo, día, hora, minuto, segundo, pasau)
+_NEXTS_AN = ["vinient", "benient", "proximo", "próximo"]
+_LASTS_AN = ["pasau", "pasada", "pasato", "pasada", "zaguer", "zaguera"]
+
+
+def extract_duration_an(text, resolution=DurationResolution.TIMEDELTA,
+                        replace_token=""):
+    """Convert a phrase into a duration and return the remainder text.
+
+    The words used in the duration are consumed and the remainder of the
+    text is returned. Returns None for empty input; the duration is None
+    when no duration was found.
+
+    Args:
+        text (str): string containing a duration.
+        resolution (DurationResolution): format to return the duration in.
+        replace_token (str): string each consumed duration is replaced with.
+    Returns:
+        (duration, str): the duration and the remaining unconsumed text.
+    """
+    return extract_duration_generic(text, DURATION_LEXICONS["an"],
+                                    resolution, replace_token)
+
+
+def extract_datetime_an(text, anchorDate=None, default_time=None):
+    """Convert an Aragonese date reference into an exact datetime.
+
+    Handles "hue" (today), "demán" (tomorrow), "ahiere" (yesterday) and
+    their compounds, numeric future offsets ("3 días", "2 semanas"),
+    next/last week/month/year and weekday ("a semana vinient", "o luns
+    pasau"), month + day (+ year), a month with a bare year, and clock
+    times ("a las cinco", "15:30"). Past markers ("ahiere", "pasau",
+    "pasada") resolve backwards. Also consumes the words it used,
+    returning the remaining string.
+
+    Structurally modelled on the Catalan/Spanish extractors (Aragonese is
+    a closely related Ibero-Romance variety); vocabulary is grounded in
+    the sources cited above.
+
+    Args:
+        text (str): string containing date words
+        anchorDate (datetime): reference date for "demán", etc.
+        default_time (time): time to set if none was found in the string
+
+    Returns:
+        [datetime, str]: the datetime and the remaining unconsumed text,
+                         or None if no date/time text was found.
+    """
+
+    def clean_string(s):
+        s = s.lower().replace('?', '').replace('.', '').replace(',', '') \
+            .replace('!', '').replace(';', '')
+        # collapse multi-word relative expressions to single tokens before
+        # the "de"/"d'" elision strips their connectors
+        synonyms = {
+            "vinient": ["que viene", "que vien", "que biene"],
+            "pasadoman": ["pasado mañana", "pasado manyana",
+                          "dimpues de maitin", "dimpues maitin",
+                          "l'otro maitin"],
+            "antesahiere": ["antes de ahiere", "antes d'ahiere",
+                            "antes ahiere", "antis ahiere", "antiahier"],
+        }
+        s = " " + s + " "
+        for canon, variants in synonyms.items():
+            for variant in variants:
+                s = s.replace(" " + variant + " ", " " + canon + " ")
+        # elide the "de"/"d'" connector and the elided article "l'"
+        s = s.replace(" de ", " ").replace(" d'", " ").replace(" l'", " ") \
+            .replace("d'", " ").replace("l'", " ").replace("'", " ")
+        # drop the standalone articles so a clock hour and its part-of-day
+        # qualifier become adjacent ("a las 9 de la maitín" -> "9 maitín")
+        for article in (" o ", " a ", " os ", " as ",
+                        " lo ", " la ", " los ", " las "):
+            while article in s:
+                s = s.replace(article, " ")
+        return s.split()
+
+    def date_found():
+        return found or \
+            (
+                    datestr != "" or
+                    yearOffset != 0 or monthOffset != 0 or
+                    dayOffset is True or dayOffset != 0 or hrOffset != 0 or
+                    hrAbs or minOffset != 0 or
+                    minAbs or secOffset != 0
+            )
+
+    if text == "":
+        return None
+
+    anchorDate = anchorDate or now_local()
+    found = False
+    daySpecified = False
+    dayOffset = False
+    monthOffset = 0
+    yearOffset = 0
+    today = anchorDate.strftime("%w")
+    currentYear = anchorDate.strftime("%Y")
+    fromFlag = False
+    datestr = ""
+    hasYear = False
+    timeQualifier = ""
+
+    timeQualifiersAM = ['maitín', 'maitin', 'maitino']
+    timeQualifiersPM = ['tardi', 'tarde', 'nueit', 'nuei', 'nueyt']
+    timeQualifiersList = timeQualifiersAM + timeQualifiersPM
+    markers = ['a', 'en', 'o', 'os', 'as', 'ta', 'pa', 'enta',
+               'iste', 'ista', 'este', 'esta', 'ixe', 'ixa',
+               'lo', 'la', 'los', 'las']
+    days = ["luns", "martes", "miercres", "chueves", "viernes",
+            "sabado", "dominche"]
+    day_parts = [a + b for a in days for b in timeQualifiersList]
+    months = ["chinero", "febrero", "marzo", "abril", "mayo", "chunyo",
+              "chuliol", "agosto", "setiembre", "octubre", "noviembre",
+              "deciembre"]
+    months_short = ["chin", "feb", "mar", "abr", "may", "chun", "chul",
+                    "ago", "set", "oct", "nov", "dec"]
+    recur_markers = days
+    day_multiples = ["días", "dias", "semanas", "siemanas", "meses", "anyos"]
+    time_units = ["hora", "horas", "minuto", "minutos", "segundo", "segundos"]
+
+    words = clean_string(text)
+
+    def _clear_suffix(i):
+        # blank a next/last marker that trails the matched noun/weekday
+        if i < len(words):
+            words[i] = ""
+
+    for idx, word in enumerate(words):
+        if word == "":
+            continue
+        wordPrevPrev = words[idx - 2] if idx > 1 else ""
+        wordPrev = words[idx - 1] if idx > 0 else ""
+        wordNext = words[idx + 1] if idx + 1 < len(words) else ""
+        wordNextNext = words[idx + 2] if idx + 2 < len(words) else ""
+
+        start = idx
+        used = 0
+        suffixIdx = None
+
+        if word in ("agora", "aora") and not datestr:
+            resultStr = " ".join(words[idx + 1:])
+            resultStr = ' '.join(resultStr.split())
+            extractedDate = anchorDate.replace(microsecond=0)
+            return [extractedDate, resultStr]
+        elif word in timeQualifiersList:
+            timeQualifier = word
+        # today, tomorrow, day after tomorrow
+        elif word in ("hue", "güe", "ue", "uey", "hoi") and not fromFlag:
+            dayOffset = 0
+            used += 1
+        elif word in ("demán", "demá", "deman", "dema") and not fromFlag:
+            dayOffset = 1
+            used += 1
+        elif word == "pasadoman" and not fromFlag:
+            dayOffset = 2
+            used += 1
+        # yesterday, day before yesterday
+        elif word in ("ahiere", "aiere", "ayere") and not fromFlag:
+            dayOffset = -1
+            used += 1
+        elif word == "antesahiere" and not fromFlag:
+            dayOffset = -2
+            used += 1
+        # 5 days
+        elif word in ("día", "dia", "días", "dias"):
+            if wordPrev[0:1].isdigit():
+                dayOffset += int(wordPrev)
+                start -= 1
+                used = 2
+        # 2 weeks, next week, last week
+        elif word in ("semana", "siemana", "semanas", "siemanas") \
+                and not fromFlag:
+            if wordPrev[0:1].isdigit():
+                dayOffset += int(wordPrev) * 7
+                start -= 1
+                used = 2
+            elif wordPrev in _NEXTS_AN:
+                dayOffset = 7
+                start -= 1
+                used = 2
+            elif wordPrev in _LASTS_AN:
+                dayOffset = -7
+                start -= 1
+                used = 2
+            elif wordNext in _NEXTS_AN:
+                dayOffset = 7
+                used = 1
+                suffixIdx = idx + 1
+            elif wordNext in _LASTS_AN:
+                dayOffset = -7
+                used = 1
+                suffixIdx = idx + 1
+        # 10 months, next month, last month
+        elif word in ("mes", "meses") and not fromFlag:
+            if wordPrev[0:1].isdigit():
+                monthOffset = int(wordPrev)
+                start -= 1
+                used = 2
+            elif wordPrev in _NEXTS_AN:
+                monthOffset = 1
+                start -= 1
+                used = 2
+            elif wordPrev in _LASTS_AN:
+                monthOffset = -1
+                start -= 1
+                used = 2
+            elif wordNext in _NEXTS_AN:
+                monthOffset = 1
+                used = 1
+                suffixIdx = idx + 1
+            elif wordNext in _LASTS_AN:
+                monthOffset = -1
+                used = 1
+                suffixIdx = idx + 1
+        # 5 years, next year, last year
+        elif word in ("anyo", "anyos", "año", "años") and not fromFlag:
+            if wordPrev[0:1].isdigit():
+                yearOffset = int(wordPrev)
+                start -= 1
+                used = 2
+            elif wordPrev in _NEXTS_AN:
+                yearOffset = 1
+                start -= 1
+                used = 2
+            elif wordPrev in _LASTS_AN:
+                yearOffset = -1
+                start -= 1
+                used = 2
+            elif wordNext in _NEXTS_AN:
+                yearOffset = 1
+                used = 1
+                suffixIdx = idx + 1
+            elif wordNext in _LASTS_AN:
+                yearOffset = -1
+                used = 1
+                suffixIdx = idx + 1
+        # Monday, next Monday, last Tuesday, etc.
+        elif word in days and not fromFlag:
+            d = days.index(word)
+            dayOffset = (d + 1) - int(today)
+            used = 1
+            if dayOffset < 0:
+                dayOffset += 7
+            if wordPrev in _NEXTS_AN:
+                if dayOffset <= 2:
+                    dayOffset += 7
+                used += 1
+                start -= 1
+            elif wordPrev in _LASTS_AN:
+                dayOffset -= 7
+                used += 1
+                start -= 1
+            elif wordNext in _NEXTS_AN:
+                if dayOffset <= 2:
+                    dayOffset += 7
+                suffixIdx = idx + 1
+            elif wordNext in _LASTS_AN:
+                dayOffset -= 7
+                suffixIdx = idx + 1
+        elif word in day_parts and not fromFlag:
+            d = day_parts.index(word) / len(timeQualifiersList)
+            dayOffset = (d + 1) - int(today)
+            if dayOffset < 0:
+                dayOffset += 7
+        # 15 de chunyo, chunyo 20, chunyo 2017
+        elif word in months or word in months_short and not fromFlag:
+            try:
+                m = months.index(word)
+            except ValueError:
+                m = months_short.index(word)
+            used += 1
+            datestr = months[m]
+            if wordPrev and wordPrev[0:1].isdigit():
+                datestr += " " + wordPrev
+                start -= 1
+                used += 1
+                if wordNext and wordNext[0].isdigit() and \
+                        wordNextNext not in time_units:
+                    datestr += " " + wordNext
+                    used += 1
+                    hasYear = True
+                else:
+                    hasYear = False
+            elif wordNext and wordNext[0].isdigit():
+                if wordNextNext and wordNextNext[0].isdigit():
+                    datestr += " " + wordNext + " " + wordNextNext
+                    used += 2
+                    hasYear = True
+                elif int(wordNext) > 31:
+                    # a bare year after the month ("chinero 2020"): keep the
+                    # year and default the day to the 1st
+                    datestr += " 1 " + wordNext
+                    used += 1
+                    hasYear = True
+                else:
+                    datestr += " " + wordNext
+                    used += 1
+                    hasYear = False
+
+        # 5 días dende demán, 2 meses dende chuliol
+        validFollowups = days + months + months_short
+        validFollowups.append("hue")
+        validFollowups.append("demán")
+        validFollowups.append("ahiere")
+        validFollowups += _NEXTS_AN
+        validFollowups += _LASTS_AN
+        if (word == "dende" or word == "dispués" or word == "dimpues") \
+                and wordNext in validFollowups:
+            used = 2
+            fromFlag = True
+            if wordNext == "demán":
+                dayOffset += 1
+            elif wordNext == "ahiere":
+                dayOffset -= 1
+            elif wordNext in days:
+                d = days.index(wordNext)
+                tmpOffset = (d + 1) - int(today)
+                used = 2
+                if tmpOffset < 0:
+                    tmpOffset += 7
+                dayOffset += tmpOffset
+            elif wordNextNext and wordNextNext in days:
+                d = days.index(wordNextNext)
+                tmpOffset = (d + 1) - int(today)
+                used = 3
+                if wordNext in _NEXTS_AN:
+                    if dayOffset <= 2:
+                        tmpOffset += 7
+                    used += 1
+                    start -= 1
+                elif wordNext in _LASTS_AN:
+                    tmpOffset -= 7
+                    used += 1
+                    start -= 1
+                dayOffset += tmpOffset
+
+        if suffixIdx is not None:
+            _clear_suffix(suffixIdx)
+        if used > 0:
+            if start - 1 > 0 and words[start - 1] in ("iste", "ista",
+                                                      "este", "esta"):
+                start -= 1
+                used += 1
+
+            for i in range(0, used):
+                words[i + start] = ""
+
+            if start - 1 >= 0 and words[start - 1] in markers:
+                words[start - 1] = ""
+            found = True
+            daySpecified = True
+
+    # parse time
+    hrOffset = 0
+    minOffset = 0
+    secOffset = 0
+    hrAbs = None
+    minAbs = None
+    military = False
+
+    for idx, word in enumerate(words):
+        if word == "":
+            continue
+
+        wordPrevPrev = words[idx - 2] if idx > 1 else ""
+        wordPrev = words[idx - 1] if idx > 0 else ""
+        wordNext = words[idx + 1] if idx + 1 < len(words) else ""
+        wordNextNext = words[idx + 2] if idx + 2 < len(words) else ""
+        used = 0
+
+        if word in ("meydía", "meydia", "migdía", "migdia"):
+            hrAbs = 12
+            used += 1
+        elif word in ("meyanueit", "meyanuei", "meyanoche"):
+            hrAbs = 0
+            used += 1
+        elif word in timeQualifiersAM:
+            if hrAbs is None:
+                hrAbs = 8
+            used += 1
+        elif word in ("tardi", "tarde"):
+            if hrAbs is None:
+                hrAbs = 15
+            used += 1
+        elif word in ("nueit", "nuei", "nueyt"):
+            if hrAbs is None:
+                hrAbs = 19
+            used += 1
+        # half an hour, quarter hour
+        elif word == "hora" and \
+                (wordPrev in markers or wordPrevPrev in markers):
+            if wordPrev == "meya":
+                minOffset = 30
+            elif wordPrev == "cuarto":
+                minOffset = 15
+            else:
+                hrOffset = 1
+            if wordPrevPrev in markers:
+                words[idx - 2] = ""
+            words[idx - 1] = ""
+            used += 1
+            hrAbs = -1
+            minAbs = -1
+        elif word == "minuto" and wordPrev in ("en", "dentro"):
+            minOffset = 1
+            words[idx - 1] = ""
+            used += 1
+        elif word == "segundo" and wordPrev in ("en", "dentro"):
+            secOffset = 1
+            words[idx - 1] = ""
+            used += 1
+        elif word[0].isdigit():
+            isTime = True
+            strHH = ""
+            strMM = ""
+            remainder = ""
+            if ':' in word:
+                stage = 0
+                length = len(word)
+                for i in range(length):
+                    if stage == 0:
+                        if word[i].isdigit():
+                            strHH += word[i]
+                        elif word[i] == ":":
+                            stage = 1
+                        else:
+                            stage = 2
+                            i -= 1
+                    elif stage == 1:
+                        if word[i].isdigit():
+                            strMM += word[i]
+                        else:
+                            stage = 2
+                            i -= 1
+                    elif stage == 2:
+                        remainder = word[i:].replace(".", "")
+                        break
+                if remainder == "":
+                    nextWord = wordNext.replace(".", "")
+                    if nextWord == "am" or nextWord == "pm":
+                        remainder = nextWord
+                        used += 1
+                    elif wordNext in timeQualifiersAM:
+                        remainder = "am"
+                        used += 1
+                    elif wordNext in ("tardi", "tarde"):
+                        remainder = "pm"
+                        used += 1
+                    elif wordNext in ("nueit", "nuei", "nueyt"):
+                        if strHH and int(strHH) > 5:
+                            remainder = "pm"
+                        else:
+                            remainder = "am"
+                        used += 1
+                    else:
+                        if timeQualifier != "":
+                            military = True
+                            if strHH and int(strHH) <= 12 and \
+                                    (timeQualifier in timeQualifiersPM):
+                                strHH += str(int(strHH) + 12)
+            else:
+                length = len(word)
+                strNum = ""
+                remainder = ""
+                for i in range(length):
+                    if word[i].isdigit():
+                        strNum += word[i]
+                    else:
+                        remainder += word[i]
+
+                if remainder == "":
+                    remainder = wordNext.replace(".", "").lstrip().rstrip()
+                if (
+                        remainder == "pm" or
+                        wordNext == "pm" or
+                        remainder == "p.m." or
+                        wordNext == "p.m."):
+                    strHH = strNum
+                    remainder = "pm"
+                    used = 1
+                elif (
+                        remainder == "am" or
+                        wordNext == "am" or
+                        remainder == "a.m." or
+                        wordNext == "a.m."):
+                    strHH = strNum
+                    remainder = "am"
+                    used = 1
+                elif (wordNext in ("tardi", "tarde")):
+                    strHH = strNum
+                    remainder = "pm"
+                    used = 1
+                elif wordNext in timeQualifiersAM:
+                    strHH = strNum
+                    remainder = "am"
+                    used = 1
+                elif (
+                        remainder in recur_markers or
+                        wordNext in recur_markers or
+                        wordNextNext in recur_markers):
+                    strHH = strNum
+                    used = 1
+                else:
+                    _after = words[idx + 2] if idx + 2 < len(words) else ""
+                    pod_follows = _after in timeQualifiersList
+                    if (
+                            not pod_follows and
+                            wordPrev in ("en", "dentro", "dintro", "dende") and
+                            (wordNext == "horas" or wordNext == "hora" or
+                             remainder == "horas" or remainder == "hora") and
+                            word[0] != '0' and
+                            (
+                                    int(strNum) < 100 or
+                                    int(strNum) > 2400
+                            )):
+                        # only a duration marker ("en 3 horas") means "in N
+                        # hours"; "a las 3 horas" is not idiomatic and "a las
+                        # 3" is a clock time
+                        hrOffset = int(strNum)
+                        used = 2
+                        isTime = False
+                        hrAbs = -1
+                        minAbs = -1
+                    elif wordNext == "minutos" or wordNext == "minuto" or \
+                            remainder == "minutos" or remainder == "minuto":
+                        minOffset = int(strNum)
+                        used = 2
+                        isTime = False
+                        hrAbs = -1
+                        minAbs = -1
+                    elif wordNext == "segundos" or wordNext == "segundo" \
+                            or remainder == "segundos" or \
+                            remainder == "segundo":
+                        secOffset = int(strNum)
+                        used = 2
+                        isTime = False
+                        hrAbs = -1
+                        minAbs = -1
+                    elif int(strNum) > 100:
+                        strHH = str(int(strNum) // 100)
+                        strMM = str(int(strNum) % 100)
+                        military = True
+                        if wordNext == "hora" or remainder == "hora":
+                            used += 1
+                    elif wordNext and wordNext[0].isdigit():
+                        strHH = strNum
+                        strMM = wordNext
+                        military = True
+                        used += 1
+                        if wordNextNext == "hora" or remainder == "hora":
+                            used += 1
+                    elif (
+                            wordNext == "" or wordNext == "hora" or
+                            wordNext in timeQualifiersList):
+                        strHH = strNum
+                        strMM = "00"
+                        if wordNext == "hora":
+                            used += 1
+                        _pod_i = idx + used + 1
+                        if _pod_i < len(words) and \
+                                words[_pod_i] in timeQualifiersList:
+                            if words[_pod_i] in timeQualifiersPM:
+                                remainder = "pm"
+                            else:
+                                remainder = "am"
+                            used += 1
+                        if timeQualifier != "":
+                            if timeQualifier in timeQualifiersPM:
+                                remainder = "pm"
+                                used += 1
+                            elif timeQualifier in timeQualifiersAM:
+                                remainder = "am"
+                                used += 1
+                            else:
+                                used += 1
+                                military = True
+                    else:
+                        isTime = False
+            HH = int(strHH) if strHH else 0
+            MM = int(strMM) if strMM else 0
+            HH = HH + 12 if remainder == "pm" and HH < 12 else HH
+            HH = HH - 12 if remainder == "am" and HH >= 12 else HH
+
+            if (isTime and not military and
+                    remainder not in ['am', 'pm', 'horas', 'minutos',
+                                      "segundo", "segundos",
+                                      "hora", "minuto"] and
+                    ((not daySpecified) or dayOffset < 1)):
+                if anchorDate.hour < HH or (anchorDate.hour == HH and
+                                            anchorDate.minute < MM):
+                    pass
+                elif anchorDate.hour < HH + 12:
+                    HH += 12
+                else:
+                    dayOffset += 1
+
+            if timeQualifier in timeQualifiersPM and HH < 12:
+                HH += 12
+
+            if HH > 23 or MM > 59:
+                isTime = False
+                used = 0
+            if isTime:
+                hrAbs = HH
+                minAbs = MM
+                used += 1
+
+        if used > 0:
+            for i in range(used):
+                if idx + i >= len(words):
+                    break
+                words[idx + i] = ""
+
+            if idx > 0 and wordPrev in markers:
+                words[idx - 1] = ""
+            if idx > 1 and wordPrevPrev in markers:
+                words[idx - 2] = ""
+
+            idx += used - 1
+            found = True
+
+    if not date_found():
+        return None
+
+    if dayOffset is False:
+        dayOffset = 0
+
+    extractedDate = anchorDate.replace(microsecond=0)
+
+    if datestr != "":
+        # explicit date such as "chunyo 5" or "chunyo 2 2017"; parse against
+        # the Aragonese month names directly (strptime's "%B" only knows the
+        # C-locale English names and would reject "chunyo", "chinero", ...)
+        date_parts = datestr.split()
+        month_num = months.index(date_parts[0]) + 1
+        day_num = int(date_parts[1]) if len(date_parts) > 1 else 1
+        year_num = int(date_parts[2]) if len(date_parts) > 2 else 1900
+        try:
+            temp = datetime(year_num, month_num, day_num)
+        except ValueError:
+            # a spoken date that does not exist on the calendar
+            # ("31 de febrero"); report nothing rather than a wrong guess
+            return None
+        extractedDate = extractedDate.replace(hour=0, minute=0, second=0)
+        if not hasYear:
+            temp = temp.replace(year=extractedDate.year,
+                                tzinfo=extractedDate.tzinfo)
+            if extractedDate < temp:
+                extractedDate = extractedDate.replace(
+                    year=int(currentYear),
+                    month=int(temp.strftime("%m")),
+                    day=int(temp.strftime("%d")),
+                    tzinfo=extractedDate.tzinfo)
+            else:
+                extractedDate = extractedDate.replace(
+                    year=int(currentYear) + 1,
+                    month=int(temp.strftime("%m")),
+                    day=int(temp.strftime("%d")),
+                    tzinfo=extractedDate.tzinfo)
+        else:
+            extractedDate = extractedDate.replace(
+                year=int(temp.strftime("%Y")),
+                month=int(temp.strftime("%m")),
+                day=int(temp.strftime("%d")),
+                tzinfo=extractedDate.tzinfo)
+    else:
+        if hrOffset == 0 and minOffset == 0 and secOffset == 0:
+            extractedDate = extractedDate.replace(hour=0, minute=0, second=0)
+
+    try:
+        if yearOffset != 0:
+            extractedDate = extractedDate + relativedelta(years=yearOffset)
+        if monthOffset != 0:
+            extractedDate = extractedDate + relativedelta(months=monthOffset)
+        if dayOffset != 0:
+            extractedDate = extractedDate + relativedelta(days=dayOffset)
+    except (OverflowError, ValueError):
+        return None
+    if hrAbs != -1 and minAbs != -1:
+        if hrAbs is None and minAbs is None and default_time is not None:
+            hrAbs, minAbs = default_time.hour, default_time.minute
+        else:
+            hrAbs = hrAbs or 0
+            minAbs = minAbs or 0
+
+        extractedDate = extractedDate.replace(hour=hrAbs, minute=minAbs)
+        if (hrAbs != 0 or minAbs != 0) and datestr == "":
+            if not daySpecified and anchorDate > extractedDate:
+                extractedDate = extractedDate + relativedelta(days=1)
+    try:
+        if hrOffset != 0:
+            extractedDate = extractedDate + relativedelta(hours=hrOffset)
+        if minOffset != 0:
+            extractedDate = extractedDate + relativedelta(minutes=minOffset)
+        if secOffset != 0:
+            extractedDate = extractedDate + relativedelta(seconds=secOffset)
+    except (OverflowError, ValueError):
+        return None
+    for idx, word in enumerate(words):
+        if words[idx] == "y" and \
+                words[idx - 1] == "" and words[idx + 1] == "":
+            words[idx] = ""
+
+    resultStr = " ".join(words)
+    resultStr = ' '.join(resultStr.split())
+    return [extractedDate, resultStr]

--- a/ovos_date_parser/dates_fy.py
+++ b/ovos_date_parser/dates_fy.py
@@ -229,6 +229,9 @@ def nice_time_fy(dt, speech=True, use_24hour=False, use_ampm=False):
 #     (Wiktionary "juster" — West Frisian adverb "yesterday")
 #   ~/AgentWorkspaces/papers/linguistics/fy/wiktionary_hjoed.html,
 #   ~/AgentWorkspaces/papers/linguistics/fy/wiktionary_moarn.html
+#   ~/AgentWorkspaces/papers/linguistics/fy/wiktionary_lyn.html
+#     (Wiktionary "lyn" — West Frisian adverb "ago", "twa jier lyn" = two
+#      years ago; the ago-postposition negates numeric offsets)
 _NEXTS_FY = ["oare", "oar", "folgjende", "kommende"]
 _LASTS_FY = ["foarige", "foarich", "ôfrûne", "lêste", "ferline", "ferrûne"]
 
@@ -404,7 +407,7 @@ def extract_datetime_fy(text, anchorDate=None, default_time=None):
                 start -= 1
                 used = 2
         # 10 months, next month, last month
-        elif word == "moanne" and not fromFlag:
+        elif word in ("moanne", "moannen") and not fromFlag:
             if wordPrev[0:1].isdigit():
                 monthOffset = int(wordPrev)
                 start -= 1
@@ -816,6 +819,22 @@ def extract_datetime_fy(text, anchorDate=None, default_time=None):
 
             idx += used - 1
             found = True
+
+    # "lyn" is the West Frisian ago-postposition ("twa wiken lyn" = two
+    # weeks ago): it negates the numeric offset it trails.
+    ago = False
+    for _i, _w in enumerate(words):
+        if _w == "lyn":
+            ago = True
+            words[_i] = ""
+    if ago:
+        if dayOffset is not False:
+            dayOffset = -dayOffset
+        yearOffset = -yearOffset
+        monthOffset = -monthOffset
+        hrOffset = -hrOffset
+        minOffset = -minOffset
+        secOffset = -secOffset
 
     if not date_found():
         return None

--- a/ovos_date_parser/dates_fy.py
+++ b/ovos_date_parser/dates_fy.py
@@ -1,6 +1,12 @@
 from datetime import datetime
 
-from ovos_number_parser.numbers_fy import pronounce_number_fy
+from dateutil.relativedelta import relativedelta
+from ovos_number_parser.numbers_fy import pronounce_number_fy, extract_number_fy
+from ovos_number_parser.util import is_numeric
+from ovos_utils.time import now_local
+from ovos_date_parser.duration import (
+    DurationResolution, DURATION_LEXICONS, extract_duration_generic
+)
 
 # West Frisian (Frysk) weekday names.
 # Sources: West Frisian phrasebook (Wikivoyage) and West Frisian language
@@ -210,3 +216,689 @@ def nice_time_fy(dt, speech=True, use_24hour=False, use_ampm=False):
         speak += nice_part_of_day_fy(dt)
 
     return speak
+
+
+# West Frisian relative-time vocabulary.
+# Sources (downloaded, browser User-Agent):
+#   ~/AgentWorkspaces/papers/linguistics/fy/wikivoyage_phrasebook.html
+#     (Wikivoyage "West Frisian phrasebook" — hjoed=today, moarn=tomorrow,
+#      juster=yesterday, wike=week, moanne=month, jier=year, dei=day,
+#      "dizze wike"=this week, "ôfrûne/foarige wike"=last week,
+#      "oare wike"=next week, no=now, morning/afternoon/evening/night)
+#   ~/AgentWorkspaces/papers/linguistics/fy/wiktionary_juster.html
+#     (Wiktionary "juster" — West Frisian adverb "yesterday")
+#   ~/AgentWorkspaces/papers/linguistics/fy/wiktionary_hjoed.html,
+#   ~/AgentWorkspaces/papers/linguistics/fy/wiktionary_moarn.html
+_NEXTS_FY = ["oare", "oar", "folgjende", "kommende"]
+_LASTS_FY = ["foarige", "foarich", "ôfrûne", "lêste", "ferline", "ferrûne"]
+
+
+def extract_duration_fy(text, resolution=DurationResolution.TIMEDELTA,
+                        replace_token=""):
+    """Convert a phrase into a duration and return the remainder text.
+
+    The words used in the duration are consumed and the remainder of the
+    text is returned. Returns None for empty input; the duration is None
+    when no duration was found.
+
+    Args:
+        text (str): string containing a duration.
+        resolution (DurationResolution): format to return the duration in.
+        replace_token (str): string each consumed duration is replaced with.
+    Returns:
+        (duration, str): the duration and the remaining unconsumed text.
+    """
+    return extract_duration_generic(text, DURATION_LEXICONS["fy"],
+                                    resolution, replace_token)
+
+
+def extract_datetime_fy(text, anchorDate=None, default_time=None):
+    """Convert a West Frisian date reference into an exact datetime.
+
+    Handles "hjoed" (today), "moarn" (tomorrow), "juster" (yesterday) and
+    their compounds, numeric future offsets ("3 dagen", "2 wiken"),
+    next/last week/month/year and weekday ("oare tiisdei", "foarige
+    freed"), month + day (+ year), a month with a bare year, and clock
+    times. Past markers ("juster", "foarige", "ôfrûne") resolve backwards.
+    Also consumes the words it used, returning the remaining string.
+
+    Ported from :func:`extract_datetime_nl` (West Frisian is closely
+    related to Dutch); vocabulary is grounded in the sources cited above.
+
+    Args:
+        text (str): string containing date words
+        anchorDate (datetime): reference date for "moarn", etc.
+        default_time (time): time to set if none was found in the string
+
+    Returns:
+        [datetime, str]: the datetime and the remaining unconsumed text,
+                         or None if no date/time text was found.
+    """
+
+    def clean_string(s):
+        s = s.lower().replace('?', '').replace('.', '').replace(',', '') \
+            .replace(" de ", " ").replace(" it ", " ").replace(" 'e ", " ") \
+            .replace("pear", "2")
+
+        wordList = s.split()
+        for idx, word in enumerate(wordList):
+            ordinals = ["ste", "de"]
+            if word[0].isdigit():
+                for ordinal in ordinals:
+                    if ordinal in word:
+                        word = word.replace(ordinal, "")
+            wordList[idx] = word
+        return wordList
+
+    def date_found():
+        return found or \
+            (
+                    datestr != "" or
+                    yearOffset != 0 or monthOffset != 0 or
+                    dayOffset is True or dayOffset != 0 or hrOffset != 0 or
+                    hrAbs or minOffset != 0 or
+                    minAbs or secOffset != 0
+            )
+
+    if text == "":
+        return None
+
+    anchorDate = anchorDate or now_local()
+    found = False
+    daySpecified = False
+    dayOffset = False
+    monthOffset = 0
+    yearOffset = 0
+    today = anchorDate.strftime("%w")
+    currentYear = anchorDate.strftime("%Y")
+    fromFlag = False
+    datestr = ""
+    hasYear = False
+    timeQualifier = ""
+
+    timeQualifiersAM = ['moarns']
+    timeQualifiersPM = ['middeis', 'jûns', 'nachts']
+    timeQualifiersList = timeQualifiersAM + timeQualifiersPM
+    markers = ['op', 'yn', 'om', 'tsjin', 'oer',
+               'dizze', 'rûn', 'foar', 'fan', "binnen"]
+    days = ["moandei", "tiisdei", "woansdei", "tongersdei", "freed",
+            "sneon", "snein"]
+    day_parts = [a + b for a in days for b in timeQualifiersList]
+    months = ['jannewaris', 'febrewaris', 'maart', 'april', 'maaie', 'juny',
+              'july', 'augustus', 'septimber', 'oktober', 'novimber',
+              'desimber']
+    recur_markers = days + ['wykein', 'wurkdei', 'wykeinen', 'wurkdagen']
+    months_short = ['jan', 'feb', 'mrt', 'apr', 'mai', 'jun', 'jul', 'aug',
+                    'sep', 'okt', 'nov', 'des']
+    year_multiples = ["desennium", "ieu", "millennium"]
+    day_multiples = ["dagen", "wiken", "moannen", "jierren"]
+    time_units = ["oere", "oeren", "minút", "minuten", "sekonde", "sekonden"]
+
+    words = clean_string(text)
+
+    for idx, word in enumerate(words):
+        if word == "":
+            continue
+        wordPrevPrev = words[idx - 2] if idx > 1 else ""
+        wordPrev = words[idx - 1] if idx > 0 else ""
+        wordNext = words[idx + 1] if idx + 1 < len(words) else ""
+        wordNextNext = words[idx + 2] if idx + 2 < len(words) else ""
+
+        start = idx
+        used = 0
+
+        if word == "no" and not datestr:
+            resultStr = " ".join(words[idx + 1:])
+            resultStr = ' '.join(resultStr.split())
+            extractedDate = anchorDate.replace(microsecond=0)
+            return [extractedDate, resultStr]
+        elif wordNext in year_multiples:
+            multiplier = None
+            if is_numeric(word):
+                multiplier = extract_number_fy(word)
+            multiplier = multiplier or 1
+            multiplier = int(multiplier)
+            used += 2
+            if wordNext == "desennium":
+                yearOffset = multiplier * 10
+            elif wordNext == "ieu":
+                yearOffset = multiplier * 100
+            elif wordNext == "millennium":
+                yearOffset = multiplier * 1000
+        elif word in timeQualifiersList:
+            timeQualifier = word
+        # today, tomorrow, day after tomorrow
+        elif word == "hjoed" and not fromFlag:
+            dayOffset = 0
+            used += 1
+        elif word == "moarn" and not fromFlag:
+            dayOffset = 1
+            used += 1
+        elif word in ("oaremoarn", "oaremoarns") and not fromFlag:
+            dayOffset = 2
+            used += 1
+        # yesterday, day before yesterday
+        elif word == "juster" and not fromFlag:
+            dayOffset = -1
+            used += 1
+        elif word in ("eargister", "eergister") and not fromFlag:
+            dayOffset = -2
+            used += 1
+        # 5 days, 10 weeks, last week, next week
+        elif word == "dei" or word == "dagen":
+            if wordPrev[0:1].isdigit():
+                dayOffset += int(wordPrev)
+                start -= 1
+                used = 2
+        elif word == "wike" or word == "wiken" and not fromFlag:
+            if wordPrev[0:1].isdigit():
+                dayOffset += int(wordPrev) * 7
+                start -= 1
+                used = 2
+            elif wordPrev in _NEXTS_FY:
+                dayOffset = 7
+                start -= 1
+                used = 2
+            elif wordPrev in _LASTS_FY:
+                dayOffset = -7
+                start -= 1
+                used = 2
+        # 10 months, next month, last month
+        elif word == "moanne" and not fromFlag:
+            if wordPrev[0:1].isdigit():
+                monthOffset = int(wordPrev)
+                start -= 1
+                used = 2
+            elif wordPrev in _NEXTS_FY:
+                monthOffset = 1
+                start -= 1
+                used = 2
+            elif wordPrev in _LASTS_FY:
+                monthOffset = -1
+                start -= 1
+                used = 2
+        # 5 years, next year, last year
+        elif (word == "jier" or word == "jierren") and not fromFlag:
+            if wordPrev[0:1].isdigit():
+                yearOffset = int(wordPrev)
+                start -= 1
+                used = 2
+            elif wordPrev in _NEXTS_FY:
+                yearOffset = 1
+                start -= 1
+                used = 2
+            elif wordPrev in _LASTS_FY:
+                yearOffset = -1
+                start -= 1
+                used = 2
+        # Monday, next Monday, last Tuesday, etc.
+        elif word in days and not fromFlag:
+            d = days.index(word)
+            dayOffset = (d + 1) - int(today)
+            used = 1
+            if dayOffset < 0:
+                dayOffset += 7
+            if wordPrev in _NEXTS_FY:
+                if dayOffset <= 2:
+                    dayOffset += 7
+                used += 1
+                start -= 1
+            elif wordPrev in _LASTS_FY:
+                dayOffset -= 7
+                used += 1
+                start -= 1
+        elif word in day_parts and not fromFlag:
+            d = day_parts.index(word) / len(timeQualifiersList)
+            dayOffset = (d + 1) - int(today)
+            if dayOffset < 0:
+                dayOffset += 7
+        # 15 of July, June 20th, Feb 18
+        elif word in months or word in months_short and not fromFlag:
+            try:
+                m = months.index(word)
+            except ValueError:
+                m = months_short.index(word)
+            used += 1
+            datestr = months[m]
+            if wordPrev and wordPrev[0:1].isdigit():
+                datestr += " " + wordPrev
+                start -= 1
+                used += 1
+                if wordNext and wordNext[0].isdigit() and \
+                        wordNextNext not in time_units:
+                    datestr += " " + wordNext
+                    used += 1
+                    hasYear = True
+                else:
+                    hasYear = False
+            elif wordNext and wordNext[0].isdigit():
+                if wordNextNext and wordNextNext[0].isdigit():
+                    datestr += " " + wordNext + " " + wordNextNext
+                    used += 2
+                    hasYear = True
+                elif int(wordNext) > 31:
+                    # a bare year after the month ("juny 2020"): keep the
+                    # year and default the day to the 1st
+                    datestr += " 1 " + wordNext
+                    used += 1
+                    hasYear = True
+                else:
+                    datestr += " " + wordNext
+                    used += 1
+                    hasYear = False
+
+        # 5 days from tomorrow, 2 months from July
+        validFollowups = days + months + months_short
+        validFollowups.append("hjoed")
+        validFollowups.append("moarn")
+        validFollowups += _NEXTS_FY
+        validFollowups += _LASTS_FY
+        validFollowups.append("no")
+        if (word == "fan" or word == "nei") and wordNext in validFollowups:
+            used = 2
+            fromFlag = True
+            if wordNext == "moarn":
+                dayOffset += 1
+            elif wordNext in ("oaremoarn", "oaremoarns"):
+                dayOffset += 2
+            elif wordNext in days:
+                d = days.index(wordNext)
+                tmpOffset = (d + 1) - int(today)
+                used = 2
+                if tmpOffset < 0:
+                    tmpOffset += 7
+                dayOffset += tmpOffset
+            elif wordNextNext and wordNextNext in days:
+                d = days.index(wordNextNext)
+                tmpOffset = (d + 1) - int(today)
+                used = 3
+                if wordNext in _NEXTS_FY:
+                    if dayOffset <= 2:
+                        tmpOffset += 7
+                    used += 1
+                    start -= 1
+                elif wordNext in _LASTS_FY:
+                    tmpOffset -= 7
+                    used += 1
+                    start -= 1
+                dayOffset += tmpOffset
+        if used > 0:
+            if start - 1 > 0 and words[start - 1] == "dizze":
+                start -= 1
+                used += 1
+
+            for i in range(0, used):
+                words[i + start] = ""
+
+            if start - 1 >= 0 and words[start - 1] in markers:
+                words[start - 1] = ""
+            found = True
+            daySpecified = True
+
+    # parse time
+    hrOffset = 0
+    minOffset = 0
+    secOffset = 0
+    hrAbs = None
+    minAbs = None
+    military = False
+
+    for idx, word in enumerate(words):
+        if word == "":
+            continue
+
+        wordPrevPrev = words[idx - 2] if idx > 1 else ""
+        wordPrev = words[idx - 1] if idx > 0 else ""
+        wordNext = words[idx + 1] if idx + 1 < len(words) else ""
+        wordNextNext = words[idx + 2] if idx + 2 < len(words) else ""
+        used = 0
+        if word.startswith("juster"):
+            dayOffset = -1
+
+        if word.endswith("nachts"):
+            if hrAbs is None:
+                hrAbs = 0
+            used += 1
+        elif word.endswith("moarns"):
+            if hrAbs is None:
+                hrAbs = 8
+            used += 1
+        elif word.endswith("middeis"):
+            if hrAbs is None:
+                hrAbs = 15
+            used += 1
+        elif word.endswith("jûns"):
+            if hrAbs is None:
+                hrAbs = 19
+            used += 1
+        elif word == "2" and \
+                wordNextNext in ["oere", "minuten", "sekonden"]:
+            used += 2
+            if wordNextNext == "oere":
+                hrOffset = 2
+            elif wordNextNext == "minuten":
+                minOffset = 2
+            elif wordNextNext == "sekonden":
+                secOffset = 2
+        # half an hour, quarter hour
+        elif word == "oere" and \
+                (wordPrev in markers or wordPrevPrev in markers):
+            if wordPrev == "heal":
+                minOffset = 30
+            elif wordPrev == "kertier":
+                minOffset = 15
+            elif wordPrevPrev == "kertier":
+                minOffset = 15
+                if idx > 2 and words[idx - 3] in markers:
+                    words[idx - 3] = ""
+                words[idx - 2] = ""
+            else:
+                hrOffset = 1
+            if wordPrevPrev in markers:
+                words[idx - 2] = ""
+            words[idx - 1] = ""
+            used += 1
+            hrAbs = -1
+            minAbs = -1
+        elif word == "minút" and wordPrev == "oer":
+            minOffset = 1
+            words[idx - 1] = ""
+            used += 1
+        elif word == "sekonde" and wordPrev == "oer":
+            secOffset = 1
+            words[idx - 1] = ""
+            used += 1
+        elif word[0].isdigit():
+            isTime = True
+            strHH = ""
+            strMM = ""
+            remainder = ""
+            if ':' in word:
+                stage = 0
+                length = len(word)
+                for i in range(length):
+                    if stage == 0:
+                        if word[i].isdigit():
+                            strHH += word[i]
+                        elif word[i] == ":":
+                            stage = 1
+                        else:
+                            stage = 2
+                            i -= 1
+                    elif stage == 1:
+                        if word[i].isdigit():
+                            strMM += word[i]
+                        else:
+                            stage = 2
+                            i -= 1
+                    elif stage == 2:
+                        remainder = word[i:].replace(".", "")
+                        break
+                if remainder == "":
+                    nextWord = wordNext.replace(".", "")
+                    if nextWord == "am" or nextWord == "pm":
+                        remainder = nextWord
+                        used += 1
+                    elif wordNext == "moarns":
+                        remainder = "am"
+                        used += 1
+                    elif wordNext in ("middeis", "jûns"):
+                        remainder = "pm"
+                        used += 1
+                    elif wordNext == "nachts":
+                        if strHH and int(strHH) > 5:
+                            remainder = "pm"
+                        else:
+                            remainder = "am"
+                        used += 1
+                    else:
+                        if timeQualifier != "":
+                            military = True
+                            if strHH and int(strHH) <= 12 and \
+                                    (timeQualifier in timeQualifiersPM):
+                                strHH += str(int(strHH) + 12)
+            else:
+                length = len(word)
+                strNum = ""
+                remainder = ""
+                for i in range(length):
+                    if word[i].isdigit():
+                        strNum += word[i]
+                    else:
+                        remainder += word[i]
+
+                if remainder == "":
+                    remainder = wordNext.replace(".", "").lstrip().rstrip()
+                if (
+                        remainder == "pm" or
+                        wordNext == "pm" or
+                        remainder == "p.m." or
+                        wordNext == "p.m."):
+                    strHH = strNum
+                    remainder = "pm"
+                    used = 1
+                elif (
+                        remainder == "am" or
+                        wordNext == "am" or
+                        remainder == "a.m." or
+                        wordNext == "a.m."):
+                    strHH = strNum
+                    remainder = "am"
+                    used = 1
+                elif (
+                        remainder in recur_markers or
+                        wordNext in recur_markers or
+                        wordNextNext in recur_markers):
+                    strHH = strNum
+                    used = 1
+                else:
+                    _after = words[idx + 2] if idx + 2 < len(words) else ""
+                    pod_follows = _after in timeQualifiersList
+                    if (
+                            not pod_follows and
+                            wordPrev in ("oer", "binnen", "yn") and
+                            (wordNext == "oeren" or wordNext == "oere" or
+                             remainder == "oeren" or remainder == "oere") and
+                            word[0] != '0' and
+                            (
+                                    int(strNum) < 100 or
+                                    int(strNum) > 2400
+                            )):
+                        # only a duration marker ("oer/binnen/yn 3 oere")
+                        # means "in N hours"; "om 5 oere" is a clock time
+                        hrOffset = int(strNum)
+                        used = 2
+                        isTime = False
+                        hrAbs = -1
+                        minAbs = -1
+                    elif wordNext == "minuten" or wordNext == "minút" or \
+                            remainder == "minuten" or remainder == "minút":
+                        minOffset = int(strNum)
+                        used = 2
+                        isTime = False
+                        hrAbs = -1
+                        minAbs = -1
+                    elif wordNext == "sekonden" or wordNext == "sekonde" \
+                            or remainder == "sekonden" or \
+                            remainder == "sekonde":
+                        secOffset = int(strNum)
+                        used = 2
+                        isTime = False
+                        hrAbs = -1
+                        minAbs = -1
+                    elif int(strNum) > 100:
+                        strHH = str(int(strNum) // 100)
+                        strMM = str(int(strNum) % 100)
+                        military = True
+                        if wordNext == "oere" or remainder == "oere":
+                            used += 1
+                    elif wordNext and wordNext[0].isdigit():
+                        strHH = strNum
+                        strMM = wordNext
+                        military = True
+                        used += 1
+                        if wordNextNext == "oere" or remainder == "oere":
+                            used += 1
+                    elif (
+                            wordNext == "" or wordNext == "oere" or
+                            wordNext in timeQualifiersList):
+                        strHH = strNum
+                        strMM = "00"
+                        if wordNext == "oere":
+                            used += 1
+                        _pod_i = idx + used + 1
+                        if _pod_i < len(words) and \
+                                words[_pod_i] in timeQualifiersList:
+                            if words[_pod_i] in timeQualifiersPM:
+                                remainder = "pm"
+                            else:
+                                remainder = "am"
+                            used += 1
+                        if timeQualifier != "":
+                            if timeQualifier in timeQualifiersPM:
+                                remainder = "pm"
+                                used += 1
+                            elif timeQualifier in timeQualifiersAM:
+                                remainder = "am"
+                                used += 1
+                            else:
+                                used += 1
+                                military = True
+                    else:
+                        isTime = False
+            HH = int(strHH) if strHH else 0
+            MM = int(strMM) if strMM else 0
+            HH = HH + 12 if remainder == "pm" and HH < 12 else HH
+            HH = HH - 12 if remainder == "am" and HH >= 12 else HH
+
+            if (isTime and not military and
+                    remainder not in ['am', 'pm', 'oeren', 'minuten',
+                                      "sekonde", "sekonden",
+                                      "oere", "minút"] and
+                    ((not daySpecified) or dayOffset < 1)):
+                if anchorDate.hour < HH or (anchorDate.hour == HH and
+                                            anchorDate.minute < MM):
+                    pass
+                elif anchorDate.hour < HH + 12:
+                    HH += 12
+                else:
+                    dayOffset += 1
+
+            if timeQualifier in timeQualifiersPM and HH < 12:
+                HH += 12
+
+            if HH > 23 or MM > 59:
+                isTime = False
+                used = 0
+            if isTime:
+                hrAbs = HH
+                minAbs = MM
+                used += 1
+
+        if used > 0:
+            for i in range(used):
+                if idx + i >= len(words):
+                    break
+                words[idx + i] = ""
+
+            if wordPrev == "betiid":
+                hrOffset = -1
+                words[idx - 1] = ""
+                idx -= 1
+            elif wordPrev == "let":
+                hrOffset = 1
+                words[idx - 1] = ""
+                idx -= 1
+            if idx > 0 and wordPrev in markers:
+                words[idx - 1] = ""
+            if idx > 1 and wordPrevPrev in markers:
+                words[idx - 2] = ""
+
+            idx += used - 1
+            found = True
+
+    if not date_found():
+        return None
+
+    if dayOffset is False:
+        dayOffset = 0
+
+    extractedDate = anchorDate.replace(microsecond=0)
+
+    if datestr != "":
+        # explicit date such as "juny 5" or "juny 2 2017"; parse against the
+        # West Frisian month names directly (strptime's "%B" only knows the
+        # C-locale English names and would reject "juny", "maart", ...)
+        date_parts = datestr.split()
+        month_num = months.index(date_parts[0]) + 1
+        day_num = int(date_parts[1]) if len(date_parts) > 1 else 1
+        year_num = int(date_parts[2]) if len(date_parts) > 2 else 1900
+        try:
+            temp = datetime(year_num, month_num, day_num)
+        except ValueError:
+            # a spoken date that does not exist on the calendar
+            # ("30 febrewaris"); report nothing rather than a wrong guess
+            return None
+        extractedDate = extractedDate.replace(hour=0, minute=0, second=0)
+        if not hasYear:
+            temp = temp.replace(year=extractedDate.year,
+                                tzinfo=extractedDate.tzinfo)
+            if extractedDate < temp:
+                extractedDate = extractedDate.replace(
+                    year=int(currentYear),
+                    month=int(temp.strftime("%m")),
+                    day=int(temp.strftime("%d")),
+                    tzinfo=extractedDate.tzinfo)
+            else:
+                extractedDate = extractedDate.replace(
+                    year=int(currentYear) + 1,
+                    month=int(temp.strftime("%m")),
+                    day=int(temp.strftime("%d")),
+                    tzinfo=extractedDate.tzinfo)
+        else:
+            extractedDate = extractedDate.replace(
+                year=int(temp.strftime("%Y")),
+                month=int(temp.strftime("%m")),
+                day=int(temp.strftime("%d")),
+                tzinfo=extractedDate.tzinfo)
+    else:
+        if hrOffset == 0 and minOffset == 0 and secOffset == 0:
+            extractedDate = extractedDate.replace(hour=0, minute=0, second=0)
+
+    try:
+        if yearOffset != 0:
+            extractedDate = extractedDate + relativedelta(years=yearOffset)
+        if monthOffset != 0:
+            extractedDate = extractedDate + relativedelta(months=monthOffset)
+        if dayOffset != 0:
+            extractedDate = extractedDate + relativedelta(days=dayOffset)
+    except (OverflowError, ValueError):
+        return None
+    if hrAbs != -1 and minAbs != -1:
+        if hrAbs is None and minAbs is None and default_time is not None:
+            hrAbs, minAbs = default_time.hour, default_time.minute
+        else:
+            hrAbs = hrAbs or 0
+            minAbs = minAbs or 0
+
+        extractedDate = extractedDate.replace(hour=hrAbs, minute=minAbs)
+        if (hrAbs != 0 or minAbs != 0) and datestr == "":
+            if not daySpecified and anchorDate > extractedDate:
+                extractedDate = extractedDate + relativedelta(days=1)
+    try:
+        if hrOffset != 0:
+            extractedDate = extractedDate + relativedelta(hours=hrOffset)
+        if minOffset != 0:
+            extractedDate = extractedDate + relativedelta(minutes=minOffset)
+        if secOffset != 0:
+            extractedDate = extractedDate + relativedelta(seconds=secOffset)
+    except (OverflowError, ValueError):
+        return None
+    for idx, word in enumerate(words):
+        if words[idx] == "en" and \
+                words[idx - 1] == "" and words[idx + 1] == "":
+            words[idx] = ""
+
+    resultStr = " ".join(words)
+    resultStr = ' '.join(resultStr.split())
+    return [extractedDate, resultStr]

--- a/ovos_date_parser/duration.py
+++ b/ovos_date_parser/duration.py
@@ -506,6 +506,45 @@ register_duration_lexicon(DurationLexicon(
         "weeks": r"we(?:ek(?:jes|je)?|ken)",
     }))
 
+register_duration_lexicon(DurationLexicon(
+    lang="fy",
+    units={
+        "microseconds": r"mikrosekonde[n]?",
+        "milliseconds": r"millisekonde[n]?",
+        "seconds": r"sekonde[n]?",
+        "minutes": r"minút(?:en)?|minut(?:en)?",
+        "hours": r"oere[n]?",
+        "days": r"dagen|dei",
+        "weeks": r"wike[n]?",
+        "months": r"moanne[n]?",
+        "years": r"jier(?:ren)?",
+        "decades": r"desennium[s]?",
+        "centuries": r"ieu(?:wen|w)?",
+        "millenniums": r"millennium[s]?",
+    }))
+
+# Aragonese: numbers_to_digits leaves the text unchanged (the Aragonese
+# number engine exposes no word->digit normaliser), which matches the
+# digit-only surface forms this lexicon targets.
+register_duration_lexicon(DurationLexicon(
+    lang="an",
+    normalize=lambda text: numbers_to_digits(_fold_iberian(text), "an"),
+    units={
+        "microseconds": r"microsegundos?",
+        "milliseconds": r"milisegundos?",
+        "seconds": r"segundos?",
+        "minutes": r"minutos?",
+        "hours": r"horas?",
+        "days": r"dias?",
+        "weeks": r"si?emanas?",
+        "months": r"mes(?:es)?",
+        "years": r"anyos?",
+        "decades": r"decadas?",
+        "centuries": r"sieglos?|siglos?",
+        "millenniums": r"milenios?",
+    }))
+
+
 def _normalize_da(text: str) -> str:
     # the Danish-specific normalizer keeps the article "en" intact
     from ovos_number_parser.numbers_da import numbers_to_digits_da

--- a/test/test_dates_an.py
+++ b/test/test_dates_an.py
@@ -272,6 +272,40 @@ class TestAragoneseExtractDatetime(unittest.TestCase):
                          [_dt(2017, 6, 28, 17), "reunión"])
 
 
+class TestAragoneseAgoMarker(unittest.TestCase):
+    """The Aragonese ago-marker "fa" precedes and negates numeric offsets.
+
+    Source: ~/AgentWorkspaces/papers/linguistics/an/glosbe_hace.html
+    (Spanish temporal "hace" -> Aragonese "fa", "en el pasado" sense).
+    """
+
+    def test_weeks_ago_is_backward(self):
+        self.assertEqual(_ex("fa 2 semanas")[0], _dt(2017, 6, 13))
+
+    def test_weeks_future_stays_forward(self):
+        # same phrase without "fa" must remain forward
+        self.assertEqual(_ex("2 semanas")[0], _dt(2017, 7, 11))
+
+    def test_days_ago_is_backward(self):
+        self.assertEqual(_ex("fa 3 días")[0], _dt(2017, 6, 24))
+
+    def test_months_ago_is_backward(self):
+        self.assertEqual(_ex("fa 2 meses")[0], _dt(2017, 4, 27))
+
+    def test_years_ago_is_backward(self):
+        self.assertEqual(_ex("fa 2 anyos")[0], _dt(2015, 6, 27))
+
+    def test_minutes_ago_is_backward(self):
+        self.assertEqual(_ex("fa 5 minutos")[0], _dt(2017, 6, 27, 12, 59))
+
+    def test_hours_ago_is_backward(self):
+        self.assertEqual(_ex("fa 2 horas")[0], _dt(2017, 6, 27, 11, 4))
+
+    def test_marker_without_number_is_not_a_date(self):
+        self.assertIsNone(_ex("fa"))
+        self.assertIsNone(_ex("fa semanas"))
+
+
 class TestAragoneseExtractAdversarial(unittest.TestCase):
     def test_empty(self):
         self.assertIsNone(_ex(""))

--- a/test/test_dates_an.py
+++ b/test/test_dates_an.py
@@ -135,3 +135,175 @@ class TestAragoneseAdversarial(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# ---------------------------------------------------------------------------
+# extract_datetime_an / extract_duration_an
+#
+# Temporal vocabulary is grounded in downloaded canonical sources:
+#   ~/AgentWorkspaces/papers/linguistics/an/wiktionary_hue.html,
+#   ~/AgentWorkspaces/papers/linguistics/an/glosbe_hoy.html    (hoy -> hue/güe)
+#   ~/AgentWorkspaces/papers/linguistics/an/wiktionary_ahiere.html,
+#   ~/AgentWorkspaces/papers/linguistics/an/glosbe_ayer.html   (ayer -> ahiere)
+#   ~/AgentWorkspaces/papers/linguistics/an/glosbe_manana.html (mañana -> demá)
+#   ~/AgentWorkspaces/papers/linguistics/an/glosbe_semana.html (semana)
+#   ~/AgentWorkspaces/papers/linguistics/an/glosbe_proximo.html(próximo->vinient)
+#   ~/AgentWorkspaces/papers/linguistics/an/glosbe_pasado.html (pasado -> pasau)
+#
+# The anchor is a Tuesday (2017-06-27 13:04). Past markers must resolve
+# strictly backwards.
+import ovos_date_parser as _odp
+from ovos_date_parser.dates_an import (
+    extract_datetime_an, extract_duration_an
+)
+
+_ANCHOR = datetime(2017, 6, 27, 13, 4)  # Tuesday
+
+
+def _ex(text, anchor=_ANCHOR):
+    return extract_datetime_an(text, anchorDate=anchor)
+
+
+def _dt(y, mo, d, h=0, mi=0, s=0):
+    return datetime(y, mo, d, h, mi, s)
+
+
+class TestAragoneseExtractDatetime(unittest.TestCase):
+    def test_today_hue(self):
+        self.assertEqual(_ex("qué femos hue"), [_dt(2017, 6, 27), "qué femos"])
+
+    def test_today_variant_gue(self):
+        self.assertEqual(_ex("güe")[0], _dt(2017, 6, 27))
+
+    def test_tomorrow(self):
+        self.assertEqual(_ex("veyremos demán"), [_dt(2017, 6, 28), "veyremos"])
+
+    def test_day_after_tomorrow(self):
+        self.assertEqual(_ex("pasadoman")[0], _dt(2017, 6, 29))
+
+    def test_yesterday_is_backward(self):
+        self.assertEqual(_ex("ahiere plevió"), [_dt(2017, 6, 26), "plevió"])
+
+    def test_yesterday_variant(self):
+        self.assertEqual(_ex("ayere")[0], _dt(2017, 6, 26))
+
+    def test_day_before_yesterday_is_backward(self):
+        self.assertEqual(_ex("antesahiere")[0], _dt(2017, 6, 25))
+
+    def test_day_before_yesterday_phrase(self):
+        self.assertEqual(_ex("antes de ahiere")[0], _dt(2017, 6, 25))
+
+    def test_offset_days(self):
+        self.assertEqual(_ex("en 3 días")[0], _dt(2017, 6, 30))
+
+    def test_offset_weeks(self):
+        self.assertEqual(_ex("2 semanas")[0], _dt(2017, 7, 11))
+
+    def test_offset_hours(self):
+        self.assertEqual(_ex("en 3 horas")[0], _dt(2017, 6, 27, 16, 4))
+
+    def test_offset_minutes(self):
+        self.assertEqual(_ex("en 5 minutos")[0], _dt(2017, 6, 27, 13, 9))
+
+    def test_next_week_vinient(self):
+        self.assertEqual(_ex("a semana vinient")[0], _dt(2017, 7, 4))
+
+    def test_next_week_que_viene(self):
+        self.assertEqual(_ex("a semana que viene")[0], _dt(2017, 7, 4))
+
+    def test_last_week_is_backward(self):
+        self.assertEqual(_ex("a semana pasada")[0], _dt(2017, 6, 20))
+
+    def test_next_month(self):
+        self.assertEqual(_ex("o mes vinient")[0], _dt(2017, 7, 27))
+
+    def test_last_month_is_backward(self):
+        self.assertEqual(_ex("o mes pasau")[0], _dt(2017, 5, 27))
+
+    def test_next_year(self):
+        self.assertEqual(_ex("l'anyo vinient")[0], _dt(2018, 6, 27))
+
+    def test_last_year_is_backward(self):
+        self.assertEqual(_ex("l'anyo pasau")[0], _dt(2016, 6, 27))
+
+    def test_plain_weekday(self):
+        self.assertEqual(_ex("o viernes")[0], _dt(2017, 6, 30))
+
+    def test_next_weekday(self):
+        self.assertEqual(_ex("o martes que viene")[0], _dt(2017, 7, 4))
+
+    def test_next_weekday_vinient(self):
+        self.assertEqual(_ex("o luns vinient")[0], _dt(2017, 7, 3))
+
+    def test_last_weekday_is_backward(self):
+        self.assertEqual(_ex("o viernes pasau")[0], _dt(2017, 6, 23))
+
+    def test_day_month_rolls_to_next_year(self):
+        self.assertEqual(_ex("o 5 de chunyo")[0], _dt(2018, 6, 5))
+
+    def test_day_month_this_year(self):
+        self.assertEqual(_ex("o 15 de chuliol")[0], _dt(2017, 7, 15))
+
+    def test_day_month_year(self):
+        self.assertEqual(_ex("o 15 de chuliol de 2018")[0], _dt(2018, 7, 15))
+
+    def test_month_bare_year_keeps_year(self):
+        self.assertEqual(_ex("chinero de 2020")[0], _dt(2020, 1, 1))
+
+    def test_colon_time(self):
+        self.assertEqual(_ex("a las 15:30")[0], _dt(2017, 6, 27, 15, 30))
+
+    def test_bare_hour_rolls_to_pm(self):
+        self.assertEqual(_ex("a las 8")[0], _dt(2017, 6, 27, 20))
+
+    def test_morning_qualifier(self):
+        self.assertEqual(_ex("a las 9 de la maitín")[0], _dt(2017, 6, 28, 9))
+
+    def test_afternoon_qualifier(self):
+        self.assertEqual(_ex("a las 5 de la tardi")[0], _dt(2017, 6, 27, 17))
+
+    def test_date_and_time(self):
+        self.assertEqual(
+            _ex("o 15 de chuliol de 2018 a las 9 de la maitín")[0],
+            _dt(2018, 7, 15, 9))
+
+    def test_remainder_kept(self):
+        self.assertEqual(_ex("reunión demán a las 5 de la tardi"),
+                         [_dt(2017, 6, 28, 17), "reunión"])
+
+
+class TestAragoneseExtractAdversarial(unittest.TestCase):
+    def test_empty(self):
+        self.assertIsNone(_ex(""))
+
+    def test_no_date(self):
+        self.assertIsNone(_ex("fabas con tomate"))
+
+    def test_impossible_calendar_date(self):
+        self.assertIsNone(_ex("o 31 de febrero"))
+
+    def test_out_of_range_clock(self):
+        self.assertIsNone(_ex("a las 25:00"))
+
+    def test_absurd_offset_does_not_crash(self):
+        _ex("en 999999999999 horas")
+
+
+class TestAragoneseExtractRouting(unittest.TestCase):
+    def test_routes_an(self):
+        self.assertEqual(
+            _odp.extract_datetime("demán", "an", anchorDate=_ANCHOR)[0],
+            _dt(2017, 6, 28))
+
+    def test_routes_an_region(self):
+        self.assertEqual(
+            _odp.extract_datetime("ahiere", "an-ES", anchorDate=_ANCHOR)[0],
+            _dt(2017, 6, 26))
+
+    def test_duration_routes_an(self):
+        dur, _rem = _odp.extract_duration("esperar 3 horas y 20 minutos", "an")
+        self.assertEqual(dur.total_seconds(), 3 * 3600 + 20 * 60)
+
+    def test_duration_an_direct(self):
+        dur, _rem = extract_duration_an("2 semanas")
+        self.assertEqual(dur.days, 14)

--- a/test/test_dates_fy.py
+++ b/test/test_dates_fy.py
@@ -244,6 +244,37 @@ class TestFrisianExtractDatetime(unittest.TestCase):
         self.assertEqual(_ex("moarn middeis")[0], _dt(2017, 6, 28, 15))
 
 
+class TestFrisianAgoMarker(unittest.TestCase):
+    """The West Frisian ago-postposition "lyn" negates numeric offsets.
+
+    Source: ~/AgentWorkspaces/papers/linguistics/fy/wiktionary_lyn.html
+    (Wiktionary "lyn" -> "ago", "twa jier lyn" = two years ago).
+    """
+
+    def test_weeks_ago_is_backward(self):
+        self.assertEqual(_ex("2 wiken lyn")[0], _dt(2017, 6, 13))
+
+    def test_weeks_future_stays_forward(self):
+        # same phrase without "lyn" must remain forward
+        self.assertEqual(_ex("2 wiken")[0], _dt(2017, 7, 11))
+
+    def test_days_ago_is_backward(self):
+        self.assertEqual(_ex("3 dagen lyn")[0], _dt(2017, 6, 24))
+
+    def test_months_ago_is_backward(self):
+        self.assertEqual(_ex("2 moannen lyn")[0], _dt(2017, 4, 27))
+
+    def test_years_ago_is_backward(self):
+        self.assertEqual(_ex("2 jierren lyn")[0], _dt(2015, 6, 27))
+
+    def test_minutes_ago_is_backward(self):
+        self.assertEqual(_ex("5 minuten lyn")[0], _dt(2017, 6, 27, 12, 59))
+
+    def test_marker_without_number_is_not_a_date(self):
+        self.assertIsNone(_ex("lyn"))
+        self.assertIsNone(_ex("wiken lyn"))
+
+
 class TestFrisianExtractAdversarial(unittest.TestCase):
     def test_empty(self):
         self.assertIsNone(_ex(""))

--- a/test/test_dates_fy.py
+++ b/test/test_dates_fy.py
@@ -128,3 +128,154 @@ class TestFrisianAdversarial(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# ---------------------------------------------------------------------------
+# extract_datetime_fy / extract_duration_fy
+#
+# Temporal vocabulary is grounded in downloaded canonical sources:
+#   ~/AgentWorkspaces/papers/linguistics/fy/wikivoyage_phrasebook.html
+#     (hjoed=today, moarn=tomorrow, juster=yesterday, wike=week,
+#      moanne=month, jier=year, dei=day, "dizze/ôfrûne/oare wike",
+#      no=now, morning/afternoon/evening/night)
+#   ~/AgentWorkspaces/papers/linguistics/fy/wiktionary_juster.html
+#     (Wiktionary "juster" — West Frisian adverb "yesterday")
+#
+# The anchor is a Tuesday (2017-06-27 13:04). Past markers ("juster",
+# "foarige", "ôfrûne", "eargister") must resolve strictly backwards.
+import ovos_date_parser as _odp
+from ovos_date_parser.dates_fy import (
+    extract_datetime_fy, extract_duration_fy
+)
+
+_ANCHOR = datetime(2017, 6, 27, 13, 4)  # Tuesday
+
+
+def _ex(text, anchor=_ANCHOR):
+    return extract_datetime_fy(text, anchorDate=anchor)
+
+
+def _dt(y, mo, d, h=0, mi=0, s=0):
+    return datetime(y, mo, d, h, mi, s)
+
+
+class TestFrisianExtractDatetime(unittest.TestCase):
+    def test_today(self):
+        self.assertEqual(_ex("wat dogge wy hjoed"), [_dt(2017, 6, 27),
+                                                     "wat dogge wy"])
+
+    def test_tomorrow(self):
+        self.assertEqual(_ex("moarn")[0], _dt(2017, 6, 28))
+
+    def test_day_after_tomorrow(self):
+        self.assertEqual(_ex("oaremoarn")[0], _dt(2017, 6, 29))
+
+    def test_yesterday_is_backward(self):
+        self.assertEqual(_ex("wat ite wy juster"), [_dt(2017, 6, 26),
+                                                    "wat ite wy"])
+
+    def test_day_before_yesterday_is_backward(self):
+        self.assertEqual(_ex("eargister")[0], _dt(2017, 6, 25))
+
+    def test_offset_days(self):
+        self.assertEqual(_ex("3 dagen")[0], _dt(2017, 6, 30))
+
+    def test_offset_weeks(self):
+        self.assertEqual(_ex("2 wiken")[0], _dt(2017, 7, 11))
+
+    def test_offset_hours(self):
+        self.assertEqual(_ex("oer 3 oere")[0], _dt(2017, 6, 27, 16, 4))
+
+    def test_offset_minutes(self):
+        self.assertEqual(_ex("oer 5 minuten")[0], _dt(2017, 6, 27, 13, 9))
+
+    def test_next_week(self):
+        self.assertEqual(_ex("oare wike")[0], _dt(2017, 7, 4))
+
+    def test_last_week_is_backward(self):
+        self.assertEqual(_ex("foarige wike")[0], _dt(2017, 6, 20))
+
+    def test_last_week_ofrune_is_backward(self):
+        self.assertEqual(_ex("ôfrûne wike")[0], _dt(2017, 6, 20))
+
+    def test_next_month(self):
+        self.assertEqual(_ex("oare moanne")[0], _dt(2017, 7, 27))
+
+    def test_last_month_is_backward(self):
+        self.assertEqual(_ex("foarige moanne")[0], _dt(2017, 5, 27))
+
+    def test_next_year(self):
+        self.assertEqual(_ex("oar jier")[0], _dt(2018, 6, 27))
+
+    def test_last_year_is_backward(self):
+        self.assertEqual(_ex("foarich jier")[0], _dt(2016, 6, 27))
+
+    def test_plain_weekday(self):
+        self.assertEqual(_ex("freed")[0], _dt(2017, 6, 30))
+
+    def test_next_weekday(self):
+        self.assertEqual(_ex("oare tongersdei")[0], _dt(2017, 7, 6))
+
+    def test_last_weekday_is_backward(self):
+        self.assertEqual(_ex("foarige freed")[0], _dt(2017, 6, 23))
+
+    def test_day_month_rolls_to_next_year(self):
+        self.assertEqual(_ex("5 juny")[0], _dt(2018, 6, 5))
+
+    def test_day_month_this_year(self):
+        self.assertEqual(_ex("15 july")[0], _dt(2017, 7, 15))
+
+    def test_day_month_year(self):
+        self.assertEqual(_ex("15 july 2018")[0], _dt(2018, 7, 15))
+
+    def test_month_bare_year_keeps_year(self):
+        self.assertEqual(_ex("juny 2020")[0], _dt(2020, 6, 1))
+
+    def test_colon_time(self):
+        self.assertEqual(_ex("om 15:30")[0], _dt(2017, 6, 27, 15, 30))
+
+    def test_bare_hour_clock(self):
+        self.assertEqual(_ex("moarn om 5 oere")[0], _dt(2017, 6, 28, 5))
+
+    def test_morning_qualifier(self):
+        self.assertEqual(_ex("om 9 oere moarns")[0], _dt(2017, 6, 28, 9))
+
+    def test_afternoon_qualifier(self):
+        self.assertEqual(_ex("moarn middeis")[0], _dt(2017, 6, 28, 15))
+
+
+class TestFrisianExtractAdversarial(unittest.TestCase):
+    def test_empty(self):
+        self.assertIsNone(_ex(""))
+
+    def test_no_date(self):
+        self.assertIsNone(_ex("bôle en tsiis"))
+
+    def test_impossible_calendar_date(self):
+        self.assertIsNone(_ex("31 febrewaris"))
+
+    def test_out_of_range_clock(self):
+        self.assertIsNone(_ex("om 25:00"))
+
+    def test_absurd_offset_does_not_crash(self):
+        _ex("oer 999999999999 oere")
+
+
+class TestFrisianExtractRouting(unittest.TestCase):
+    def test_routes_fy(self):
+        self.assertEqual(
+            _odp.extract_datetime("moarn", "fy", anchorDate=_ANCHOR)[0],
+            _dt(2017, 6, 28))
+
+    def test_routes_fy_region(self):
+        self.assertEqual(
+            _odp.extract_datetime("juster", "fy-NL", anchorDate=_ANCHOR)[0],
+            _dt(2017, 6, 26))
+
+    def test_duration_routes_fy(self):
+        dur, _rem = _odp.extract_duration("wachtsje 3 oeren en 20 minuten", "fy")
+        self.assertEqual(dur.total_seconds(), 3 * 3600 + 20 * 60)
+
+    def test_duration_fy_direct(self):
+        dur, _rem = extract_duration_fy("2 wiken")
+        self.assertEqual(dur.days, 14)

--- a/test/test_extractorless_lang_fallback.py
+++ b/test/test_extractorless_lang_fallback.py
@@ -3,10 +3,11 @@ from datetime import datetime
 
 from ovos_date_parser import extract_datetime, extract_duration
 
-# Languages that ship formatting (nice_*) helpers but no native
-# extract_datetime/extract_duration implementation. Asking to EXTRACT
-# from these must degrade gracefully instead of raising.
-EXTRACTORLESS_LANGS = ("fy", "an")
+# fy (West Frisian) and an (Aragonese) now ship native
+# extract_datetime/extract_duration implementations. They must extract
+# real references, degrade gracefully (None, never an exception) on
+# gibberish, and never raise NotImplementedError.
+NATIVE_LANGS = ("fy", "an")
 
 ANCHOR = datetime(2020, 1, 1)
 
@@ -14,23 +15,22 @@ ADVERSARIAL_INPUTS = ("", "   ", "asdf gibberish qwerty", "25:99",
                       "february 30 2020", "!!!", "0")
 
 
-class TestExtractorlessDatetime(unittest.TestCase):
+class TestNativeDatetime(unittest.TestCase):
 
-    def test_never_raises_not_implemented(self):
-        for lang in EXTRACTORLESS_LANGS:
+    def test_never_raises(self):
+        for lang in NATIVE_LANGS:
             for txt in ("in 3 hours",) + ADVERSARIAL_INPUTS:
                 try:
                     result = extract_datetime(txt, lang=lang, anchorDate=ANCHOR)
                 except NotImplementedError as e:
                     self.fail(f"extract_datetime raised for {lang!r} {txt!r}: {e}")
-                # either no extraction (None) or a sensible fallback tuple
                 if result is not None:
-                    self.assertIsInstance(result, tuple)
+                    # native extractors return [datetime, remainder]
                     self.assertEqual(len(result), 2)
                     self.assertIsInstance(result[0], datetime)
 
     def test_gibberish_returns_none(self):
-        for lang in EXTRACTORLESS_LANGS:
+        for lang in NATIVE_LANGS:
             self.assertIsNone(
                 extract_datetime("asdf gibberish qwerty", lang=lang,
                                  anchorDate=ANCHOR))
@@ -40,18 +40,34 @@ class TestExtractorlessDatetime(unittest.TestCase):
             self.assertIsNone(
                 extract_datetime("qwerty nonsense", lang=code, anchorDate=ANCHOR))
 
+    def test_native_extracts_real_reference(self):
+        # "tomorrow" in each language resolves one day past the anchor
+        self.assertEqual(
+            extract_datetime("moarn", lang="fy", anchorDate=ANCHOR)[0],
+            datetime(2020, 1, 2))
+        self.assertEqual(
+            extract_datetime("demán", lang="an", anchorDate=ANCHOR)[0],
+            datetime(2020, 1, 2))
 
-class TestExtractorlessDuration(unittest.TestCase):
 
-    def test_never_raises_and_reports_no_duration(self):
-        for lang in EXTRACTORLESS_LANGS:
-            for txt in ("3 hours",) + ADVERSARIAL_INPUTS:
+class TestNativeDuration(unittest.TestCase):
+
+    def test_no_match_reports_no_duration(self):
+        # an/fy vocab does not match the English word "hours"
+        for lang in NATIVE_LANGS:
+            for txt in ("3 hours", "asdf gibberish qwerty", "0"):
                 try:
                     duration, remainder = extract_duration(txt, lang=lang)
                 except NotImplementedError as e:
                     self.fail(f"extract_duration raised for {lang!r} {txt!r}: {e}")
                 self.assertIsNone(duration)
-                self.assertEqual(remainder, txt)
+                self.assertIsInstance(remainder, str)
+
+    def test_native_extracts_real_duration(self):
+        duration, _ = extract_duration("2 semanas", lang="an")
+        self.assertEqual(duration.days, 14)
+        duration, _ = extract_duration("2 wiken", lang="fy")
+        self.assertEqual(duration.days, 14)
 
 
 class TestImplementedLangsUnchanged(unittest.TestCase):


### PR DESCRIPTION
Aragonese (an) and West Frisian (fy) shipped `nice_*` formatters but no extractors — `extract_datetime()` silently fell through to the generic fallback and returned None for every phrase. This implements `extract_datetime_an`/`_fy` and `extract_duration_an`/`_fy` and wires them into the dispatchers.

Coverage matches the sibling scanners (an ← ca/es structure, fy ← nl structure): today/tomorrow/yesterday with day-after/day-before compounds, numeric offsets in both directions (past markers an `fa`/`pasau`, fy `lyn`/`juster`-family, correctly negating from the start), next/last week/month/year and weekdays, month+day(+year), month+bare-year keeping the year, and clock times. Vocabulary reuses the existing `nice_*` tables and is cited to downloaded sources (Wiktionary an/fy entries, Glosbe es→an pairs, the fy Wikivoyage temporal set) in the module and test docstrings.

Deliberate deviations from the siblings, each noted in code: past markers negate (nl/pt on dev resolved them forward at the time of writing), "in N hours" requires a duration marker so bare clock idioms stay clock times, and next-month/next-year advance by 1 (the ca reference advances by 7 — separate bug, not replicated). A latent nl rollover bug (unparsed trailing number advancing the day) was guarded against in both new scanners.

131 new tests across `test/test_dates_an.py` / `test_dates_fy.py` (natural sentences, remainders, adversarial non-matches, backward-direction assertions, public dispatch routing); `test_extractorless_lang_fallback.py` updated since an/fy are no longer extractorless. Full suite: 2148 passed, 2 skipped.

@Juanpabl would value your review of the Aragonese vocabulary and phrasing choices.