### PR TITLE
fix: strip dangling conjunctions from extract_duration remainder

### DIFF
--- a/ovos_date_parser/duration.py
+++ b/ovos_date_parser/duration.py
@@ -94,6 +94,13 @@ class DurationLexicon:
         normalize: optional override for text normalization; receives the
             raw text and returns text with numerals as digits. Defaults
             to ``numbers_to_digits(text.lower(), lang)``.
+        connectors: regex fragments (no capturing groups) matching the
+            conjunction word(s) used to join two duration chunks (e.g.
+            ``"and"`` in English, ``"y"`` in Spanish). When a connector
+            (optionally surrounded by commas) is left sandwiched between
+            two consumed ``<number> <unit>`` matches it is stripped from
+            the remainder along with the matches themselves; a connector
+            touching unconsumed text on either side is left untouched.
     """
     lang: str
     units: Dict[str, str]
@@ -101,6 +108,7 @@ class DurationLexicon:
     joiner: str = r"(?:\s+|-)"
     pattern_template: Optional[str] = None
     normalize: Optional[Callable[[str], str]] = None
+    connectors: Tuple[str, ...] = ()
 
     def _normalize(self, text: str) -> str:
         if self.normalize:
@@ -129,6 +137,14 @@ def extract_duration_generic(
 
     text = lexicon._normalize(text)
 
+    # when the caller wants consumed chunks erased (the default), matches
+    # are replaced with a private-use sentinel instead of "" so that, once
+    # every unit has been consumed, connective tokens ("and", ",", ...)
+    # left stranded *between two sentinels* can be told apart from ones
+    # still joining real, unconsumed text and cleaned up accordingly.
+    marker = ""
+    token = marker if not replace_token else replace_token
+
     values: Dict[str, float] = {}
     for unit in _UNITS:
         frag = lexicon.units.get(unit)
@@ -141,11 +157,22 @@ def extract_duration_generic(
             if "half" in match.groupdict() and match.group("half"):
                 val += 0.5
             values[_unit] = values.get(_unit, 0) + val
-            return replace_token
+            return token
 
         text = re.sub(pattern, repl, text)
 
     if not replace_token:
+        if lexicon.connectors:
+            conn_alt = "|".join(lexicon.connectors)
+            sep = (r"\s*,\s*|\s+(?:" + conn_alt + r")\s+|"
+                   r"\s*,\s*(?:" + conn_alt + r")\s*")
+            collapse = re.compile(marker + r"(?:" + sep + r")" + marker)
+            while True:
+                new_text = collapse.sub(marker + marker, text)
+                if new_text == text:
+                    break
+                text = new_text
+        text = text.replace(marker, "")
         text = re.sub(r"\s+", " ", text).strip(" ,;.!")
 
     return _resolve(values, resolution), text
@@ -354,6 +381,7 @@ def _normalize_en(text: str) -> str:
 register_duration_lexicon(DurationLexicon(
     lang="en",
     normalize=_normalize_en,
+    connectors=("and",),
     units={
         "microseconds": r"microseconds?",
         "milliseconds": r"milliseconds?",
@@ -395,6 +423,7 @@ register_duration_lexicon(DurationLexicon(
 register_duration_lexicon(DurationLexicon(
     lang="es",
     normalize=lambda text: numbers_to_digits(_fold_iberian(text), "es"),
+    connectors=("y",),
     units={
         "microseconds": r"microsegundos?",
         "milliseconds": r"milisegundos?",

--- a/test/parse_tests/test_parse_en.py
+++ b/test/parse_tests/test_parse_en.py
@@ -85,6 +85,26 @@ class TestExtractDurationEN(unittest.TestCase):
         self.assertEqual(extract_duration("hello there", lang="en-us"),
                          (None, "hello there"))
 
+    def test_remainder_has_no_dangling_conjunctions(self):
+        # a leftover "and"/"," that only joined two consumed duration
+        # chunks must be removed, not left dangling in the remainder
+        res = extract_duration(
+            "It will take about 2 hours and 30 minutes", lang="en-us")
+        self.assertEqual(res[0], timedelta(seconds=9000))
+        self.assertEqual(res[1], "It will take about")
+
+        res = extract_duration(
+            "It will take about 2 hours, 30 minutes, and 10 seconds",
+            lang="en-us")
+        self.assertEqual(res[0], timedelta(seconds=9010))
+        self.assertEqual(res[1], "It will take about")
+
+        # "and" that connects unconsumed text on both sides must survive
+        res = extract_duration(
+            "two hours and rest and relax", lang="en-us")
+        self.assertEqual(res[0], timedelta(seconds=7200))
+        self.assertEqual(res[1], "and rest and relax")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/parse_tests/test_parse_es.py
+++ b/test/parse_tests/test_parse_es.py
@@ -209,6 +209,17 @@ class TestExtractDuration(unittest.TestCase):
         self.assertEqual(extract_duration("5 milenios"),
                          (timedelta(days=DAYS_IN_1_YEAR * 1000 * 5), ""))
 
+    def test_remainder_has_no_dangling_conjunctions(self):
+        # a leftover "y"/"," that only joined two consumed duration
+        # chunks must be removed, not left dangling in the remainder
+        res = extract_duration("demorará 2 horas y 30 minutos")
+        self.assertEqual(res[0], timedelta(seconds=9000))
+        self.assertEqual(res[1], "demorará")
+
+        res = extract_duration("2 horas, 30 minutos, y 10 segundos")
+        self.assertEqual(res[0], timedelta(seconds=9010))
+        self.assertEqual(res[1], "")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What was broken

`extract_duration_generic` (the shared engine backing `extract_duration` for
most languages) consumed each matched `<number> <unit>` chunk by replacing it
with an empty string. When two chunks in the same sentence were joined by a
conjunction or comma, that connector was left stranded in the remainder text.

```python
>>> extract_duration("It will take about 2 hours and 30 minutes", "en")
(timedelta(seconds=9000), "It will take about and")
>>> extract_duration("2 horas, 30 minutos, y 10 segundos", "es")
(timedelta(seconds=9010), "y")
```

## How it fails

The remainder text is meant to be the sentence with the duration wording
removed, for use by callers (e.g. skills) that want to do something with
"the rest" of the utterance. A dangling "and"/"y" (optionally with commas)
is ungrammatical and can trip up anything downstream that expects clean
leftover text.

## The fix

`extract_duration_generic` now replaces consumed matches with an internal
private-use sentinel character instead of `""`. Once every unit has been
consumed, a connector (with optional surrounding commas) that is sandwiched
between two sentinels — i.e. it only ever joined two *consumed* chunks — is
collapsed away along with them. A connector that still touches real,
unconsumed text on either side is left alone, so "two hours and rest and
relax" still returns remainder `"and rest and relax"`.

This is opt-in per language via a new `DurationLexicon.connectors` field
(a tuple of regex fragments for the language's conjunction word(s)), so it
only changes behavior where explicitly wired up. It's wired up for English
(`"and"`) and Spanish (`"y"`), where the bug was confirmed. Other languages
(e.g. German `"und"`, French `"et"`) keep their existing, already-tested
remainder behavior — those tests intentionally leave the connector in the
remainder and are unaffected.

## Verification

Following this repo's NL-TDD convention, failing tests were written first
to reproduce the bug (`test/parse_tests/test_parse_en.py` and
`test/parse_tests/test_parse_es.py`), then the fix was applied and the
tests turned green.

Ran the full suite before and after the change (`PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
pytest test/`): the same 14 pre-existing failures are present on `dev`
before this change (unrelated `test_dates_an*` and `test_packaging`
failures) — zero new failures, zero regressions.

---
Authored with AI assistance (Claude).