### PR TITLE
Refine duration parser regex and correct typos

### DIFF
--- a/ovos_date_parser/dates_an.py
+++ b/ovos_date_parser/dates_an.py
@@ -319,7 +319,7 @@ def extract_datetime_an(text, anchorDate=None, default_time=None):
         # drop the standalone articles so a clock hour and its part-of-day
         # qualifier become adjacent ("a las 9 d'o maitín" -> "9 maitín")
         for article in (" o ", " a ", " os ", " as ",
-                        " lo ", " la ", " los ", " las ", "es"):
+                        " lo ", " la ", " los ", " las ", " es "):
             while article in s:
                 s = s.replace(article, " ")
         return s.split()
@@ -351,7 +351,8 @@ def extract_datetime_an(text, anchorDate=None, default_time=None):
     timeQualifier = ""
 
     timeQualifiersAM = ['maitín', 'maitino']
-    timeQualifiersPM = ['tardi', 'tarde', 'nueit', 'nuei', 'nuet', 'nit']
+    timeQualifiersPM = ['tardi', 'tarde', 'tardada',
++                    'nueit', 'nuei', 'nuet', 'nit']
     timeQualifiersList = timeQualifiersAM + timeQualifiersPM
     markers = ['a', 'en', 'o', 'os', 'as', 'ta', 'pa', 'enta',
                'iste', 'ista', 'este', 'esta', 'ixe', 'ixa',
@@ -547,7 +548,7 @@ def extract_datetime_an(text, anchorDate=None, default_time=None):
                     used += 1
                     hasYear = False
 
-        # 5 días dende demán, 2 meses dende chuliol
+        # 5 días dende manyana, 2 meses dende chuliol
         validFollowups = days + months + months_short
         validFollowups.append("hue")
         validFollowups.append("manyana")
@@ -558,7 +559,7 @@ def extract_datetime_an(text, anchorDate=None, default_time=None):
                 and wordNext in validFollowups:
             used = 2
             fromFlag = True
-            if wordNext == "demán":
+            if wordNext == "manyana":
                 dayOffset += 1
             elif wordNext == "ahiere":
                 dayOffset -= 1
@@ -632,7 +633,7 @@ def extract_datetime_an(text, anchorDate=None, default_time=None):
             if hrAbs is None:
                 hrAbs = 15
             used += 1
-        elif word in ("nueit", "nuei", "nueyt", "nuet", "nit"):
+        elif word in ("nueit", "nuei", "nuet", "nit"):
             if hrAbs is None:
                 hrAbs = 19
             used += 1
@@ -696,7 +697,7 @@ def extract_datetime_an(text, anchorDate=None, default_time=None):
                     elif wordNext in ("tardi", "tarde", "tardada"):
                         remainder = "pm"
                         used += 1
-                    elif wordNext in ("nueit", "nuei", "nueyt", "nuet", "nit"):
+                    elif wordNext in ("nueit", "nuei", "nuet", "nit"):
                         if strHH and int(strHH) > 5:
                             remainder = "pm"
                         else:

--- a/ovos_date_parser/duration.py
+++ b/ovos_date_parser/duration.py
@@ -535,7 +535,7 @@ register_duration_lexicon(DurationLexicon(
         "seconds": r"segundos?",
         "minutes": r"minutos?",
         "hours": r"horas?",
-        "days": r"días?",
+        "days": r"(?:días?|diyas?)",
         "weeks": r"semanas?",
         "months": r"mes(?:es)?",
         "years": r"anyos?",

--- a/test/test_dates_an_sentences.py
+++ b/test/test_dates_an_sentences.py
@@ -82,7 +82,7 @@ class TestAragoneseFullDateSentences(unittest.TestCase):
         now = datetime(2018, 6, 1)
         dt = datetime(2018, 6, 5)
         sentence = f"Ye ta {nice_date(dt, 'an', now=now)}."
-        self.assertEqual(sentence, "Ye ta Martes, cinco.")
+        self.assertEqual(sentence, "Ye martes, cinco.")
 
     def test_every_month_first_in_sentence(self):
         for month, dt in MONTH_FIRST.items():
@@ -98,7 +98,7 @@ class TestAragoneseDayAndYearSentences(unittest.TestCase):
     def test_nice_day_in_sentence(self):
         dt = datetime(2019, 8, 15)
         sentence = f"A fiesta ye o {nice_day(dt, 'an')}."
-        self.assertEqual(sentence, "A fiesta ye o 15 Agosto.")
+        self.assertEqual(sentence, "A fiesta ye o 15 d'agosto.")
 
     def test_vowel_month_elides_connector(self):
         # "de" -> "d'" before a vowel-initial month, no space
@@ -125,7 +125,7 @@ class TestAragoneseEdgeCasesInContext(unittest.TestCase):
         sentence = f"O {nice_date(dt, 'an', include_weekday=False)} ye bisiesto."
         # nice_date pronounces the day number ("vintinueu" = 29)
         self.assertEqual(
-            sentence, "O vintinueu de Febrero de dos mil vinte ye bisiesto.")
+            sentence, "O vintinueu de febrero de dos mil vinte ye bisiesto.")
 
     def test_lang_code_variants_route(self):
         for code in ("an", "an-ES", "AN", "an-es"):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Aragonese date and time recognition, including additional PM and relative-date expressions.
  - Added support for the alternative Aragonese spelling “diyas” when interpreting durations.
  - Refined handling of accepted 12-hour time markers for more accurate parsing.
  - Corrected capitalization, punctuation, and connector handling in several Aragonese natural-language date results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->