### PR TITLE
Change Aragonese date parser with improved synonyms and tests

### DIFF
--- a/ovos_date_parser/dates_an.py
+++ b/ovos_date_parser/dates_an.py
@@ -303,7 +303,7 @@ def extract_datetime_an(text, anchorDate=None, default_time=None):
         # the "de"/"d'" elision strips their connectors
         synonyms = {
             "vinient": ["que viene", "que vien"],
-            "pasadoman": ["pasau manyana", "pasau mañana",
+            "pasadoman": ["dimpués de manyana", "dimpués de mañana", "pasau manyana", "pasau mañana",
                           "dimpues de maitín", "despús demá",
                           "l'atro maitín"],
             "antesahiere": ["antes d'ahiere", "antes d'ahier",

--- a/ovos_date_parser/dates_an.py
+++ b/ovos_date_parser/dates_an.py
@@ -248,8 +248,8 @@ def nice_date_time_an(dt, now=None, use_24hour=False, use_ampm=False):
 #     (hace [temporal, "en el pasado"] -> fa; the ago-marker "fa dos
 #      semanas" precedes and negates the numeric offset)
 #   Biquipedia "Mes"/"Tiempo" (mes, anyo, día, hora, minuto, segundo, pasau)
-_NEXTS_AN = ["vinient", "benient", "proximo", "próximo"]
-_LASTS_AN = ["pasau", "pasada", "pasato", "pasada", "zaguer", "zaguera"]
+_NEXTS_AN = ["venient", "vinient", "siguient", "proximo", "proxima"]
+_LASTS_AN = ["pasau", "pasada", "pasato", "pasata", "zaguer", "zaguera"]
 
 
 def extract_duration_an(text, resolution=DurationResolution.TIMEDELTA,
@@ -274,9 +274,9 @@ def extract_duration_an(text, resolution=DurationResolution.TIMEDELTA,
 def extract_datetime_an(text, anchorDate=None, default_time=None):
     """Convert an Aragonese date reference into an exact datetime.
 
-    Handles "hue" (today), "demán" (tomorrow), "ahiere" (yesterday) and
+    Handles "hue" (today), "manyana" (tomorrow), "ahiere" (yesterday) and
     their compounds, numeric future offsets ("3 días", "2 semanas"),
-    next/last week/month/year and weekday ("a semana vinient", "o luns
+    next/last week/month/year and weekday ("la semana vinient", "lo luns
     pasau"), month + day (+ year), a month with a bare year, and clock
     times ("a las cinco", "15:30"). Past markers ("ahiere", "pasau",
     "pasada") resolve backwards. Also consumes the words it used,
@@ -288,7 +288,7 @@ def extract_datetime_an(text, anchorDate=None, default_time=None):
 
     Args:
         text (str): string containing date words
-        anchorDate (datetime): reference date for "demán", etc.
+        anchorDate (datetime): reference date for "manyana", etc.
         default_time (time): time to set if none was found in the string
 
     Returns:
@@ -302,12 +302,12 @@ def extract_datetime_an(text, anchorDate=None, default_time=None):
         # collapse multi-word relative expressions to single tokens before
         # the "de"/"d'" elision strips their connectors
         synonyms = {
-            "vinient": ["que viene", "que vien", "que biene"],
-            "pasadoman": ["pasado mañana", "pasado manyana",
-                          "dimpues de maitin", "dimpues maitin",
-                          "l'otro maitin"],
-            "antesahiere": ["antes de ahiere", "antes d'ahiere",
-                            "antes ahiere", "antis ahiere", "antiahier"],
+            "vinient": ["que viene", "que vien"],
+            "pasadoman": ["pasau manyana", "pasau mañana",
+                          "dimpues de maitín", "despús demá",
+                          "l'atro maitín"],
+            "antesahiere": ["antes d'ahiere", "antes d'ahier",
+                            "antes ahiere", "antis d'ahier", "antiahier"],
         }
         s = " " + s + " "
         for canon, variants in synonyms.items():
@@ -317,9 +317,9 @@ def extract_datetime_an(text, anchorDate=None, default_time=None):
         s = s.replace(" de ", " ").replace(" d'", " ").replace(" l'", " ") \
             .replace("d'", " ").replace("l'", " ").replace("'", " ")
         # drop the standalone articles so a clock hour and its part-of-day
-        # qualifier become adjacent ("a las 9 de la maitín" -> "9 maitín")
+        # qualifier become adjacent ("a las 9 d'o maitín" -> "9 maitín")
         for article in (" o ", " a ", " os ", " as ",
-                        " lo ", " la ", " los ", " las "):
+                        " lo ", " la ", " los ", " las ", "es"):
             while article in s:
                 s = s.replace(article, " ")
         return s.split()
@@ -350,12 +350,12 @@ def extract_datetime_an(text, anchorDate=None, default_time=None):
     hasYear = False
     timeQualifier = ""
 
-    timeQualifiersAM = ['maitín', 'maitin', 'maitino']
-    timeQualifiersPM = ['tardi', 'tarde', 'nueit', 'nuei', 'nueyt']
+    timeQualifiersAM = ['maitín', 'maitino']
+    timeQualifiersPM = ['tardi', 'tarde', 'nueit', 'nuei', 'nuet', 'nit']
     timeQualifiersList = timeQualifiersAM + timeQualifiersPM
     markers = ['a', 'en', 'o', 'os', 'as', 'ta', 'pa', 'enta',
                'iste', 'ista', 'este', 'esta', 'ixe', 'ixa',
-               'lo', 'la', 'los', 'las']
+               'lo', 'la', 'los', 'las', 'es']
     days = ["luns", "martes", "miercres", "chueves", "viernes",
             "sabado", "dominche"]
     day_parts = [a + b for a in days for b in timeQualifiersList]
@@ -365,7 +365,7 @@ def extract_datetime_an(text, anchorDate=None, default_time=None):
     months_short = ["chin", "feb", "mar", "abr", "may", "chun", "chul",
                     "ago", "set", "oct", "nov", "dec"]
     recur_markers = days
-    day_multiples = ["días", "dias", "semanas", "siemanas", "meses", "anyos"]
+    day_multiples = ["días", "diyas", "semanas", "meses", "anyos"]
     time_units = ["hora", "horas", "minuto", "minutos", "segundo", "segundos"]
 
     words = clean_string(text)
@@ -398,27 +398,27 @@ def extract_datetime_an(text, anchorDate=None, default_time=None):
         elif word in ("hue", "güe", "ue", "uey", "hoi") and not fromFlag:
             dayOffset = 0
             used += 1
-        elif word in ("demán", "demá", "deman", "dema") and not fromFlag:
+        elif word in ("manyana", "mañana", "demán", "demá", "deman", "dema") and not fromFlag:
             dayOffset = 1
             used += 1
         elif word == "pasadoman" and not fromFlag:
             dayOffset = 2
             used += 1
         # yesterday, day before yesterday
-        elif word in ("ahiere", "aiere", "ayere") and not fromFlag:
+        elif word in ("ahiere", "ahier", "ayere", "ayer") and not fromFlag:
             dayOffset = -1
             used += 1
         elif word == "antesahiere" and not fromFlag:
             dayOffset = -2
             used += 1
         # 5 days
-        elif word in ("día", "dia", "días", "dias"):
+        elif word in ("día", "diya", "días", "diyas"):
             if wordPrev[0:1].isdigit():
                 dayOffset += int(wordPrev)
                 start -= 1
                 used = 2
         # 2 weeks, next week, last week
-        elif word in ("semana", "siemana", "semanas", "siemanas") \
+        elif word in ("semana", "semanas") \
                 and not fromFlag:
             if wordPrev[0:1].isdigit():
                 dayOffset += int(wordPrev) * 7
@@ -463,7 +463,7 @@ def extract_datetime_an(text, anchorDate=None, default_time=None):
                 used = 1
                 suffixIdx = idx + 1
         # 5 years, next year, last year
-        elif word in ("anyo", "anyos", "año", "años") and not fromFlag:
+        elif word in ("anyo", "anyos", "año", "años", "an", "ans") and not fromFlag:
             if wordPrev[0:1].isdigit():
                 yearOffset = int(wordPrev)
                 start -= 1
@@ -550,7 +550,7 @@ def extract_datetime_an(text, anchorDate=None, default_time=None):
         # 5 días dende demán, 2 meses dende chuliol
         validFollowups = days + months + months_short
         validFollowups.append("hue")
-        validFollowups.append("demán")
+        validFollowups.append("manyana")
         validFollowups.append("ahiere")
         validFollowups += _NEXTS_AN
         validFollowups += _LASTS_AN
@@ -618,28 +618,28 @@ def extract_datetime_an(text, anchorDate=None, default_time=None):
         wordNextNext = words[idx + 2] if idx + 2 < len(words) else ""
         used = 0
 
-        if word in ("meydía", "meydia", "migdía", "migdia"):
+        if word in ("meyodía", "mediodiya", "meidía", "michdía"):
             hrAbs = 12
             used += 1
-        elif word in ("meyanueit", "meyanuei", "meyanoche"):
+        elif word in ("meyanueit", "medianueit", "medianuet", "medianit", "meyanuei", "meyanoche"):
             hrAbs = 0
             used += 1
         elif word in timeQualifiersAM:
             if hrAbs is None:
                 hrAbs = 8
             used += 1
-        elif word in ("tardi", "tarde"):
+        elif word in ("tardi", "tarde", "tardada"):
             if hrAbs is None:
                 hrAbs = 15
             used += 1
-        elif word in ("nueit", "nuei", "nueyt"):
+        elif word in ("nueit", "nuei", "nueyt", "nuet", "nit"):
             if hrAbs is None:
                 hrAbs = 19
             used += 1
         # half an hour, quarter hour
         elif word == "hora" and \
                 (wordPrev in markers or wordPrevPrev in markers):
-            if wordPrev == "meya":
+            if wordPrev in ("meya", "media"):
                 minOffset = 30
             elif wordPrev == "cuarto":
                 minOffset = 15
@@ -651,11 +651,11 @@ def extract_datetime_an(text, anchorDate=None, default_time=None):
             used += 1
             hrAbs = -1
             minAbs = -1
-        elif word == "minuto" and wordPrev in ("en", "dentro"):
+        elif word == "minuto" and wordPrev in ("en", "dentro", "drento", "dintro"):
             minOffset = 1
             words[idx - 1] = ""
             used += 1
-        elif word == "segundo" and wordPrev in ("en", "dentro"):
+        elif word == "segundo" and wordPrev in ("en", "dentro", "drento", "dintro"):
             secOffset = 1
             words[idx - 1] = ""
             used += 1
@@ -693,10 +693,10 @@ def extract_datetime_an(text, anchorDate=None, default_time=None):
                     elif wordNext in timeQualifiersAM:
                         remainder = "am"
                         used += 1
-                    elif wordNext in ("tardi", "tarde"):
+                    elif wordNext in ("tardi", "tarde", "tardada"):
                         remainder = "pm"
                         used += 1
-                    elif wordNext in ("nueit", "nuei", "nueyt"):
+                    elif wordNext in ("nueit", "nuei", "nueyt", "nuet", "nit"):
                         if strHH and int(strHH) > 5:
                             remainder = "pm"
                         else:
@@ -755,7 +755,7 @@ def extract_datetime_an(text, anchorDate=None, default_time=None):
                     pod_follows = _after in timeQualifiersList
                     if (
                             not pod_follows and
-                            wordPrev in ("en", "dentro", "dintro",
+                            wordPrev in ("en", "dentro", "dintro", "drento",
                                          "dende", "fa") and
                             (wordNext == "horas" or wordNext == "hora" or
                              remainder == "horas" or remainder == "hora") and

--- a/ovos_date_parser/duration.py
+++ b/ovos_date_parser/duration.py
@@ -535,12 +535,12 @@ register_duration_lexicon(DurationLexicon(
         "seconds": r"segundos?",
         "minutes": r"minutos?",
         "hours": r"horas?",
-        "days": r"dias?",
-        "weeks": r"si?emanas?",
+        "days": r"días?",
+        "weeks": r"semanas?",
         "months": r"mes(?:es)?",
         "years": r"anyos?",
         "decades": r"decadas?",
-        "centuries": r"sieglos?|siglos?",
+        "centuries": r"sieglos?",
         "millenniums": r"milenios?",
     }))
 

--- a/test/test_dates_an.py
+++ b/test/test_dates_an.py
@@ -176,10 +176,10 @@ class TestAragoneseExtractDatetime(unittest.TestCase):
         self.assertEqual(_ex("güe")[0], _dt(2017, 6, 27))
 
     def test_tomorrow(self):
-        self.assertEqual(_ex("veyremos demán"), [_dt(2017, 6, 28), "veyremos"])
+        self.assertEqual(_ex("veyeremos manyana"), [_dt(2017, 6, 28), "veyeremos"])
 
     def test_day_after_tomorrow(self):
-        self.assertEqual(_ex("pasadoman")[0], _dt(2017, 6, 29))
+        self.assertEqual(_ex("dimpués de manyana")[0], _dt(2017, 6, 29))
 
     def test_yesterday_is_backward(self):
         self.assertEqual(_ex("ahiere plevió"), [_dt(2017, 6, 26), "plevió"])
@@ -188,7 +188,7 @@ class TestAragoneseExtractDatetime(unittest.TestCase):
         self.assertEqual(_ex("ayere")[0], _dt(2017, 6, 26))
 
     def test_day_before_yesterday_is_backward(self):
-        self.assertEqual(_ex("antesahiere")[0], _dt(2017, 6, 25))
+        self.assertEqual(_ex("antes d'ahiere")[0], _dt(2017, 6, 25))
 
     def test_day_before_yesterday_phrase(self):
         self.assertEqual(_ex("antes de ahiere")[0], _dt(2017, 6, 25))
@@ -206,16 +206,16 @@ class TestAragoneseExtractDatetime(unittest.TestCase):
         self.assertEqual(_ex("en 5 minutos")[0], _dt(2017, 6, 27, 13, 9))
 
     def test_next_week_vinient(self):
-        self.assertEqual(_ex("a semana vinient")[0], _dt(2017, 7, 4))
+        self.assertEqual(_ex("la semana vinient")[0], _dt(2017, 7, 4))
 
     def test_next_week_que_viene(self):
-        self.assertEqual(_ex("a semana que viene")[0], _dt(2017, 7, 4))
+        self.assertEqual(_ex("la semana que viene")[0], _dt(2017, 7, 4))
 
     def test_last_week_is_backward(self):
         self.assertEqual(_ex("a semana pasada")[0], _dt(2017, 6, 20))
 
     def test_next_month(self):
-        self.assertEqual(_ex("o mes vinient")[0], _dt(2017, 7, 27))
+        self.assertEqual(_ex("lo mes vinient")[0], _dt(2017, 7, 27))
 
     def test_last_month_is_backward(self):
         self.assertEqual(_ex("o mes pasau")[0], _dt(2017, 5, 27))
@@ -230,16 +230,16 @@ class TestAragoneseExtractDatetime(unittest.TestCase):
         self.assertEqual(_ex("o viernes")[0], _dt(2017, 6, 30))
 
     def test_next_weekday(self):
-        self.assertEqual(_ex("o martes que viene")[0], _dt(2017, 7, 4))
+        self.assertEqual(_ex("lo martes que viene")[0], _dt(2017, 7, 4))
 
     def test_next_weekday_vinient(self):
-        self.assertEqual(_ex("o luns vinient")[0], _dt(2017, 7, 3))
+        self.assertEqual(_ex("lo luns vinient")[0], _dt(2017, 7, 3))
 
     def test_last_weekday_is_backward(self):
         self.assertEqual(_ex("o viernes pasau")[0], _dt(2017, 6, 23))
 
     def test_day_month_rolls_to_next_year(self):
-        self.assertEqual(_ex("o 5 de chunyo")[0], _dt(2018, 6, 5))
+        self.assertEqual(_ex("lo 5 de chunyo")[0], _dt(2018, 6, 5))
 
     def test_day_month_this_year(self):
         self.assertEqual(_ex("o 15 de chuliol")[0], _dt(2017, 7, 15))
@@ -257,18 +257,18 @@ class TestAragoneseExtractDatetime(unittest.TestCase):
         self.assertEqual(_ex("a las 8")[0], _dt(2017, 6, 27, 20))
 
     def test_morning_qualifier(self):
-        self.assertEqual(_ex("a las 9 de la maitín")[0], _dt(2017, 6, 28, 9))
+        self.assertEqual(_ex("a las 9 d'o maitín")[0], _dt(2017, 6, 28, 9))
 
     def test_afternoon_qualifier(self):
-        self.assertEqual(_ex("a las 5 de la tardi")[0], _dt(2017, 6, 27, 17))
+        self.assertEqual(_ex("a las 5 d'a tardi")[0], _dt(2017, 6, 27, 17))
 
     def test_date_and_time(self):
         self.assertEqual(
-            _ex("o 15 de chuliol de 2018 a las 9 de la maitín")[0],
+            _ex("o 15 de chuliol de 2018 a las 9 d'o maitín")[0],
             _dt(2018, 7, 15, 9))
 
     def test_remainder_kept(self):
-        self.assertEqual(_ex("reunión demán a las 5 de la tardi"),
+        self.assertEqual(_ex("reunión manyana a las 5 de la tardi"),
                          [_dt(2017, 6, 28, 17), "reunión"])
 
 
@@ -326,7 +326,7 @@ class TestAragoneseExtractAdversarial(unittest.TestCase):
 class TestAragoneseExtractRouting(unittest.TestCase):
     def test_routes_an(self):
         self.assertEqual(
-            _odp.extract_datetime("demán", "an", anchorDate=_ANCHOR)[0],
+            _odp.extract_datetime("manyana", "an", anchorDate=_ANCHOR)[0],
             _dt(2017, 6, 28))
 
     def test_routes_an_region(self):
@@ -335,7 +335,7 @@ class TestAragoneseExtractRouting(unittest.TestCase):
             _dt(2017, 6, 26))
 
     def test_duration_routes_an(self):
-        dur, _rem = _odp.extract_duration("esperar 3 horas y 20 minutos", "an")
+        dur, _rem = _odp.extract_duration("aguardar 3 horas y 20 minutos", "an")
         self.assertEqual(dur.total_seconds(), 3 * 3600 + 20 * 60)
 
     def test_duration_an_direct(self):

--- a/test/test_dates_an_sentences.py
+++ b/test/test_dates_an_sentences.py
@@ -71,12 +71,12 @@ class TestAragoneseFullDateSentences(unittest.TestCase):
         sentence = f"L'acto ye o {nice_date(WEEK['Martes'], 'an')}."
         self.assertEqual(
             sentence,
-            "L'acto ye o Martes, cinco de Chunyo de dos mil y deciueito.")
+            "L'acto ye o martes, cinco de chunyo de dos mil deciueito.")
 
     def test_full_date_without_weekday(self):
         dt = MONTH_FIRST["Chinero"]
         sentence = f"Naixió o {nice_date(dt, 'an', include_weekday=False)}."
-        self.assertEqual(sentence, "Naixió o un de Chinero de dos mil y decinueu.")
+        self.assertEqual(sentence, "Naixió o un de chinero de dos mil decinueu.")
 
     def test_relative_same_month_shortens(self):
         now = datetime(2018, 6, 1)
@@ -109,12 +109,12 @@ class TestAragoneseDayAndYearSentences(unittest.TestCase):
     def test_year_in_sentence(self):
         dt = datetime(2020, 1, 1)
         sentence = f"Estamos en l'anyo {nice_year(dt, 'an')}."
-        self.assertEqual(sentence, "Estamos en l'anyo dos mil y vinte.")
+        self.assertEqual(sentence, "Somos en l'anyo dos mil vinte.")
 
     def test_bc_year_in_sentence(self):
         dt = datetime(44, 3, 15)
-        sentence = f"Chulio Zesar morió en {nice_year(dt, 'an', bc=True)}."
-        self.assertEqual(sentence, "Chulio Zesar morió en cuaranta y cuatre a.C..")
+        sentence = f"Chulio César morió en {nice_year(dt, 'an', bc=True)}."
+        self.assertEqual(sentence, "Chulio César murió en cuaranta y cuatre a.C..")
         self.assertIn(" a.C.", sentence)
 
 
@@ -125,7 +125,7 @@ class TestAragoneseEdgeCasesInContext(unittest.TestCase):
         sentence = f"O {nice_date(dt, 'an', include_weekday=False)} ye bisiesto."
         # nice_date pronounces the day number ("vintinueu" = 29)
         self.assertEqual(
-            sentence, "O vintinueu de Febrero de dos mil y vinte ye bisiesto.")
+            sentence, "O vintinueu de Febrero de dos mil vinte ye bisiesto.")
 
     def test_lang_code_variants_route(self):
         for code in ("an", "an-ES", "AN", "an-es"):

--- a/test/test_extractorless_lang_fallback.py
+++ b/test/test_extractorless_lang_fallback.py
@@ -46,7 +46,7 @@ class TestNativeDatetime(unittest.TestCase):
             extract_datetime("moarn", lang="fy", anchorDate=ANCHOR)[0],
             datetime(2020, 1, 2))
         self.assertEqual(
-            extract_datetime("demán", lang="an", anchorDate=ANCHOR)[0],
+            extract_datetime("manyana", lang="an", anchorDate=ANCHOR)[0],
             datetime(2020, 1, 2))
 
 


### PR DESCRIPTION
I checked and corrected some words. 
Apart from the changes, it must be noted that month and day names (luns, deciembre) should not be written with the initial letter in upper case (unless they need to be for other reasons).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Aragonese date and time recognition for additional spelling, vocabulary, and connector variants.
  * Added support for more expressions covering relative days, weeks, months, years, durations, clock times, and AM/PM qualifiers.
* **Bug Fixes**
  * Improved parsing of natural-language phrases involving date rollovers, time qualifiers, and minute/second expressions.
  * Updated formatted Aragonese date sentences for clearer capitalization, punctuation, and wording.
* **Tests**
  * Expanded coverage for revised Aragonese date, time, duration, and sentence formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->