### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 # ovos-date-parser
 
-Multilingual parsing, extraction and formatting of human date, time and duration
-expressions — a two-way bridge between machine timestamps and the way people
-actually speak and write about time.
+Multilingual parsing, extraction, and formatting of human date, time, and
+duration expressions. The library is a two-way bridge between machine
+timestamps and the way people speak and write about time.
 
-- **Text → datetime**: pull a `datetime` out of "next friday at 3pm" or
+- **Text to datetime**: pull a `datetime` out of "next friday at 3pm" or
   "amanhã às 15h30", and keep the leftover words.
-- **Text → duration**: turn "two hours and thirty minutes" into a `timedelta`.
-- **datetime → speech**: render `2024-01-05 15:30` as "January fifth twenty
+- **Text to duration**: turn "two hours and thirty minutes" into a `timedelta`.
+- **Datetime to speech**: render `2024-01-05 15:30` as "January fifth twenty
   twenty four at half past three".
 - **Dozens of languages**, resolved by BCP-47 code, with an automatic
   [dateparser](https://dateparser.readthedocs.io) fallback for the rest.
 
-It powers date/time understanding in [OpenVoiceOS](https://openvoiceos.org), but
-it is a **plain Python library with no voice-assistant dependency at runtime** —
-equally useful in an NER pipeline, a TTS front-end, an ASR post-processor, or a
-scheduling/calendar/logging tool.
+The library powers date and time understanding in
+[OpenVoiceOS](https://openvoiceos.org). It is a plain Python library with no
+voice-assistant dependency at runtime. Use it in an NER pipeline, a TTS
+front-end, an ASR post-processor, or a scheduling, calendar, or logging tool.
 
 ## Installation
 
@@ -51,13 +51,13 @@ but this package.
 
 ## Use it outside OVOS
 
-The same handful of functions solve everyday text/speech problems that have
-nothing to do with voice assistants.
+The same handful of functions solve everyday text and speech problems that
+have nothing to do with voice assistants.
 
 ### Temporal entity extraction (NER)
 
-Tag dates, times and durations in free text and keep the non-temporal
-remainder — useful for log mining, ticket triage or note-taking apps.
+Tag dates, times, and durations in free text, and keep the non-temporal
+remainder. This helps with log mining, ticket triage, and note-taking apps.
 
 ```python
 from datetime import datetime
@@ -65,16 +65,16 @@ from ovos_date_parser import extract_datetime
 
 text = "call the supplier next monday at 2pm about the delayed order"
 when, rest = extract_datetime(text, "en", anchorDate=datetime(2024, 1, 5))
-# when -> 2024-01-08 14:00 ; rest -> 'call supplier delayed order'
+# when -> 2024-01-08 14:00, rest -> 'call supplier delayed order'
 ```
 
-`anchorDate` is the "now" that relative phrases resolve against — pass a fixed
-value for reproducible extraction, or `datetime.now()` live. See
+`anchorDate` is the "now" that relative phrases resolve against. Pass a fixed
+value for reproducible extraction, or `datetime.now()` for live use. See
 [`examples/ner_temporal.py`](examples/ner_temporal.py).
 
 ### TTS normalization
 
-Speech engines mangle raw digits. Normalize a timestamp to words *before*
+Speech engines mangle raw digits. Normalize a timestamp to words before
 synthesis:
 
 ```python
@@ -90,7 +90,7 @@ See [`examples/tts_normalization.py`](examples/tts_normalization.py).
 
 ### ASR post-processing
 
-Speech-to-text emits words; downstream logic needs structure. Convert a
+Speech-to-text emits words, but downstream logic needs structure. Convert a
 transcript into a real datetime and an action payload:
 
 ```python
@@ -99,14 +99,14 @@ from ovos_date_parser import extract_datetime
 
 utterance = "remind me next tuesday at nine thirty to water the plants"
 when, action = extract_datetime(utterance, "en", anchorDate=datetime(2024, 1, 5))
-# when -> 2024-01-09 09:30 ; action -> 'remind me to water plants'
+# when -> 2024-01-09 09:30, action -> 'remind me to water plants'
 ```
 
 See [`examples/asr_postproc.py`](examples/asr_postproc.py).
 
 ### In an OVOS skill vs. standalone
 
-The library behaves identically in both settings; only who calls it changes.
+The library behaves the same way in both settings. Only the caller changes.
 
 ```python
 # In an OVOS skill: language and anchor come from the session
@@ -120,113 +120,113 @@ when, _ = extract_datetime(user_text, "en", anchorDate=datetime.now())
 
 | Function | Direction | Purpose |
 |----------|-----------|---------|
-| `extract_datetime(text, lang, anchorDate=None, default_time=None)` | text → datetime | Date/time from a phrase + leftover text |
-| `extract_duration(text, lang, *, resolution=..., replace_token="")` | text → duration | `timedelta`/`relativedelta`/float + leftover text |
-| `nice_time(dt, lang, speech=True, use_24hour=False, use_ampm=False, variant=None)` | datetime → text | Speakable or digit clock time |
-| `nice_date(dt, lang, now=None, include_weekday=True)` | datetime → text | Speakable date, shortened against `now` |
-| `nice_date_time(dt, lang, now=None, use_24hour=False, use_ampm=False)` | datetime → text | Date and time combined |
-| `nice_day` / `nice_weekday` / `nice_month` / `nice_year` | datetime → text | Individual date components |
-| `nice_duration(duration, lang, speech=True)` | seconds/timedelta → text | Speakable timespan |
-| `nice_relative_time(when, relative_to=None, lang="en-us")` | datetime → text | Short "N minutes/days" phrase |
-| `get_date_strings(dt, lang, date_format=None, time_format="full")` | datetime → dict | Display strings for GUI clients |
+| `extract_datetime(text, lang, anchorDate=None, default_time=None)` | text to datetime | Date/time from a phrase, plus leftover text |
+| `extract_duration(text, lang, *, resolution=..., replace_token="")` | text to duration | `timedelta`/`relativedelta`/float, plus leftover text |
+| `nice_time(dt, lang, speech=True, use_24hour=False, use_ampm=False, variant=None)` | datetime to text | Speakable or digit clock time |
+| `nice_date(dt, lang, now=None, include_weekday=True)` | datetime to text | Speakable date, shortened against `now` |
+| `nice_date_time(dt, lang, now=None, use_24hour=False, use_ampm=False)` | datetime to text | Date and time combined |
+| `nice_day` / `nice_weekday` / `nice_month` / `nice_year` | datetime to text | Individual date components |
+| `nice_duration(duration, lang, speech=True)` | seconds/timedelta to text | Speakable timespan |
+| `nice_relative_time(when, relative_to=None, lang="en-us")` | datetime to text | Short "N minutes/days" phrase |
+| `get_date_strings(dt, lang, date_format=None, time_format="full")` | datetime to dict | Display strings for GUI clients |
 
-Full signatures, return shapes and examples: [docs/api.md](docs/api.md).
+Full signatures, return shapes, and examples: [docs/api.md](docs/api.md).
 
-Dialects resolve by prefix — `"pt-BR"`, `"pt-PT"` and `"pt"` all reach the
+Dialects resolve by prefix. `"pt-BR"`, `"pt-PT"`, and `"pt"` all reach the
 Portuguese implementation. Unsupported languages raise `NotImplementedError`,
-except `extract_datetime`, which first tries the `dateparser` fallback.
+except `extract_datetime`, which tries the `dateparser` fallback first.
 
 ## Language support
 
-Twenty-plus languages have dedicated, idiomatic implementations. Extraction for
-any other language falls back to `dateparser`; formatting falls back to a
-generic word-table.
+Twenty-plus languages have dedicated, idiomatic implementations. Extraction
+for any other language falls back to `dateparser`. Formatting falls back to a
+generic word table.
 
-- ✅ dedicated implementation
-- 🚧 partial / generic (language-agnostic helper or external library)
-- ❌ not available (raises `NotImplementedError`)
+- Full: dedicated implementation
+- Partial: partial or generic support (a language-agnostic helper or an external library)
+- None: not available, raises `NotImplementedError`
 
 **Parsing**
 
 | Language | `extract_datetime` | `extract_duration` |
 |----------|:---:|:---:|
-| ar Arabic       | ✅ | ✅ |
-| ast Asturian    | ✅ | ✅ |
-| az Azerbaijani  | ✅ | ✅ |
-| ca Catalan      | ✅ | ✅ |
-| cs Czech        | ✅ | ✅ |
-| da Danish       | ✅ | ✅ |
-| de German       | ✅ | ✅ |
-| en English      | ✅ | ✅ |
-| es Spanish      | ✅ | ✅ |
-| eu Basque       | ✅ | ✅ |
-| fa Persian      | ✅ | ✅ |
-| fr French       | ✅ | ✅ |
-| gl Galician     | 🚧 | ✅ |
-| hu Hungarian    | 🚧 | ✅ |
-| it Italian      | ✅ | ✅ |
-| kab Kabyle      | ✅ | ✅ |
-| nb Norwegian Bokmål | ✅ | ✅ |
-| nl Dutch        | ✅ | ✅ |
-| nn Norwegian Nynorsk | ✅ | ✅ |
-| oc Occitan      | ✅ | ✅ |
-| pl Polish       | ✅ | ✅ |
-| pt Portuguese   | ✅ | ✅ |
-| ro Romanian     | ✅ | ✅ |
-| ru Russian      | ✅ | ✅ |
-| sl Slovenian    | ✅ | ✅ |
-| sv Swedish      | ✅ | ✅ |
-| uk Ukrainian    | ✅ | ✅ |
+| ar Arabic       | Full | Full |
+| ast Asturian    | Full | Full |
+| az Azerbaijani  | Full | Full |
+| ca Catalan      | Full | Full |
+| cs Czech        | Full | Full |
+| da Danish       | Full | Full |
+| de German       | Full | Full |
+| en English      | Full | Full |
+| es Spanish      | Full | Full |
+| eu Basque       | Full | Full |
+| fa Persian      | Full | Full |
+| fr French       | Full | Full |
+| gl Galician     | Partial | Full |
+| hu Hungarian    | Partial | Full |
+| it Italian      | Full | Full |
+| kab Kabyle      | Full | Full |
+| nb Norwegian Bokmål | Full | Full |
+| nl Dutch        | Full | Full |
+| nn Norwegian Nynorsk | Full | Full |
+| oc Occitan      | Full | Full |
+| pl Polish       | Full | Full |
+| pt Portuguese   | Full | Full |
+| ro Romanian     | Full | Full |
+| ru Russian      | Full | Full |
+| sl Slovenian    | Full | Full |
+| sv Swedish      | Full | Full |
+| uk Ukrainian    | Full | Full |
 
-> Any language not listed uses the `dateparser` fallback for `extract_datetime`
-> (good at absolute dates, weak at conversational relative phrases). The
-> languages on the shared duration engine (all of the above except ar, ast, fa,
-> kab, sv) also support the `resolution` and `replace_token` options of
-> `extract_duration` — see [docs/api.md](docs/api.md).
+Any language not listed uses the `dateparser` fallback for `extract_datetime`.
+This fallback is good at absolute dates and weak at conversational relative
+phrases. The languages on the shared duration engine (all of the above except
+ar, ast, fa, kab, sv) also support the `resolution` and `replace_token` options
+of `extract_duration`. See [docs/api.md](docs/api.md).
 
 **Formatting**
 
 | Language | `nice_date` family | `nice_time` | `nice_duration` | `nice_relative_time` |
 |----------|:---:|:---:|:---:|:---:|
-| ar Arabic       | 🚧 | ✅ | ✅ | 🚧 |
-| ast Asturian    | ✅ | ✅ | ✅ | 🚧 |
-| az Azerbaijani  | ✅ | ✅ | ✅ | 🚧 |
-| ca Catalan      | ✅ | ✅ | ✅ | 🚧 |
-| cs Czech        | ✅ | ✅ | ✅ | 🚧 |
-| da Danish       | ✅ | ✅ | ✅ | 🚧 |
-| de German       | ✅ | ✅ | ✅ | 🚧 |
-| en English      | ✅ | ✅ | ✅ | 🚧 |
-| es Spanish      | ✅ | ✅ | ✅ | 🚧 |
-| eu Basque       | ✅ | ✅ | ✅ | ✅ |
-| fa Persian      | ✅ | ✅ | ✅ | 🚧 |
-| fr French       | ✅ | ✅ | ✅ | 🚧 |
-| gl Galician     | ✅ | ✅ | ✅ | 🚧 |
-| hu Hungarian    | ✅ | ✅ | ✅ | 🚧 |
-| it Italian      | ✅ | ✅ | ✅ | 🚧 |
-| kab Kabyle      | 🚧 | ✅ | ✅ | 🚧 |
-| nb Norwegian Bokmål | ✅ | ✅ | ✅ | 🚧 |
-| nl Dutch        | ✅ | ✅ | ✅ | 🚧 |
-| nn Norwegian Nynorsk | ✅ | ✅ | ✅ | 🚧 |
-| oc Occitan      | ✅ | ✅ | ✅ | 🚧 |
-| pl Polish       | ✅ | ✅ | ✅ | 🚧 |
-| pt Portuguese   | ✅ | ✅ | ✅ | 🚧 |
-| ro Romanian     | ✅ | ✅ | ✅ | 🚧 |
-| ru Russian      | ✅ | ✅ | ✅ | 🚧 |
-| sl Slovenian    | ✅ | ❌ | ✅ | 🚧 |
-| sv Swedish      | ✅ | ✅ | ✅ | 🚧 |
-| uk Ukrainian    | ✅ | ✅ | ✅ | 🚧 |
+| ar Arabic       | Partial | Full | Full | Partial |
+| ast Asturian    | Full | Full | Full | Partial |
+| az Azerbaijani  | Full | Full | Full | Partial |
+| ca Catalan      | Full | Full | Full | Partial |
+| cs Czech        | Full | Full | Full | Partial |
+| da Danish       | Full | Full | Full | Partial |
+| de German       | Full | Full | Full | Partial |
+| en English      | Full | Full | Full | Partial |
+| es Spanish      | Full | Full | Full | Partial |
+| eu Basque       | Full | Full | Full | Full |
+| fa Persian      | Full | Full | Full | Partial |
+| fr French       | Full | Full | Full | Partial |
+| gl Galician     | Full | Full | Full | Partial |
+| hu Hungarian    | Full | Full | Full | Partial |
+| it Italian      | Full | Full | Full | Partial |
+| kab Kabyle      | Partial | Full | Full | Partial |
+| nb Norwegian Bokmål | Full | Full | Full | Partial |
+| nl Dutch        | Full | Full | Full | Partial |
+| nn Norwegian Nynorsk | Full | Full | Full | Partial |
+| oc Occitan      | Full | Full | Full | Partial |
+| pl Polish       | Full | Full | Full | Partial |
+| pt Portuguese   | Full | Full | Full | Partial |
+| ro Romanian     | Full | Full | Full | Partial |
+| ru Russian      | Full | Full | Full | Partial |
+| sl Slovenian    | Full | None | Full | Partial |
+| sv Swedish      | Full | Full | Full | Partial |
+| uk Ukrainian    | Full | Full | Full | Partial |
 
-> `nice_relative_time` uses a shared implementation for every language except
-> Basque, which has a dedicated one; the shared version is functional but not
-> idiomatically tuned per language.
+`nice_relative_time` uses a shared implementation for every language except
+Basque, which has a dedicated one. The shared version is functional but not
+tuned to each language's idiom.
 
 Per-language quirks (Catalan bell-tower time, Occitan quarter idioms, Romanian
-"fără un sfert", Kabyle calendar names, Portuguese `15h30` style, ...) are
+"fără un sfert", Kabyle calendar names, Portuguese `15h30` style, and more) are
 documented in [docs/languages.md](docs/languages.md).
 
 ## Examples
 
-Runnable, dependency-free scripts in [`examples/`](examples/):
+Runnable, dependency-free scripts live in [`examples/`](examples/):
 
 | Script | Shows |
 |--------|-------|
@@ -243,15 +243,15 @@ python examples/ner_temporal.py
 
 ## Documentation
 
-- [API reference](docs/api.md) — every public function and its parameters
-- [Language notes](docs/languages.md) — per-language behaviour and known gaps
-- [Adding a language](docs/adding-a-language.md) — implementation guide
+- [API reference](docs/api.md): every public function and its parameters
+- [Language notes](docs/languages.md): per-language behavior and known gaps
+- [Adding a language](docs/adding-a-language.md): implementation guide
 
 ## Related projects
 
-- [ovos-number-parser](https://github.com/OpenVoiceOS/ovos-number-parser) — numbers
-- [ovos-lang-parser](https://github.com/OVOSHatchery/ovos-lang-parser) — languages
-- [ovos-color-parser](https://github.com/OVOSHatchery/ovos-color-parser) — colors
+- [ovos-number-parser](https://github.com/OpenVoiceOS/ovos-number-parser): numbers
+- [ovos-lang-parser](https://github.com/OVOSHatchery/ovos-lang-parser): languages
+- [ovos-color-parser](https://github.com/OVOSHatchery/ovos-color-parser): colors
 
 ## License
 

--- a/docs/adding-a-language.md
+++ b/docs/adding-a-language.md
@@ -7,46 +7,46 @@ and is wired into the dispatcher functions in `ovos_date_parser/__init__.py`.
 
 Parsing:
 
-- `extract_datetime_<code>(text, anchorDate=None, default_time=None)` —
+- `extract_datetime_<code>(text, anchorDate=None, default_time=None)`:
   returns `[datetime, remaining_text]` or `None`. Handle at least: weekday
-  names, month + day (+ optional year), today/tomorrow/yesterday, relative
-  offsets ("in N hours/days/weeks"), morning/afternoon/evening qualifiers,
-  and digit times.
-- Duration parsing — the preferred path is the **shared duration engine**:
-  register a `DurationLexicon` (unit words + conjunctions) with
+  names, month plus day (plus optional year), today/tomorrow/yesterday,
+  relative offsets ("in N hours/days/weeks"), morning/afternoon/evening
+  qualifiers, and digit times.
+- Duration parsing: the preferred path is the shared duration engine.
+  Register a `DurationLexicon` (unit words and conjunctions) with
   `register_duration_lexicon(...)` in `ovos_date_parser/duration.py`, then have
   `extract_duration_<code>` delegate to
   `extract_duration_generic(text, DURATION_LEXICONS["<code>"], ...)`. Languages
   on this engine get `resolution` and `replace_token` support for free. A
   standalone `extract_duration_<code>(text) -> (timedelta, remaining_text)` is
-  only needed when a language cannot use the shared lexicon.
+  needed only when a language cannot use the shared lexicon.
 
 Formatting:
 
 - `nice_time_<code>(dt, speech=True, use_24hour=False, use_ampm=False)`
 - `nice_date_<code>`, `nice_date_time_<code>`, `nice_year_<code>`,
   `nice_weekday_<code>`, `nice_month_<code>`, `nice_day_<code>`
-- `nice_duration_<code>` (optional — `nice_duration_generic` covers basic
+- `nice_duration_<code>` (optional. `nice_duration_generic` covers basic
   needs via a unit-word table)
 
-Use a structurally close existing language as the template; the es/pt/eu
-modules share one lineage, en/nl/de another.
+Use a structurally close existing language as the template. The es/pt/eu
+modules share one lineage, and en/nl/de share another.
 
 Number words come from
-[ovos-number-parser](https://github.com/OpenVoiceOS/ovos-number-parser) —
-add the language there first if it is missing.
+[ovos-number-parser](https://github.com/OpenVoiceOS/ovos-number-parser).
+Add the language there first if it is missing.
 
 ## 2. Resources
 
 Display formats (dates as strings for GUIs) live in
 `ovos_date_parser/res/<lang>/date_time.json`. Copy `res/en/date_time.json`
-and translate.
+and translate it.
 
 ## 3. Dispatcher
 
 Add the language-prefix branch to each matching top-level function in
 `__init__.py` (`extract_datetime`, `extract_duration`, `nice_time`,
-`nice_date`, ...).
+`nice_date`, and the rest).
 
 ## 4. Tests
 
@@ -61,9 +61,12 @@ Add `test/parse_tests/test_parse_<code>.py` and
 - `nice_time` across the special minutes (00, 15, 30, 45, o'clock styles)
 - `nice_date` shortening against `now` (today/tomorrow/yesterday)
 
-Anchor expectations must come from reference material or native usage —
-never pin unverified engine output as gold.
+Anchor expectations must come from reference material or native usage.
+Never pin unverified engine output as gold.
 
 ## 5. README
 
 Add the language rows to the parse and format matrices in `README.md`.
+
+---
+[← Language notes](languages.md) · [Home](../README.md)

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,8 +2,8 @@
 
 All public functions live in the top-level `ovos_date_parser` package and take
 a BCP-47 language code (`lang`). Dialects resolve by prefix (`"pt-BR"`,
-`"pt-PT"` and `"pt"` all reach the Portuguese parser). Unsupported languages
-raise `NotImplementedError`; `extract_datetime` falls back to
+`"pt-PT"`, and `"pt"` all reach the Portuguese parser). Unsupported languages
+raise `NotImplementedError`. `extract_datetime` falls back to
 [dateparser](https://dateparser.readthedocs.io) before giving up.
 
 ```python
@@ -15,10 +15,10 @@ from ovos_date_parser import (
 )
 ```
 
-Nothing here needs a running OVOS stack; the package is pure Python plus a few
+Nothing here needs a running OVOS stack. The package is pure Python plus a few
 small parsing dependencies.
 
-## Parsing (text → structured value)
+## Parsing (text to structured value)
 
 ### `extract_datetime(text, lang, anchorDate=None, default_time=None)`
 
@@ -36,19 +36,19 @@ Extract a datetime from a phrase. Returns `[datetime, remaining_text]`, or
 None
 ```
 
-- `anchorDate` (`datetime`) — the "now" that relative expressions
-  ("tomorrow", "in 2 hours", "next tuesday") are resolved against; defaults to
+- `anchorDate` (`datetime`): the "now" that relative expressions
+  ("tomorrow", "in 2 hours", "next tuesday") resolve against. Defaults to
   the current local time. Pass a fixed value for deterministic extraction.
-- `default_time` (`datetime.time`) — used when the phrase names a day but no
+- `default_time` (`datetime.time`): used when the phrase names a day but no
   time. `extract_datetime("on friday", "en", default_time=time(9, 0))`
   resolves to friday at 09:00 instead of midnight.
 
 The returned `remaining_text` is the input with the recognized date/time words
-removed — the non-temporal payload, handy for intent parsing or NER.
+removed. This is the non-temporal payload, useful for intent parsing or NER.
 
 ### `extract_duration(text, lang, *, resolution=DurationResolution.TIMEDELTA, replace_token="")`
 
-Parse a duration. Returns `(duration, remaining_text)`; `duration` is `None`
+Parse a duration. Returns `(duration, remaining_text)`. `duration` is `None`
 when nothing is found.
 
 ```python
@@ -58,19 +58,19 @@ when nothing is found.
 (None, 'nothing here')
 ```
 
-`resolution` and `replace_token` are keyword-only and only supported for the
-languages on the **shared duration engine** (ar, ast, fa, kab and sv use a
-simpler dedicated parser and accept neither — passing them raises
-`NotImplementedError`).
+`resolution` and `replace_token` are keyword-only and supported only for the
+languages on the shared duration engine. The languages ar, ast, fa, kab, and
+sv use a simpler dedicated parser and accept neither. Passing them to those
+languages raises `NotImplementedError`.
 
-- `resolution` (`DurationResolution`) — the type to return:
-  - `TIMEDELTA` (default) — a `datetime.timedelta`.
-  - `RELATIVEDELTA` — a calendar-accurate `dateutil.relativedelta`, so
+- `resolution` (`DurationResolution`): the type to return.
+  - `TIMEDELTA` (default): a `datetime.timedelta`.
+  - `RELATIVEDELTA`: a calendar-accurate `dateutil.relativedelta`, so
     "2 months" stays 2 months rather than an approximate day count.
-  - single-unit totals such as `TOTAL_SECONDS`, `TOTAL_MINUTES`,
-    `TOTAL_HOURS`, `TOTAL_DAYS` — a `float` in that unit.
-- `replace_token` (`str`) — string that each consumed duration is replaced
-  with in `remaining_text`, marking where it was found.
+  - Single-unit totals such as `TOTAL_SECONDS`, `TOTAL_MINUTES`,
+    `TOTAL_HOURS`, `TOTAL_DAYS`: a `float` in that unit.
+- `replace_token` (`str`): string that replaces each consumed duration
+  in `remaining_text`, marking where it was found.
 
 ```python
 >>> from ovos_date_parser.duration import DurationResolution
@@ -82,7 +82,7 @@ simpler dedicated parser and accept neither — passing them raises
 
 Import `DurationResolution` from `ovos_date_parser.duration`.
 
-## Formatting (datetime → text)
+## Formatting (datetime to text)
 
 ### `nice_time(dt, lang, speech=True, use_24hour=False, use_ampm=False, variant=None)`
 
@@ -97,11 +97,11 @@ Speakable or display form of a time.
 'thirteen thirty'
 ```
 
-- `speech` — words for TTS (`True`) or a digit clock string (`False`).
-- `use_24hour` — 24-hour reading ("thirteen thirty") instead of 12-hour.
-- `use_ampm` — add the am/pm / part-of-day marker in 12-hour mode.
-- `variant` — Catalan-only register selector (`TimeVariantCA`, see below).
-  Ignored by other languages.
+- `speech`: words for TTS (`True`) or a digit clock string (`False`).
+- `use_24hour`: 24-hour reading ("thirteen thirty") instead of 12-hour.
+- `use_ampm`: add the am/pm or part-of-day marker in 12-hour mode.
+- `variant`: Catalan-only register selector (`TimeVariantCA`, see below).
+  Other languages ignore it.
 
 **Catalan registers.** Catalan can read the clock in several styles. Import the
 enum and pass it as `variant`:
@@ -118,9 +118,10 @@ enum and pass it as `variant`:
 
 ### `nice_date(dt, lang, now=None, include_weekday=True)`
 
-Pronounceable date. When `now` is given, the output is shortened relative to
-it — same day returns "today", adjacent days "tomorrow"/"yesterday", the year
-is omitted when it matches `now`. `include_weekday=False` drops the weekday.
+Pronounceable date. When `now` is given, the output shortens relative to
+it: same day returns "today", adjacent days return "tomorrow" or "yesterday",
+and the year drops when it matches `now`. `include_weekday=False` drops the
+weekday.
 
 ```python
 >>> nice_date(datetime(2024, 1, 5), "en")
@@ -130,20 +131,20 @@ is omitted when it matches `now`. `include_weekday=False` drops the weekday.
 ### `nice_date_time(dt, lang, now=None, use_24hour=False, use_ampm=False)`
 
 Date and time combined ("tuesday, june fifth at half past one"). `now`,
-`use_24hour` and `use_ampm` behave as in `nice_date` / `nice_time`.
+`use_24hour`, and `use_ampm` behave as in `nice_date` and `nice_time`.
 
 ### `nice_day(dt, lang, date_format='DMY', include_month=True)`
 
 Day number, optionally with the month, ordered by `date_format` (`'DMY'`,
-`'MDY'` or `'YMD'`).
+`'MDY'`, or `'YMD'`).
 
 ### `nice_weekday(dt, lang)` / `nice_month(dt, lang, date_format='MDY')` / `nice_year(dt, lang, bc=False, ad=False)`
 
 Individual components in speakable form. `nice_year` appends a B.C. marker when
-`bc=True` (Python `datetime` cannot itself represent B.C. years). Some locales
-(currently Danish) also support an explicit A.D./C.E. marker via `ad=True`;
-`bc` takes precedence if both are set. `ad` is a no-op for locales that don't
-define one.
+`bc=True`, because a Python `datetime` cannot represent B.C. years directly.
+Some locales (currently Danish) also support an explicit A.D./C.E. marker via
+`ad=True`. `bc` takes precedence when both are set. `ad` is a no-op for
+locales that do not define one.
 
 ```python
 >>> nice_year(datetime(1984, 1, 1), "en")
@@ -164,8 +165,8 @@ Speakable timespan. Accepts seconds (`int`/`float`) or a `timedelta`.
 ### `nice_relative_time(when, relative_to=None, lang="en-us")`
 
 Short relative description of an instant relative to `relative_to` (default:
-now) — "twenty four hours", "five days" style. Every language except Basque
-uses a shared, functional-but-generic implementation.
+now), in a "twenty four hours" or "five days" style. Every language except
+Basque uses a shared, functional but generic implementation.
 
 ### `get_date_strings(dt, lang, date_format=None, time_format="full")`
 
@@ -176,5 +177,8 @@ Dict of display strings for GUI clients:
  'day_string', 'year_string', 'weekday_string'}
 ```
 
-`date_format` defaults to the OVOS configuration value (or `'DMY'`);
+`date_format` defaults to the OVOS configuration value (or `'DMY'`).
 `time_format="full"` selects a 24-hour `time_string`.
+
+---
+[Home](../README.md) · [Language notes →](languages.md)

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -1,88 +1,88 @@
 # Language notes
 
-Per-language behaviour that goes beyond the support matrix in the README.
+Per-language behavior that goes beyond the support matrix in the README.
 
 ## Relative expressions
 
 Every `extract_datetime` implementation resolves relative phrases against
 `anchorDate`: "tomorrow morning", "next tuesday", "in 2 hours", "day before
-yesterday" and their equivalents. Purely relative offsets ("in 2 hours")
-keep the anchor's time of day; day-level expressions ("tomorrow") resolve to
+yesterday", and their equivalents. Purely relative offsets ("in 2 hours")
+keep the anchor's time of day. Day-level expressions ("tomorrow") resolve to
 midnight unless a time is present or `default_time` is passed.
 
 ## Time formats understood
 
 Digit forms (`15:30`, `3:30 pm`) parse in every language alongside the
-spoken forms. Portuguese additionally understands the `15h30` / `14h30min`
+spoken forms. Portuguese also understands the `15h30` / `14h30min`
 style. Explicit years parse in the languages with full date support
 ("11 de agosto de 1998").
 
 ## nice_time conventions
 
-- Languages with a 12-hour speech habit (en, pt, es, ...) speak
+- Languages with a 12-hour speech habit (en, pt, es, and others) speak
   "half past one" style with an optional am/pm marker
-  (`use_ampm=True` → "in the morning" equivalents).
+  (`use_ampm=True` produces "in the morning" equivalents).
 - `use_24hour=True` produces military-style readings ("thirteen thirty").
 - French reads 12-hour by default ("une heure vingt-deux",
   "huit heures moins vingt").
-- Basque, Catalan and Persian have their own idiomatic readings
-  (Catalan supports `TimeVariantCA` for bell-tower style).
+- Basque, Catalan, and Persian have their own idiomatic readings. Catalan
+  supports `TimeVariantCA` for bell-tower style.
 - Occitan (classical orthography, Lengadocian variety) reads 12-hour with
   the traditional quarter idioms: "una ora e quart", "cinc oras e mièja",
   and the quarter-to form naming the next hour ("doas oras manca un quart"
-  for 1:45); noon and midnight are "miègjorn" / "mièjanuèch".
+  for 1:45). Noon and midnight are "miègjorn" and "mièjanuèch".
 
 ## Asturian (ast)
 
 Full support: `nice_time`, `nice_date`, `nice_date_time`, `nice_day`,
-`nice_weekday`, `nice_month`, `nice_year`, `extract_datetime` and
+`nice_weekday`, `nice_month`, `nice_year`, `extract_datetime`, and
 `extract_duration`. Spoken time follows the feminine-article convention
 ("la una", "les cinco y media", "les ocho menos cuartu", "en puntu") with
 `use_ampm=True` adding "de la madrugada / mañana / tarde / nueche".
 Duration parsing handles the Asturian plurals in `-es` (hores, selmanes,
 díes) as well as the singular forms. "mañana" is ambiguous between
-"tomorrow" and "morning" and is disambiguated the same way as in Spanish.
+"tomorrow" and "morning" and resolves the same way as in Spanish.
 
 ## Kabyle
 
-Weekdays are the everyday Arabic-derived names (`letnayen` ... `lḥedd`);
-months follow the Kabyle calendar spellings (`yennayer`, `fuṛar`, ...
-`dujembeṛ`). `extract_datetime` covers the relative day words (`azekka`
-"tomorrow", `iḍelli` "yesterday", `ass-a` "today"), weekday and month
-names with day numbers, digit clock times, and spoken clock phrases
-(see below); it does not yet cover year words. `extract_duration`
+Weekdays are the everyday Arabic-derived names (`letnayen` through
+`lḥedd`). Months follow the Kabyle calendar spellings (`yennayer`, `fuṛar`,
+through `dujembeṛ`). `extract_datetime` covers the relative day words
+(`azekka` "tomorrow", `iḍelli` "yesterday", `ass-a` "today"), weekday and
+month names with day numbers, digit clock times, and spoken clock phrases
+(see below). It does not yet cover year words. `extract_duration`
 accepts both the Amazigh neologisms (`tasint` second, `amalas` week) and
 the Arabic-derived units in daily use (`ddqiqa` minute, `ssaɛa` hour),
 with an optional genitive `n` between quantity and unit (`10 n
-tesdidin`). `nice_time` joins hour and minutes with the conjunction `d`;
-day parts use `ssbeḥ` (morning) and `tameddit` (evening). Years are
-given in digits; a verified spoken-year formulation is not available.
+tesdidin`). `nice_time` joins hour and minutes with the conjunction `d`.
+Day parts use `ssbeḥ` (morning) and `tameddit` (evening). Years are
+given in digits. A verified spoken-year formulation is not available.
 
 ### Spoken clock phrases
 
 `extract_datetime` understands the native "presentative" clock grammar
-built around `d` ("it is"), not just digit times:
+built around `d` ("it is"), not just digit times.
 
 - Bare hours: `d lweḥda` (1:00), `d lɛecṛa` (10:00).
 - Exact: `swaswa` marks the hour precisely (`d lɛecṛa swaswa`).
 - Quarter/half: `u ṛbeɛ` (+15), `u neṣṣ`/`azgen`/`nofc`/`nofç`/`nefs`
-  (+30) — all four spellings of "half" are accepted, spanning the
+  (+30). All four spellings of "half" are accepted, spanning the
   Amazigh word, the old Arabic borrowing, and two contemporary variants.
-- Minus: `ɣiṛ` + a number subtracts from the *next* hour (`d lɛecṛa ɣiṛ
-  xemsa` = 9:55); `ɣiṛ ṛbeɛ` is quarter-to; bare `ɣiṛ` with no number is
+- Minus: `ɣiṛ` plus a number subtracts from the next hour (`d lɛecṛa ɣiṛ
+  xemsa` = 9:55). `ɣiṛ ṛbeɛ` is quarter-to. Bare `ɣiṛ` with no number is
   a vague "almost the hour" and resolves to a fixed 10-minute-to offset,
   matching the source grammar's own description of it as indeterminate
   rather than a specific count.
 - Vague plus: `u wac` / `u ci` ("and a bit") resolve the same way, as a
   fixed 10 minutes past.
 - Day-period disambiguation: a trailing `n <period>` both attaches a
-  period and resolves 12h/24h ambiguity — `d juǧ` alone stays 2:00, but
+  period and resolves 12h/24h ambiguity. `d juǧ` alone stays 2:00, but
   `d juǧ n uzal` resolves to 14:00. Periods recognized: `ṣṣbeḥ` (early
   morning, 4-8h), `ssbeḥ` (morning, 8-12h), `uzal` (midday, 12-15h),
   `tameddit`/`tmeddit` (afternoon/evening, 15-20h), `iḍ`/`yiḍ` (night,
   20-4h).
 - Regional variant: `ssaɛtin` is accepted as an alternative to `juǧ` for
-  "two o'clock" (Soummam valley usage), e.g. `d ssaɛtin ɣiṛ xemsa`
+  "two o'clock" (Soummam valley usage), for example `d ssaɛtin ɣiṛ xemsa`
   (1:55).
 - Midnight set phrases: `nṣaf n yiḍ` and `ttnaṣfa n yiḍ` both resolve
   directly to 00:00.
@@ -92,27 +92,27 @@ before handing the word to the number extractor. This surfaces two
 ways, mirroring Arabic sun/moon letters: a plain `l-` before some
 consonants (`lɛecṛa`, `lxemsa`) and gemination of the noun's own first
 consonant before others (`ttnac` = article + `tnac` "12", `ttlata` =
-article + `tlata` "3"). "One o'clock" additionally uses the feminine
+article + `tlata` "3"). "One o'clock" also uses the feminine
 loan-numeral `weḥda`, agreeing with the feminine noun `ssaɛa` (hour),
 rather than the masculine `waḥed` used elsewhere.
 
 Not yet handled: the preposition `af` ("at") as an alternative to `d`
-(`Af ttlata n ṣṣbeḥ`, "at three in the early morning") — only one
-example of this construction is attested, and it's unclear whether it
+(`Af ttlata n ṣṣbeḥ`, "at three in the early morning"). Only one
+example of this construction is attested, and it is unclear whether it
 behaves identically to `d` in every pattern above. `nice_time` also
-does not yet *generate* these forms (fractions, day-periods beyond
-`ssbeḥ`/`tameddit`, the vague markers) — extraction is currently richer
+does not yet generate these forms (fractions, day-periods beyond
+`ssbeḥ`/`tameddit`, the vague markers). Extraction is currently richer
 than generation for this language.
 
 ## Norwegian Bokmål (nb)
 
 Bokmål is supported with `no` accepted as an alias. It covers `nice_time`,
 `nice_date`, `nice_date_time`, `nice_day`, `nice_weekday`, `nice_month`,
-`nice_year`, `nice_duration`, `nice_relative_time`, `extract_datetime` and
+`nice_year`, `nice_duration`, `nice_relative_time`, `extract_datetime`, and
 `extract_duration`. Number and ordinal words use the modern tens-first
 counting reform (`tjueen` = 21) with decimal tens (`femti`, `åtti`), so
 years read "nitten hundre og åttifire" and "to tusen og tjueen". Weekdays
-are `mandag` … `søndag`; one o'clock reads with the neuter `ett`
+are `mandag` through `søndag`. One o'clock reads with the neuter `ett`
 (`klokka ett`). `extract_datetime` covers relative day words, weekdays
 with `neste`/`forrige`, month names with day and optional year, and digit
 clock times.
@@ -124,27 +124,27 @@ If a language has no `extract_datetime` implementation, the
 absolute dates well but not conversational relative phrases.
 
 `nice_duration` uses a generic per-language unit table
-(`nice_duration_generic`) for languages without a dedicated implementation;
-plural declension may be imperfect (e.g. Slovenian dual forms).
+(`nice_duration_generic`) for languages without a dedicated implementation.
+Plural declension may be imperfect (for example, Slovenian dual forms).
 
 ## Romanian
 
 - `nice_time` speaks quarter-hours idiomatically: "opt și un sfert" (8:15),
-  "opt și jumătate" (8:30, half past), "nouă fără un sfert" (8:45, "fără" =
-  minus, quarter to nine); exact hours take "fix". `use_ampm=True` appends
-  "dimineața" / "după-amiaza" / "seara" / "noaptea".
-- "luni" is both Monday and the plural of "lună" (month); a numeric context
+  "opt și jumătate" (8:30, half past), "nouă fără un sfert" (8:45, "fără"
+  means minus, quarter to nine). Exact hours take "fix". `use_ampm=True`
+  appends "dimineața" / "după-amiaza" / "seara" / "noaptea".
+- "luni" is both Monday and the plural of "lună" (month). A numeric context
   ("3 luni") selects the month unit, otherwise it is the weekday.
-- "mai" is both May and a very common adverb; it only parses as a month next
+- "mai" is both May and a very common adverb. It only parses as a month next
   to a day or year number ("3 mai", "mai 2019").
-- Spoken numbers are understood in dates, times and durations
+- Spoken numbers are understood in dates, times, and durations
   ("peste trei zile", "douăzeci de minute").
 
 ## Danish (da)
 
 - `nice_year` supports an explicit AD/CE marker via `nice_year(dt, "da",
   ad=True)`, appending "e.Kr." the same way `bc=True` appends "f.Kr.". The two
-  are mutually exclusive; if both are passed, `bc` wins. Years are implicitly
+  are mutually exclusive. If both are passed, `bc` wins. Years are implicitly
   AD when neither flag is set, as before.
 - The `ad` parameter is part of the generic `year_format` engine and is a
   no-op for any locale that does not define an `"ad"` key in its
@@ -152,10 +152,13 @@ plural declension may be imperfect (e.g. Slovenian dual forms).
 
 ## Known gaps
 
-- Relative *past* wording ("anoche", "bart", "last night") is not handled in
-  es/eu; the corresponding tests are skipped.
+- Relative past wording ("anoche", "bart", "last night") is not handled in
+  es/eu. The corresponding tests are skipped.
 - `nice_time` is missing for sl.
-- `gl` and `hu` `extract_datetime` are partial (🚧 in the README matrix).
+- `gl` and `hu` `extract_datetime` are partial (see the README matrix).
 - The `resolution` / `replace_token` options of `extract_duration` are only
-  available on the shared duration engine; ar, ast, fa, kab and sv use a
+  available on the shared duration engine. ar, ast, fa, kab, and sv use a
   dedicated parser that returns a plain `timedelta` and rejects those options.
+
+---
+[← API reference](api.md) · [Home](../README.md) · [Adding a language →](adding-a-language.md)


### PR DESCRIPTION
Rewrites the README and docs/*.md prose for clarity, keeping every fact, code block, and the language support matrices. Adds the standard relative-link navigation footer to the docs pages.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)